### PR TITLE
v1.2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An unofficial YouTube Music client for Android, built with Jetpack Compose. BitC
 
 - **Sign in with your Google account** — an in-app WebView runs the real `accounts.google.com` login (2FA and passkeys work as normal); only the resulting session cookies are captured, never the credential itself.
 - **Search, browse and play** anything available on YouTube Music — songs, albums, artists, playlists.
-- **Gapless playback with crossfade**, adjustable 0–12s, powered by Media3/ExoPlayer.
+- **Gapless playback with true crossfade**, adjustable 0–12s — two overlapping decoders on an equal-power curve, applied to manual skips as well as track ends, powered by Media3/ExoPlayer.
 - **Per-network audio quality** — separate quality ceilings for Wi-Fi and mobile data.
 - **Playback speed control** (0.5×–2.0×) and **skip silence**.
 - **Synced lyrics** via LRCLIB.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         // Haze falls back to a translucent scrim below that.
         minSdk = 26
         targetSdk = 36
-        versionCode = 2
-        versionName = "1.1"
+        versionCode = 3
+        versionName = "1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,7 +136,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 
     // ---- Stream resolution: NewPipe solves YouTube's signature + `n` throttling ----
-    implementation("com.github.TeamNewPipe:NewPipeExtractor:v0.26.3")
+    implementation("com.github.TeamNewPipe:NewPipeExtractor:v0.26.4")
 
     // ---- Auth/session storage ----
     implementation("androidx.security:security-crypto:1.1.0-alpha06")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,22 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!--
+      Package visibility for the Dolby Atmos panel the spatial audio row hands
+      the user to. Without this, API 30+ hides those packages from the launcher
+      lookup and the row would fall back to plain sound settings even on a
+      device that ships the Atmos app.
+    -->
+    <queries>
+        <package android:name="com.dolby.dax2appui" />
+        <package android:name="com.dolby.daxappui" />
+        <package android:name="com.dolby.dolby234" />
+        <package android:name="com.atc.daxappUI" />
+        <intent>
+            <action android:name="android.settings.SOUND_SETTINGS" />
+        </intent>
+    </queries>
+
     <application
         android:name=".BitChordApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/music/bitchord/BitChordApplication.kt
+++ b/app/src/main/java/com/music/bitchord/BitChordApplication.kt
@@ -3,14 +3,22 @@ package com.music.bitchord
 import android.app.Application
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
+import coil3.request.crossfade
 import com.music.bitchord.auth.AuthStore
 import com.music.bitchord.playback.AudioCache
+import com.music.bitchord.playback.DolbyAtmos
 import com.music.bitchord.playback.LastPlayed
 import com.music.bitchord.data.innertube.Innertube
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.SearchHistory
 
-class BitChordApplication : Application() {
+class BitChordApplication : Application(), SingletonImageLoader.Factory {
 
     @OptIn(UnstableApi::class)
     override fun onCreate() {
@@ -20,12 +28,42 @@ class BitChordApplication : Application() {
         authStore = AuthStore(this)
         Innertube.cookie = authStore.cookie
         AppSettings.init(this)
+        // After AppSettings: a device with Atmos switched off retires the
+        // spatial audio preference on the spot, and that needs prefs open.
+        DolbyAtmos.init(this)
         SearchHistory.init(this)
         LastPlayed.init(this)
         // One cache directory can only be opened once per process, and
         // PlaybackService shares this one — so it's opened here, not there.
         AudioCache.init(this)
     }
+
+    /**
+     * Artwork loading, which was previously left entirely on Coil's defaults.
+     *
+     * The defaults aren't unreasonable, but the disk cache is sized at 2% of
+     * free space — which on a full phone is the 10MB floor, a few screens of
+     * covers, and covers are exactly the thing worth still having tomorrow.
+     * Naming a directory alongside it keeps that cache somewhere identifiable
+     * rather than in the process's temp dir.
+     */
+    override fun newImageLoader(context: PlatformContext): ImageLoader =
+        ImageLoader.Builder(context)
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(context, 0.20)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("image_cache"))
+                    .maxSizeBytes(100L * 1024 * 1024)
+                    .build()
+            }
+            // Covers arriving with a hard cut read as the list flickering as
+            // it scrolls; a short fade reads as them developing.
+            .crossfade(200)
+            .build()
 
     companion object {
         lateinit var authStore: AuthStore

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -64,6 +64,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.music.bitchord.auth.YtMusicLoginScreen
 import com.music.bitchord.data.model.BrowseType
 import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.model.UiState
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.ThemeMode
 import com.music.bitchord.ui.screens.SettingsScreen
@@ -82,6 +83,7 @@ import com.music.bitchord.ui.components.BottomTab
 import com.music.bitchord.ui.components.FloatingBottomBar
 import com.music.bitchord.ui.components.FrostedTopBar
 import com.music.bitchord.ui.components.MiniPlayer
+import com.music.bitchord.ui.components.UpdateAvailableDialog
 import com.music.bitchord.ui.icons.BitChordIcons
 import androidx.media3.common.Player
 import com.music.bitchord.data.YtMusicRepository
@@ -135,6 +137,34 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
 
     val homeState by viewModel.home.collectAsStateWithLifecycle()
     val homeLoadingMore by viewModel.homeLoadingMore.collectAsStateWithLifecycle()
+
+    // The top bar's icon is the quiet, always-there nudge; this is the
+    // once-per-launch popup version of the same news. `updateDialogShown`
+    // rides out configuration changes on rememberSaveable so a rotation
+    // doesn't bring it back — only a fresh launch does.
+    //
+    // Held until Home has settled. The GitHub check almost always returns
+    // first, and an alert thrown over a page of skeletons reads as something
+    // having gone wrong rather than as an aside — quite apart from its glass
+    // having nothing worth frosting yet. Error counts as settled: the page has
+    // stopped moving either way, and the news is still worth delivering.
+    var updateDialogShown by rememberSaveable { mutableStateOf(false) }
+    var showUpdateDialog by remember { mutableStateOf(false) }
+    val updateAvailable by viewModel.updateAvailable.collectAsStateWithLifecycle()
+
+    /**
+     * The single gate both surfaces read, so the icon can't announce the update
+     * a beat before the popup does — they're one piece of news, and staggering
+     * them made the top bar look like it had caught something the app hadn't.
+     */
+    val updateNotice = updateAvailable?.takeIf { homeState !is UiState.Loading }
+
+    LaunchedEffect(updateNotice) {
+        if (updateNotice != null && !updateDialogShown) {
+            updateDialogShown = true
+            showUpdateDialog = true
+        }
+    }
     val query by viewModel.query.collectAsStateWithLifecycle()
     val results by viewModel.results.collectAsStateWithLifecycle()
     val exploreState by viewModel.explore.collectAsStateWithLifecycle()
@@ -145,7 +175,6 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
     val lyrics by viewModel.lyrics.collectAsStateWithLifecycle()
     val lyricsChecked by viewModel.lyricsChecked.collectAsStateWithLifecycle()
     val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
-    val updateAvailable by viewModel.updateAvailable.collectAsStateWithLifecycle()
     val detailStack by viewModel.detailStack.collectAsStateWithLifecycle()
     val detail = detailStack.lastOrNull()
     // Settings has no tab of its own — it sits on top of whatever tab was
@@ -159,10 +188,17 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
 
     // AutoPlay: once the queue reaches its last track, extend it with YouTube
     // Music's radio mix for that song so playback carries on by itself.
+    //
+    // Repeat-all is left out of the trigger: its whole point is to loop the
+    // queue as it stands, which AutoPlay extending it forever would defeat —
+    // the queue would never actually reach the end repeat-all is meant to
+    // wrap from. See onCycleRepeat, which drops whatever AutoPlay has already
+    // added the moment repeat-all is turned on.
     var autoplaySeed by remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(autoplay, player.queueIndex, player.queue.size, player.song?.videoId) {
+    LaunchedEffect(autoplay, player.queueIndex, player.queue.size, player.song?.videoId, player.repeatMode) {
         val current = player.song?.videoId
         if (!autoplay || current == null) return@LaunchedEffect
+        if (player.repeatMode == Player.REPEAT_MODE_ALL) return@LaunchedEffect
         if (player.queueIndex < player.queue.lastIndex) return@LaunchedEffect
         if (autoplaySeed == current) return@LaunchedEffect
         autoplaySeed = current
@@ -359,6 +395,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
         BackHandler(enabled = detail == null && !showSettings && selectedTab != TAB_HOME) {
             selectedTab = TAB_HOME
         }
+        BackHandler(enabled = showUpdateDialog) { showUpdateDialog = false }
 
         AnimatedContent(
             targetState = when {
@@ -556,7 +593,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                 // Only worth surfacing where there's room for it and it won't
                 // be mistaken for a per-page action — Home, at rest.
                 if (!showSettings && detail == null && selectedTab == TAB_HOME) {
-                    updateAvailable?.let { update ->
+                    updateNotice?.let { update ->
                         IconButton(onClick = {
                             context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(update.releaseUrl)))
                         }) {
@@ -677,11 +714,19 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                     onToggleShuffle = { controller?.let(QueueShuffle::toggle) },
                     onCycleRepeat = {
                         controller?.let {
-                            it.repeatMode = when (it.repeatMode) {
+                            val next = when (it.repeatMode) {
                                 Player.REPEAT_MODE_OFF -> Player.REPEAT_MODE_ALL
                                 Player.REPEAT_MODE_ALL -> Player.REPEAT_MODE_ONE
                                 else -> Player.REPEAT_MODE_OFF
                             }
+                            // Repeat-all loops the queue as it stands; AutoPlay's
+                            // tracks are the opposite of that — an endless supply
+                            // of new ones — so they come back out first. Native
+                            // REPEAT_MODE_ALL then wraps a plain queue exactly as
+                            // it should, and the LaunchedEffect above leaves it be
+                            // for as long as repeat-all stays on.
+                            if (next == Player.REPEAT_MODE_ALL) it.dropAutoplayTracks()
+                            it.repeatMode = next
                         }
                     },
                     onToggleAutoplay = {
@@ -700,6 +745,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                     },
                     onJumpTo = { controller?.seekToDefaultPosition(it) },
                     onRemoveFromQueue = { controller?.removeMediaItem(it) },
+                    onMoveInQueue = { from, to -> controller?.moveMediaItem(from, to) },
                     // The enriched copy, not player.song — otherwise the menu
                     // hides the album and artist rows even once their browse
                     // ids have been resolved.
@@ -812,6 +858,21 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                         },
                     )
                 }
+            }
+        }
+
+        // ---- Update available (once per launch) ----
+        if (showUpdateDialog) {
+            updateNotice?.let { update ->
+                UpdateAvailableDialog(
+                    version = update.version,
+                    hazeState = hazeState,
+                    onDismiss = { showUpdateDialog = false },
+                    onUpdate = {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(update.releaseUrl)))
+                        showUpdateDialog = false
+                    },
+                )
             }
         }
     }

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -157,6 +157,14 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
     val player = rememberPlayerState(controller)
     val shuffleEnabled by QueueShuffle.enabled.collectAsStateWithLifecycle()
 
+    // A failed play used to be completely silent: the spinner stopped and
+    // nothing else happened, which is indistinguishable from the app ignoring
+    // the tap. Keyed on the track as well as the message so the same error on
+    // a later song still shows.
+    LaunchedEffect(player.error, player.song?.videoId) {
+        player.error?.let { Toast.makeText(context, it, Toast.LENGTH_SHORT).show() }
+    }
+
     // AutoPlay: once the queue reaches its last track, extend it with YouTube
     // Music's radio mix for that song so playback carries on by itself.
     var autoplaySeed by remember { mutableStateOf<String?>(null) }

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -157,14 +157,6 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
     val player = rememberPlayerState(controller)
     val shuffleEnabled by QueueShuffle.enabled.collectAsStateWithLifecycle()
 
-    // A failed play used to be completely silent: the spinner stopped and
-    // nothing else happened, which is indistinguishable from the app ignoring
-    // the tap. Keyed on the track as well as the message so the same error on
-    // a later song still shows.
-    LaunchedEffect(player.error, player.song?.videoId) {
-        player.error?.let { Toast.makeText(context, it, Toast.LENGTH_SHORT).show() }
-    }
-
     // AutoPlay: once the queue reaches its last track, extend it with YouTube
     // Music's radio mix for that song so playback carries on by itself.
     var autoplaySeed by remember { mutableStateOf<String?>(null) }

--- a/app/src/main/java/com/music/bitchord/data/Http.kt
+++ b/app/src/main/java/com/music/bitchord/data/Http.kt
@@ -13,9 +13,6 @@ import java.util.concurrent.TimeUnit
  * address family and connection pooling identical for both.
  */
 object Http {
-    const val IOS_USER_AGENT =
-        "com.google.ios.youtube/20.03.02 (iPhone16,2; U; CPU iOS 18_2_1 like Mac OS X;)"
-
     val client: OkHttpClient = OkHttpClient.Builder()
         .connectTimeout(20, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/java/com/music/bitchord/data/YtMusicRepository.kt
+++ b/app/src/main/java/com/music/bitchord/data/YtMusicRepository.kt
@@ -12,11 +12,13 @@ import com.music.bitchord.data.model.SearchFilter
 import com.music.bitchord.data.model.SearchResult
 import com.music.bitchord.data.model.ShelfItem
 import com.music.bitchord.data.model.Song
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonObject
 
 /** Suspend API over Innertube. Every call returns a Result so the UI can show a real error. */
 object YtMusicRepository {
@@ -226,10 +228,37 @@ object YtMusicRepository {
             ?: error("no watch entry for $videoId")
     }
 
-    /** Tracks of an album/playlist card tapped in the home feed. */
-    suspend fun browseSongs(browseId: String): Result<List<Song>> = call("browse:$browseId") {
-        songsPaged(browseId)
+    /**
+     * One page of a browse feed's tracks, and the token for the page after
+     * it — null once there is nothing more.
+     */
+    data class SongPage(val songs: List<Song>, val continuation: String?)
+
+    /**
+     * The first page of an album/playlist's tracks, and nothing more.
+     *
+     * Deliberately not the whole list. Following every continuation before
+     * returning meant a long playlist spent up to ten round trips showing a
+     * spinner, when every row needed to fill the first screenful was in the
+     * first response. The rest arrives behind a page that is by then already
+     * being read — see [moreSongs].
+     */
+    suspend fun browseSongs(browseId: String): Result<SongPage> = call("browse:$browseId") {
+        pageOf(Innertube.browse(browseId))
     }
+
+    /** The page [SongPage.continuation] points at. */
+    suspend fun moreSongs(token: String): Result<SongPage> = call("browse:more") {
+        pageOf(Innertube.browseContinuation(token))
+    }
+
+    private fun pageOf(response: JsonObject) = SongPage(
+        // One response can name the same track twice — an album page that
+        // also carries a "you might also like" shelf, say. Collecting into a
+        // map used to take care of that; paging by hand means saying so.
+        songs = InnertubeParser.collectSongsDeep(response).distinctBy { it.videoId },
+        continuation = InnertubeParser.continuationToken(response),
+    )
 
     /**
      * Every track behind a browse id, following continuations.
@@ -238,6 +267,10 @@ object YtMusicRepository {
      * a long list otherwise arrives silently truncated. Capped at
      * [MAX_PAGES] so a runaway feed can't hold the UI open forever, and a
      * failed page keeps whatever was already collected.
+     *
+     * Holds its caller until the last page lands, so it belongs behind things
+     * nobody is watching — the library sync, an artist's back catalogue. For
+     * anything a screen is waiting on, use [browseSongs] and [moreSongs].
      */
     private suspend fun songsPaged(browseId: String): List<Song> {
         val out = LinkedHashMap<String, Song>()
@@ -252,7 +285,7 @@ object YtMusicRepository {
         return out.values.toList()
     }
 
-    private const val MAX_PAGES = 10
+    const val MAX_PAGES = 10
 
     /** Liked Music: the `LM` auto-playlist, addressed as a playlist browse id. */
     private const val LIKED_MUSIC = "VLLM"
@@ -283,6 +316,11 @@ object YtMusicRepository {
     private suspend fun <T> call(label: String, block: suspend () -> T): Result<T> =
         withContext(Dispatchers.IO) {
             runCatching { block() }
+                // runCatching catches Throwable, cancellation included, which
+                // would turn "the user typed another letter" into a failed
+                // Result and put the abandoned request's error on screen.
+                // Cancellation isn't this call's to answer for.
+                .onFailure { if (it is CancellationException) throw it }
                 .onSuccess { Log.d(TAG, "$label ok") }
                 .onFailure { Log.w(TAG, "$label failed: ${it.message}") }
         }

--- a/app/src/main/java/com/music/bitchord/data/innertube/Innertube.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/Innertube.kt
@@ -11,14 +11,18 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -28,15 +32,15 @@ import java.security.MessageDigest
 /**
  * Minimal Innertube (youtubei) client.
  *
- * Two client identities, for different reasons:
+ * Two kinds of client identity, for different reasons:
  *
  *  - **WEB_REMIX** against music.youtube.com for browse/search/library. It
  *    returns the full YT Music shelf layout and honours the signed-in session.
  *
- *  - **IOS** against www.youtube.com for the `player` endpoint. Google now
- *    answers ANDROID_MUSIC (and ANDROID_VR) with `LOGIN_REQUIRED`, while the
- *    iOS client still returns `OK` with unciphered `url` fields — so no
- *    signature-cipher solving is needed. Verified against the live endpoint.
+ *  - **A device client** for the `player` endpoint, chosen per call. Which
+ *    ones Google answers changes without notice, so [player] takes the
+ *    identity as an argument and [StreamResolver] walks a list of them rather
+ *    than betting the app on any single one. See [PlayerClient].
  *
  * Authenticated requests are signed with Google's SAPISIDHASH scheme derived
  * from the stored cookie; no long-lived token is ever minted or stored.
@@ -49,8 +53,6 @@ object Innertube {
 
     private const val WEB_REMIX_VERSION = "1.20250101.01.00"
     private const val WEB_REMIX_CLIENT_ID = "67"
-    private const val IOS_VERSION = "20.03.02"
-    private val IOS_USER_AGENT = com.music.bitchord.data.Http.IOS_USER_AGENT
 
     private const val TAG = "BitChord"
 
@@ -58,12 +60,65 @@ object Innertube {
     var cookie: String? = null
 
     /**
-     * Google's per-session visitor id, lifted from the first response that
-     * carries one. Stats pings are attributed to it, so it has to be the same
-     * value the browse/player calls used.
+     * Google's per-session visitor id.
+     *
+     * Far more load-bearing than "an id for stats". A `player` request that
+     * carries no visitor id is treated as a client with no session at all, and
+     * Google answers it in one of two ways: the honest one, `LOGIN_REQUIRED` /
+     * "Sign in to confirm you're not a bot", or the quiet one — a perfectly
+     * ordinary-looking response whose stream URLs serve a byte to anything that
+     * asks and then refuse every real read with 403. The second is what
+     * "it loads and then doesn't play" is made of.
+     *
+     * So it is fetched deliberately by [ensureVisitorData] rather than being
+     * hoped for: browse responses carry one only sometimes, and a session that
+     * never happened to see one would silently never play anything.
      */
     @Volatile
     private var visitorData: String? = null
+
+    /**
+     * A visitor id for this session, minting one if there isn't one yet.
+     *
+     * @param refresh discard the current id and take a fresh one — worth doing
+     *   exactly once when a request comes back accusing us of being a bot,
+     *   since an id can be burned while the session around it is fine.
+     */
+    suspend fun ensureVisitorData(refresh: Boolean = false): String? {
+        if (!refresh && visitorData != null) return visitorData
+        runCatching { fetchVisitorData() }
+            .onFailure { Log.w(TAG, "could not mint a visitor id: ${it.message}") }
+            .getOrNull()
+            ?.let { visitorData = it }
+        return visitorData
+    }
+
+    /**
+     * The service worker bootstrap the web player loads before anything else,
+     * which is where a fresh visitor id comes from without needing a page.
+     * It answers with an anti-hijacking prefix and then plain nested arrays,
+     * so the id is found by shape rather than by a path that would rot.
+     */
+    private suspend fun fetchVisitorData(): String? {
+        val body = client.get("https://www.youtube.com/sw.js_data") {
+            header("User-Agent", WEB_USER_AGENT)
+        }.bodyAsText()
+        val payload = Json.parseToJsonElement(body.substringAfter("\n", body.drop(5)))
+        return findVisitorData(payload)
+    }
+
+    private fun findVisitorData(element: JsonElement): String? = when (element) {
+        is JsonArray -> element.firstNotNullOfOrNull { findVisitorData(it) }
+        is JsonPrimitive -> element.contentOrNull?.takeIf { VISITOR_DATA.matches(it) }
+        else -> null
+    }
+
+    /** Protobuf-in-base64; always this shape, and nothing else in there is. */
+    private val VISITOR_DATA = Regex("""Cg[A-Za-z0-9_%-]{40,}""")
+
+    private const val WEB_USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+            "(KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36"
 
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -117,11 +172,27 @@ object Innertube {
         }
 
     /**
-     * Highest-bitrate audio-only stream for [videoId], or null when the track
-     * is genuinely unplayable (region block, takedown, members-only).
+     * The `player` response for [videoId] as seen by [client] — the audio
+     * formats and whatever it takes to unlock them.
+     *
+     * The single cheapest thing this app does to start a track: one POST,
+     * answered in a few hundred milliseconds, against an endpoint that carries
+     * no HTML and is not rate-shaped the way the watch page is.
+     *
+     * [signatureTimestamp] is required by the clients whose formats come back
+     * ciphered ([PlayerClient.needsSignatureTimestamp]) and ignored by the
+     * rest; it is read out of YouTube's own player JavaScript.
+     *
+     * @throws UnplayableException when the track is refused rather than
+     *   missing — a region block, a takedown, or the client being turned away.
+     *   Callers walk on to the next client on the strength of that distinction.
      */
-    suspend fun playerStreamUrl(videoId: String): String? {
-        val response = postPlayer(videoId)
+    suspend fun player(
+        videoId: String,
+        client: PlayerClient,
+        signatureTimestamp: Int? = null,
+    ): JsonObject {
+        val response = postPlayer(videoId, client, signatureTimestamp)
 
         val status = response["playabilityStatus"]?.jsonObject
             ?.get("status")?.jsonPrimitive?.content
@@ -130,29 +201,31 @@ object Innertube {
                 ?.get("reason")?.jsonPrimitive?.content
             throw UnplayableException(reason ?: status)
         }
-
-        return response["streamingData"]?.jsonObject
-            ?.get("adaptiveFormats")?.jsonArray
-            ?.map { it.jsonObject }
-            ?.filter { format ->
-                format["mimeType"]?.jsonPrimitive?.content?.startsWith("audio/") == true &&
-                    format["url"] != null // skip ciphered entries outright
-            }
-            ?.maxByOrNull { it["bitrate"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L }
-            ?.get("url")?.jsonPrimitive?.content
+        return response
     }
 
-    class UnplayableException(reason: String) :
-        IllegalStateException("Track unavailable: $reason")
+    class UnplayableException(private val reason: String) :
+        IllegalStateException("Track unavailable: $reason") {
+
+        /**
+         * Whether this is Google doubting the client rather than the track
+         * being unavailable. Worth a fresh visitor id and another go; a real
+         * region block or takedown is not.
+         */
+        val looksLikeBotCheck: Boolean
+            get() = reason.contains("bot", ignoreCase = true) ||
+                reason.contains("unusual traffic", ignoreCase = true) ||
+                reason.contains("sign in", ignoreCase = true)
+    }
 
     /** The stats endpoints a player response nominates for one playback. */
     data class PlaybackTracking(val playbackUrl: String, val watchtimeUrl: String?)
 
     /**
      * Player response fetched *with* the session cookie, purely to read back
-     * `playbackTracking` — [playerStreamUrl] deliberately skips auth so it can
-     * use the iOS client and dodge signature ciphering, so it never sees this
-     * block. Null for guests: there's no account history to update.
+     * `playbackTracking` — [player] deliberately skips auth so its device
+     * clients are answered at all, so it never sees this block. Null for
+     * guests: there's no account history to update.
      */
     suspend fun playbackTracking(videoId: String): PlaybackTracking? {
         if (cookie == null) return null
@@ -286,25 +359,52 @@ object Innertube {
         return response
     }
 
-    /** Deliberately unauthenticated: the iOS client is rejected when signed cookies are attached. */
-    private suspend fun postPlayer(videoId: String): JsonObject =
-        client.post("$YT_BASE/player") {
+    /**
+     * Deliberately unauthenticated.
+     *
+     * The app clients this walks through are answered *because* they look like
+     * anonymous devices; attaching the session cookie to one is what gets it
+     * turned away with `LOGIN_REQUIRED`. Nothing about the account is needed to
+     * fetch audio — history is credited separately, by [playbackTracking] and
+     * the stats pings, which do carry the session.
+     */
+    private suspend fun postPlayer(
+        videoId: String,
+        playerClient: PlayerClient,
+        signatureTimestamp: Int?,
+    ): JsonObject =
+        client.post("${playerClient.apiBase()}/player") {
             contentType(ContentType.Application.Json)
             parameter("prettyPrint", "false")
-            header("User-Agent", IOS_USER_AGENT)
-            header("Origin", "https://www.youtube.com")
+            header("User-Agent", playerClient.userAgent)
+            header("X-YouTube-Client-Name", playerClient.clientId)
+            header("X-YouTube-Client-Version", playerClient.clientVersion)
+            playerClient.origin?.let { header("Origin", it) }
+            playerClient.referer?.let { header("Referer", it) }
+            // Shared with browse/search so one session is seen throughout,
+            // rather than a device that mints a new identity per request.
+            visitorData?.let { header("X-Goog-Visitor-Id", it) }
             setBody(
                 buildJsonObject {
                     putJsonObject("context") {
                         putJsonObject("client") {
-                            put("clientName", "IOS")
-                            put("clientVersion", IOS_VERSION)
-                            put("deviceMake", "Apple")
-                            put("deviceModel", "iPhone16,2")
-                            put("osName", "iPhone")
-                            put("osVersion", "18.2.1.22C161")
+                            put("clientName", playerClient.clientName)
+                            put("clientVersion", playerClient.clientVersion)
+                            playerClient.osName?.let { put("osName", it) }
+                            playerClient.osVersion?.let { put("osVersion", it) }
+                            playerClient.deviceMake?.let { put("deviceMake", it) }
+                            playerClient.deviceModel?.let { put("deviceModel", it) }
+                            playerClient.androidSdkVersion?.let { put("androidSdkVersion", it.toInt()) }
                             put("hl", "en")
                             put("gl", "US")
+                            visitorData?.let { put("visitorData", it) }
+                        }
+                    }
+                    if (playerClient.needsSignatureTimestamp && signatureTimestamp != null) {
+                        putJsonObject("playbackContext") {
+                            putJsonObject("contentPlaybackContext") {
+                                put("signatureTimestamp", signatureTimestamp)
+                            }
                         }
                     }
                     put("videoId", videoId)
@@ -313,6 +413,9 @@ object Innertube {
                 },
             )
         }.body<JsonObject>()
+
+    /** Browser-shaped clients are served from the Music host; app clients from YouTube proper. */
+    private fun PlayerClient.apiBase(): String = if (usesMusicHost) MUSIC_BASE else YT_BASE
 
     private fun sapisidFrom(cookieHeader: String): String? =
         cookieHeader.split("; ", ";")

--- a/app/src/main/java/com/music/bitchord/data/innertube/Innertube.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/Innertube.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
@@ -15,6 +16,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -27,6 +29,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import java.io.IOException
 import java.security.MessageDigest
 
 /**
@@ -126,7 +129,46 @@ object Innertube {
         // Same OkHttp instance ExoPlayer streams through — see Http.
         engine { preconfigured = com.music.bitchord.data.Http.client }
         install(ContentNegotiation) { json(json) }
+        // Without this the only bound is OkHttp's own read timeout, and the
+        // failure it raises reads as "Socket timeout has expired […]
+        // socket_timeout=unknown" — Ktor reporting a limit it was never told.
+        install(HttpTimeout) {
+            requestTimeoutMillis = 30_000
+            connectTimeoutMillis = 15_000
+            socketTimeoutMillis = 20_000
+        }
         expectSuccess = true
+    }
+
+    /**
+     * Runs [block], giving transport failures another go before letting them
+     * reach the caller.
+     *
+     * A connection reset on mobile data is weather, not information: the
+     * request was fine and asking again generally answers. That matters most
+     * on a shared connection pool, where a socket torn down under one request
+     * — an abandoned search, a network handover — surfaces as
+     * "Software caused connection abort" on whichever request picked that
+     * connection up next, which had nothing to do with it.
+     *
+     * Only transport failures. An HTTP error status is an answer, and
+     * repeating the question won't change it. Cancellation isn't caught at
+     * all: [delay] throws when the coroutine is cancelled, so a search the
+     * user has typed past stops here instead of retrying on behalf of a query
+     * nobody is waiting for.
+     */
+    private suspend fun <T> withRetry(attempts: Int = 3, block: suspend () -> T): T {
+        var backoff = 500L
+        repeat(attempts - 1) {
+            try {
+                return block()
+            } catch (e: IOException) {
+                Log.d(TAG, "retrying: ${e.message}")
+            }
+            delay(backoff)
+            backoff *= 2
+        }
+        return block()
     }
 
     // ---- Public API ---------------------------------------------------------
@@ -316,41 +358,43 @@ object Innertube {
         query: Map<String, String> = emptyMap(),
         bodyExtras: JsonObjectBuilder.() -> Unit,
     ): JsonObject {
-        val response = client.post("$MUSIC_BASE/$endpoint") {
-            contentType(ContentType.Application.Json)
-            parameter("prettyPrint", "false")
-            query.forEach { (key, value) -> parameter(key, value) }
-            header("X-Origin", MUSIC_ORIGIN)
-            header("Origin", MUSIC_ORIGIN)
-            header("Referer", "$MUSIC_ORIGIN/")
-            // Stats pings are only honoured for a session Google recognises as
-            // a real client, so identify as one here too — the visitor id is
-            // minted on the first call and reused for the rest of the session.
-            header("X-YouTube-Client-Name", WEB_REMIX_CLIENT_ID)
-            header("X-YouTube-Client-Version", WEB_REMIX_VERSION)
-            visitorData?.let { header("X-Goog-Visitor-Id", it) }
-            cookie?.let { c ->
-                header("Cookie", c)
-                header("X-Goog-AuthUser", "0")
-                sapisidFrom(c)?.let { header("Authorization", sapisidHash(it)) }
-            }
-            setBody(
-                buildJsonObject {
-                    putJsonObject("context") {
-                        putJsonObject("client") {
-                            put("clientName", "WEB_REMIX")
-                            put("clientVersion", WEB_REMIX_VERSION)
-                            put("hl", "en")
-                            put("gl", "US")
-                            visitorData?.let { put("visitorData", it) }
+        val response = withRetry {
+            client.post("$MUSIC_BASE/$endpoint") {
+                contentType(ContentType.Application.Json)
+                parameter("prettyPrint", "false")
+                query.forEach { (key, value) -> parameter(key, value) }
+                header("X-Origin", MUSIC_ORIGIN)
+                header("Origin", MUSIC_ORIGIN)
+                header("Referer", "$MUSIC_ORIGIN/")
+                // Stats pings are only honoured for a session Google recognises
+                // as a real client, so identify as one here too — the visitor
+                // id is minted on the first call and reused for the session.
+                header("X-YouTube-Client-Name", WEB_REMIX_CLIENT_ID)
+                header("X-YouTube-Client-Version", WEB_REMIX_VERSION)
+                visitorData?.let { header("X-Goog-Visitor-Id", it) }
+                cookie?.let { c ->
+                    header("Cookie", c)
+                    header("X-Goog-AuthUser", "0")
+                    sapisidFrom(c)?.let { header("Authorization", sapisidHash(it)) }
+                }
+                setBody(
+                    buildJsonObject {
+                        putJsonObject("context") {
+                            putJsonObject("client") {
+                                put("clientName", "WEB_REMIX")
+                                put("clientVersion", WEB_REMIX_VERSION)
+                                put("hl", "en")
+                                put("gl", "US")
+                                visitorData?.let { put("visitorData", it) }
+                            }
+                            putJsonObject("user") { put("lockedSafetyMode", false) }
+                            putJsonObject("request") { put("useSsl", true) }
                         }
-                        putJsonObject("user") { put("lockedSafetyMode", false) }
-                        putJsonObject("request") { put("useSsl", true) }
-                    }
-                    bodyExtras()
-                },
-            )
-        }.body<JsonObject>()
+                        bodyExtras()
+                    },
+                )
+            }.body<JsonObject>()
+        }
 
         if (visitorData == null) {
             visitorData = response["responseContext"]?.jsonObject

--- a/app/src/main/java/com/music/bitchord/data/innertube/InnertubeParser.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/InnertubeParser.kt
@@ -196,11 +196,15 @@ object InnertubeParser {
         val songs = mutableListOf<Song>()
         var moreSongs: String? = null
         val shelves = mutableListOf<HomeShelf>()
+        val header = response["header"]
+        // "Top songs" rows are billed by the page they sit on: the subtitle
+        // beside them counts plays where a search row names the artist.
+        val credit = Credits(artistName = artistName(header))
 
         sections.forEach { section ->
             section.o("musicShelfRenderer")?.let { shelf ->
                 shelf.a("contents").orEmpty().forEach { row ->
-                    parseResponsiveListItem(row.o("musicResponsiveListItemRenderer"))
+                    parseResponsiveListItem(row.o("musicResponsiveListItemRenderer"), credit)
                         ?.let(songs::add)
                 }
                 if (moreSongs == null) {
@@ -220,11 +224,10 @@ object InnertubeParser {
                 }
             }
         }
-        val header = response["header"]
         return ArtistPage(
             songs, moreSongs, shelves,
             thumbnailUrl = artistThumbnail(header),
-            name = artistName(header),
+            name = credit.artistName,
         )
     }
 
@@ -271,11 +274,13 @@ object InnertubeParser {
      */
     fun collectSongsDeep(root: JsonElement): List<Song> {
         val out = LinkedHashMap<String, Song>()
+        // A release's own rows are credited by its header, not one by one.
+        val pageCredit = pageCredit(root)
         fun walk(node: JsonElement) {
             when (node) {
                 is JsonObject -> {
                     node["musicResponsiveListItemRenderer"]?.let { renderer ->
-                        parseResponsiveListItem(renderer as? JsonObject)
+                        parseResponsiveListItem(renderer as? JsonObject, pageCredit)
                             ?.let { out[it.videoId] = it }
                     }
                     node.values.forEach(::walk)
@@ -325,7 +330,14 @@ object InnertubeParser {
 
     // ---- Renderers ----------------------------------------------------------
 
-    private fun parseResponsiveListItem(renderer: JsonObject?): Song? {
+    /**
+     * One track row. [fallback] is what the page it came from is billed to —
+     * see [pageCredit] — and is used only where the row itself says nothing.
+     */
+    private fun parseResponsiveListItem(
+        renderer: JsonObject?,
+        fallback: Credits = Credits(),
+    ): Song? {
         if (renderer == null) return null
         val videoId = renderer.o("playlistItemData").s("videoId")
             ?: renderer.o("overlay")
@@ -346,9 +358,11 @@ object InnertubeParser {
         // On the "All" tab the first segment is the row type ("Song", "Video"),
         // not the artist — skip those so the subtitle reads like a credit.
         val rowType = parts.firstOrNull { it.lowercase() in TYPE_WORDS }?.lowercase()
+        // A track row on an album lists its play count where a search row
+        // lists the artist, so a segment that reads as a tally is no credit.
         val artist = parts.firstOrNull {
-            !it.matches(DURATION) && it.lowercase() !in TYPE_WORDS
-        } ?: "Unknown artist"
+            !it.matches(DURATION) && it.lowercase() !in TYPE_WORDS && !it.matches(TALLY)
+        }
 
         // The artist/album names in the subtitle carry browse endpoints; pull
         // them out so the long-press menu can open those pages.
@@ -365,13 +379,18 @@ object InnertubeParser {
             videoId = videoId,
             title = title,
             // The run that links to an artist page is the authoritative
-            // credit; the "All" tab often lists only "Song • 4:30" otherwise.
-            artist = credits.artistName?.takeIf { it.isNotBlank() } ?: artist,
+            // credit; the "All" tab often lists only "Song • 4:30" otherwise,
+            // and an album's own rows carry no credit at all — the release is
+            // billed once, in the header the row hangs under.
+            artist = credits.artistName?.takeIf { it.isNotBlank() }
+                ?: artist
+                ?: fallback.artistName
+                ?: "Unknown artist",
             thumbnailUrl = thumbnails.best(),
             durationText = duration,
-            artistId = credits.artistId,
-            albumId = credits.albumId,
-            albumName = credits.albumName,
+            artistId = credits.artistId ?: fallback.artistId,
+            albumId = credits.albumId ?: fallback.albumId,
+            albumName = credits.albumName ?: fallback.albumName,
             // The row type word is the clean signal when present ("All" tab);
             // otherwise a music-video upload gives itself away with widescreen
             // art where a catalogue track has square album cover art.
@@ -403,6 +422,45 @@ object InnertubeParser {
             }
         }
         return credits
+    }
+
+    /**
+     * Who a release page is billed to, off its own header.
+     *
+     * An album or single doesn't repeat the credit on every track — it says
+     * "Single • Dhanda Nyoliwala" once at the top and then lists bare titles,
+     * so every row read on its own comes back as "Unknown artist". The header
+     * is that missing credit, and carries the artist's browse id with it, so
+     * the long-press menu can still open the artist page from those rows.
+     *
+     * Only releases, never playlists: a playlist's header names whoever put
+     * it together, which is not what its tracks are by. Playlist rows carry
+     * their own credits anyway.
+     */
+    private fun pageCredit(root: JsonElement): Credits {
+        val header = HEADER_RENDERERS.firstNotNullOfOrNull {
+            collectRenderers(root, it).firstOrNull()
+        } ?: return Credits()
+        // The current header hangs the artist off a strapline above the title;
+        // the older one packs it into the subtitle, "Album • Artist • 2024".
+        val lines = HEADER_CREDIT_LINES.map { header.o(it).a("runs").orEmpty() }
+        // Split per line, not across them: the strapline and the subtitle are
+        // separate sentences, and running them together would weld the artist
+        // onto the word that says this is a release at all.
+        val parts = lines.flatMap { line ->
+            line.joinToString("") { it.s("text").orEmpty() }.split(" • ").map(String::trim)
+        }
+        if (parts.none { it.lowercase() in RELEASE_WORDS }) return Credits()
+
+        val credits = creditsOf(lines.flatten())
+        if (credits.artistName?.isNotBlank() == true) return credits
+        // An artist YouTube has no page for is named in the same line without
+        // a link to follow, leaving the name as the only thing to go on.
+        val name = parts.firstOrNull {
+            it.isNotBlank() && it.lowercase() !in TYPE_WORDS && !it.matches(TALLY) &&
+                !it.matches(YEAR) && !it.matches(DURATION)
+        }
+        return credits.copy(artistName = name)
     }
 
     /**
@@ -498,6 +556,26 @@ object InnertubeParser {
     }
 
     private val DURATION = Regex("""\d+:\d{2}""")
+    private val YEAR = Regex("""\d{4}""")
+    /**
+     * A counted quantity rather than a name — "12.4M plays", "13 songs",
+     * "1 hour, 4 minutes". Deliberately narrow: it has to leave "21 Savage"
+     * and "50 Cent" alone, so a number only disqualifies a segment when it is
+     * counting one of the words YouTube counts with.
+     */
+    private val TALLY = Regex(
+        """[\d.,]+\s*[KMB]?\s+(plays|views|likes|songs|tracks|subscribers|""" +
+            """hours?|minutes?|seconds?)\b.*""",
+        RegexOption.IGNORE_CASE,
+    )
+    /** Header words that mark a page as a release, whose rows share its credit. */
+    private val RELEASE_WORDS = setOf("album", "single", "ep")
+    private val HEADER_RENDERERS = listOf(
+        "musicResponsiveHeaderRenderer",
+        "musicDetailHeaderRenderer",
+    )
+    /** Header lines that name the artist, in either header shape. */
+    private val HEADER_CREDIT_LINES = listOf("straplineTextOne", "subtitle")
     private val TYPE_WORDS = setOf(
         "song", "video", "album", "single", "ep", "artist",
         "playlist", "podcast", "episode",
@@ -525,13 +603,20 @@ private fun JsonElement?.runs(): String =
     this.a("runs")?.joinToString("") { it.s("text").orEmpty() }.orEmpty()
 
 /**
- * Last thumbnail is the largest. The size hint is normalised rather than
- * trusted — YouTube's largest offer is 544px, but it will serve any size
- * asked for, and [com.music.bitchord.data.model.artworkAt] trades up from
- * here for the full-screen player.
+ * Last thumbnail is the largest, taken exactly as offered.
+ *
+ * This used to rewrite the size hint up to 544px on the way past, on the
+ * reasoning that YouTube will serve any size asked for and bigger is better.
+ * It is, for the one image drawn full-screen — and it is wasteful for every
+ * other, which is most of them: YouTube offers a search row's cover at 120px
+ * for 7.8kB and will happily serve the same cover at 544px for 84kB, to fill
+ * a square the size of a fingertip.
+ *
+ * So the size is now decided where the image is drawn rather than here, by
+ * [com.music.bitchord.data.model.artworkAt] — which trades up just as freely
+ * as it trades down, and is what the player calls.
  */
-private fun JsonArray?.best(): String? =
-    this?.lastOrNull().s("url")?.replace(Regex("""w\d+-h\d+"""), "w544-h544")
+private fun JsonArray?.best(): String? = this?.lastOrNull().s("url")
 
 /**
  * Catalogue art is always square; a music-video upload's thumbnail is

--- a/app/src/main/java/com/music/bitchord/data/innertube/PlayerClient.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/PlayerClient.kt
@@ -1,0 +1,210 @@
+package com.music.bitchord.data.innertube
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+/**
+ * One client identity for the `player` endpoint.
+ *
+ * YouTube hands out stream URLs per client, and which clients are answered
+ * changes without notice: an identity that returns `OK` today answers
+ * `LOGIN_REQUIRED` next month, and one that is merely *old* is refused with a
+ * bare HTTP 400 before playability is even considered. So this is a list to
+ * walk rather than a constant — see [StreamResolver].
+ *
+ * Three things travel together and must not be separated:
+ *
+ *  - **[userAgent]**, which the media fetch has to repeat. googlevideo bakes
+ *    the client into the URL as `c=`/`cver=` and compares it against the
+ *    headers of the request that comes back for the bytes.
+ *  - **[origin]**, sent only by the browser-shaped clients, and pointing at
+ *    the host that client actually runs on. Native app clients send none, and
+ *    sending one anyway is as wrong as omitting it from a web client.
+ *  - **[needsSignatureTimestamp]**, which decides whether the player request
+ *    has to carry a timestamp lifted from YouTube's player JavaScript. The
+ *    clients that need it are the ones that answer with ciphered formats.
+ *
+ * The versions here are load-bearing and were checked against the live
+ * endpoint rather than copied from anywhere; see each one's note.
+ */
+data class PlayerClient(
+    val clientName: String,
+    val clientVersion: String,
+    val clientId: String,
+    val userAgent: String,
+    val osName: String? = null,
+    val osVersion: String? = null,
+    val deviceMake: String? = null,
+    val deviceModel: String? = null,
+    val androidSdkVersion: String? = null,
+    /** The host this client runs on, for browser-shaped clients only. */
+    val origin: String? = null,
+    /** Ciphered formats can't be unlocked without one. */
+    val needsSignatureTimestamp: Boolean = false,
+) {
+    val referer: String? get() = origin?.let { "$it/" }
+
+    /** Browser-shaped clients are served from their own host; app clients from YouTube proper. */
+    val usesMusicHost: Boolean get() = origin == MUSIC_ORIGIN
+
+    /**
+     * Headers the *media* request must carry for a URL this client minted.
+     *
+     * The stream fetch is a separate request from the one that produced the
+     * URL, and googlevideo treats a mismatch between the two as reason enough
+     * to throttle the response to a crawl or refuse it with 403.
+     */
+    fun mediaHeaders(): Map<String, String> = buildMap {
+        put("User-Agent", userAgent)
+        origin?.let { put("Origin", it) }
+        referer?.let { put("Referer", it) }
+    }
+
+    companion object {
+        private const val MUSIC_ORIGIN = "https://music.youtube.com"
+        private const val YOUTUBE_ORIGIN = "https://www.youtube.com"
+
+        private const val WEB_USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36"
+
+        /**
+         * iPhone YouTube, and the one that carries the session in practice: it
+         * is answered without a login, without a proof of origin token and
+         * without a signature timestamp, and it returns plain `url` fields —
+         * so a stream is one POST away with no player JavaScript in the path.
+         *
+         * The version is the whole ballgame. Anything Google considers stale is
+         * refused with an HTTP 400 before playability is looked at, which is
+         * not a "try the next format" failure but a "this identity is dead"
+         * one. 19.29.1 is already past that line; these two are not.
+         */
+        val IOS = PlayerClient(
+            clientName = "IOS",
+            clientVersion = "20.03.02",
+            clientId = "5",
+            userAgent = "com.google.ios.youtube/20.03.02 (iPhone16,2; U; CPU iOS 18_2_1 like Mac OS X;)",
+            osName = "iPhone",
+            osVersion = "18.2.1.22C161",
+            deviceMake = "Apple",
+            deviceModel = "iPhone16,2",
+        )
+
+        /** A newer build of the same app: refused on a different schedule. */
+        val IOS_RECENT = IOS.copy(
+            clientVersion = "20.10.4",
+            userAgent = "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)",
+            osVersion = "18.3.2.22D82",
+        )
+
+        /**
+         * The phone YouTube app. Answers `OK` where the others are turned away,
+         * but every format comes back ciphered — so reaching it costs a
+         * download of YouTube's player JavaScript and a signature to solve.
+         * Worth it as a fallback; not worth it first.
+         */
+        val ANDROID = PlayerClient(
+            clientName = "ANDROID",
+            clientVersion = "21.10.38",
+            clientId = "3",
+            userAgent = "com.google.android.youtube/21.10.38 " +
+                "(Linux; U; Android 15; en_US; Pixel 9 Pro; Build/AP4A.250205.002; Cronet/132.0.6834.79) gzip",
+            osName = "Android",
+            osVersion = "15",
+            deviceMake = "Google",
+            deviceModel = "Pixel 9 Pro",
+            androidSdkVersion = "35",
+            needsSignatureTimestamp = true,
+        )
+
+        /**
+         * The Quest's YouTube app, and the first thing to try: unciphered,
+         * login-free, no proof-of-origin token and no signature timestamp, so
+         * a stream is one POST away with no player JavaScript in the path.
+         *
+         * Worth knowing when this list is next revisited: whether it is
+         * answered depends on the *network the request leaves from*, not on
+         * the app or the account. It serves a phone on mobile data or home
+         * wifi while answering the same request from a datacentre or a
+         * hard-used address with `LOGIN_REQUIRED` / "Sign in to confirm you're
+         * not a bot". A check run from anywhere but the device is measuring
+         * the wrong thing.
+         */
+        val ANDROID_VR = PlayerClient(
+            clientName = "ANDROID_VR",
+            clientVersion = "1.61.48",
+            clientId = "28",
+            userAgent = "com.google.android.apps.youtube.vr.oculus/1.61.48 " +
+                "(Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
+            osName = "Android",
+            osVersion = "12",
+            deviceMake = "Oculus",
+            deviceModel = "Quest 3",
+            androidSdkVersion = "32",
+        )
+
+        /** An older build of the same app; refused on a different schedule. */
+        val ANDROID_VR_LEGACY = ANDROID_VR.copy(
+            clientVersion = "1.43.32",
+            userAgent = "com.google.android.apps.youtube.vr.oculus/1.43.32 " +
+                "(Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/107.0.5284.2)",
+        )
+
+        /** Last resort: the web player itself. Always ciphered, and usually refused. */
+        val WEB_REMIX = PlayerClient(
+            clientName = "WEB_REMIX",
+            clientVersion = "1.20260114.01.00",
+            clientId = "67",
+            userAgent = WEB_USER_AGENT,
+            origin = MUSIC_ORIGIN,
+            needsSignatureTimestamp = true,
+        )
+
+        /**
+         * Identities we never mint with, but may still have to fetch for:
+         * [forStreamUrl] dresses a URL however that URL says it was made, and
+         * the extraction failsafe picks its own client without asking.
+         */
+        private val WEB = PlayerClient(
+            clientName = "WEB",
+            clientVersion = "2.20260114.00.00",
+            clientId = "1",
+            userAgent = WEB_USER_AGENT,
+            origin = YOUTUBE_ORIGIN,
+        )
+
+        private val TVHTML5 = PlayerClient(
+            clientName = "TVHTML5",
+            clientVersion = "7.20260114.00.00",
+            clientId = "7",
+            userAgent = "Mozilla/5.0(SMART-TV; Linux; Tizen 4.0.0.2) AppleWebkit/605.1.15 " +
+                "(KHTML, like Gecko) SamsungBrowser/9.2 TV Safari/605.1.15",
+            origin = YOUTUBE_ORIGIN,
+        )
+
+        /**
+         * The client a googlevideo URL says minted it, so the media fetch can
+         * be dressed as that client whatever produced the URL — including the
+         * extraction failsafe, which picks a client of its own choosing.
+         *
+         * Falls back to [IOS] when the URL names a client we don't model: it is
+         * what mints most of them here, and being approximately right beats
+         * sending a smart TV's headers for a URL an iPhone asked for.
+         */
+        fun forStreamUrl(url: String): PlayerClient {
+            val parsed = url.toHttpUrlOrNull() ?: return IOS
+            val name = parsed.queryParameter("c")?.uppercase() ?: return IOS
+            val version = parsed.queryParameter("cver")
+            return when {
+                name.startsWith("IOS") ->
+                    if (version == IOS_RECENT.clientVersion) IOS_RECENT else IOS
+                name == "ANDROID_VR" ->
+                    if (version == ANDROID_VR_LEGACY.clientVersion) ANDROID_VR_LEGACY else ANDROID_VR
+                name.startsWith("ANDROID") -> ANDROID
+                name.startsWith("TVHTML5") -> TVHTML5
+                name == "WEB_REMIX" -> WEB_REMIX
+                name.startsWith("WEB") || name == "MWEB" -> WEB
+                else -> IOS
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
@@ -5,9 +5,6 @@ import android.util.Log
 import com.music.bitchord.data.Http
 import com.music.bitchord.data.NerdStats
 import com.music.bitchord.data.settings.AppSettings
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.NewPipe
@@ -30,16 +27,10 @@ import java.util.concurrent.ConcurrentHashMap
  * by running YouTube's own player JavaScript — which is what NewPipe's
  * [YoutubeJavaScriptPlayerManager] does (and caches per player version).
  *
- * Strategy, most reliable path first:
- *  1. NewPipe's full extractor, which picks a client that still works, derives
- *     the signature timestamp and solves `n` itself. Tried [NEWPIPE_ATTEMPTS]
- *     times, because its failures are usually transient — a timeout, or the
- *     loader thread being interrupted — rather than a real "can't play this".
- *  2. Only then the hand-rolled Innertube IOS player response. Google has
- *     since tightened that client, and the URLs it mints are frequently
- *     rejected with **HTTP 403**, so it is a last resort and not a peer of the
- *     path above. A 403 from it is recovered by [invalidate] + a re-resolve,
- *     driven from PlaybackService's error handler.
+ * Strategy, cheapest path first:
+ *  1. Innertube IOS player response → direct unciphered URL → deobfuscate `n`.
+ *  2. Fall back to NewPipe's full extractor, which re-derives everything
+ *     itself and survives client-side changes on YouTube's end.
  */
 object StreamResolver {
 
@@ -99,74 +90,25 @@ object StreamResolver {
      * Results are held briefly — see [recent]. Resolving is the slow part of
      * starting a track, and ExoPlayer asks again for every re-open: each seek
      * outside the buffer, and each range the cache fills in.
-     *
-     * Resolution for one videoId is serialised by [locks]. Without it the
-     * player's loader and [com.music.bitchord.playback.AudioCache]'s read-ahead
-     * race to resolve the same track at the same moment, tripling the work —
-     * each extraction is several round trips plus running YouTube's player
-     * JavaScript — and making the timeouts that push us onto the failing
-     * fallback far more likely. The second caller through the gate finds the
-     * first one's result already in [recent] and pays nothing.
      */
     suspend fun resolve(videoId: String): String {
         init
 
-        cached(videoId)?.let { return it }
+        recent[videoId]
+            ?.takeIf { SystemClock.elapsedRealtime() - it.at < URL_TTL_MS }
+            ?.let { return it.url }
 
-        val lock = locks.computeIfAbsent(videoId) { Mutex() }
-        return lock.withLock {
-            // Whoever held the lock has very likely just resolved this.
-            cached(videoId) ?: extract(videoId).also { remember(videoId, it) }
-        }
-    }
-
-    /** The remembered URL for [videoId], if one is still inside its TTL. */
-    private fun cached(videoId: String): String? = recent[videoId]
-        ?.takeIf { SystemClock.elapsedRealtime() - it.at < URL_TTL_MS }
-        ?.url
-
-    /**
-     * Drops the remembered URL for [videoId], so the next [resolve] goes back
-     * out and mints a fresh one.
-     *
-     * Needed because a URL is remembered as soon as it is produced, before
-     * anything has tried to fetch it. When one turns out to be dead — a 403
-     * off the IOS fallback — the entry would otherwise keep being served from
-     * [recent] for the whole TTL, and every retry would fail identically
-     * without a single request leaving the device.
-     */
-    fun invalidate(videoId: String) {
-        recent.remove(videoId)
-    }
-
-    /**
-     * NewPipe first and repeatedly, then the IOS fallback.
-     *
-     * Cancellation is rethrown rather than retried: when ExoPlayer abandons a
-     * load it interrupts the thread this runs on, and there is nothing left to
-     * resolve for.
-     */
-    private suspend fun extract(videoId: String): String {
-        repeat(NEWPIPE_ATTEMPTS) { attempt ->
-            try {
-                return newPipeUrl(videoId).also { Log.d(TAG, "resolved via NewPipe") }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: InterruptedException) {
-                // The interrupt flag is still set; anything further fails
-                // instantly, so stop rather than burn the remaining attempts.
-                Thread.currentThread().interrupt()
-                throw e
-            } catch (e: Exception) {
-                Log.w(
-                    TAG,
-                    "NewPipe resolve failed for $videoId " +
-                        "(attempt ${attempt + 1}/$NEWPIPE_ATTEMPTS): ${e.message}",
-                )
+        val url = runCatching { newPipeUrl(videoId) }
+            .onFailure { Log.w(TAG, "NewPipe resolve failed for $videoId: ${it.message}") }
+            .getOrNull()
+            ?.also { Log.d(TAG, "resolved via NewPipe") }
+            ?: run {
+                Log.d(TAG, "falling back to Innertube IOS client for $videoId")
+                innertubeUrl(videoId)
             }
-        }
-        Log.w(TAG, "falling back to Innertube IOS client for $videoId — expect 403s")
-        return innertubeUrl(videoId)
+
+        remember(videoId, url)
+        return url
     }
 
     /**
@@ -194,23 +136,10 @@ object StreamResolver {
      */
     private val recent = ConcurrentHashMap<String, Resolved>()
 
-    /** One gate per videoId, so concurrent callers resolve it only once. */
-    private val locks = ConcurrentHashMap<String, Mutex>()
-
     private const val URL_TTL_MS = 20 * 60 * 1000L
 
     /** Enough for the queue in hand; this is a latency cache, not a store. */
     private const val MAX_REMEMBERED = 32
-
-    /**
-     * How many times NewPipe is asked before the IOS fallback.
-     *
-     * Its failures in practice are `timeout` and `interrupted` — transient, and
-     * a second ask usually succeeds. Since the fallback is the thing that
-     * returns 403s, spending another few seconds here is strictly better than
-     * reaching it.
-     */
-    private const val NEWPIPE_ATTEMPTS = 3
 
     private fun remember(videoId: String, url: String) {
         if (recent.size >= MAX_REMEMBERED) {
@@ -219,11 +148,6 @@ object StreamResolver {
             if (recent.size >= MAX_REMEMBERED) recent.clear()
         }
         recent[videoId] = Resolved(url, SystemClock.elapsedRealtime())
-        // The gates outlive the entries they guarded, so they are trimmed on
-        // the same schedule rather than growing for the life of the process.
-        if (locks.size > MAX_REMEMBERED) {
-            locks.keys.removeAll { !recent.containsKey(it) && locks[it]?.isLocked != true }
-        }
     }
 
     private suspend fun innertubeUrl(videoId: String): String {

--- a/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
@@ -5,6 +5,11 @@ import android.util.Log
 import com.music.bitchord.data.Http
 import com.music.bitchord.data.NerdStats
 import com.music.bitchord.data.settings.AppSettings
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.NewPipe
@@ -16,25 +21,66 @@ import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
 import org.schabi.newpipe.extractor.services.youtube.YoutubeJavaScriptPlayerManager
 import org.schabi.newpipe.extractor.stream.DeliveryMethod
 import org.schabi.newpipe.extractor.stream.StreamInfo
+import java.net.URLDecoder
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 /**
  * Turns a videoId into a URL ExoPlayer can actually stream.
  *
- * The subtlety that makes or breaks this: every googlevideo URL carries an
- * `n` query parameter. Sent as-is, YouTube throttles the response to a crawl
- * or rejects it outright with **HTTP 403**. The value has to be transformed
- * by running YouTube's own player JavaScript — which is what NewPipe's
- * [YoutubeJavaScriptPlayerManager] does (and caches per player version).
+ * Three things make or break this, and the order they are attempted in matters
+ * as much as the mechanics of each:
  *
- * Strategy, cheapest path first:
- *  1. Innertube IOS player response → direct unciphered URL → deobfuscate `n`.
- *  2. Fall back to NewPipe's full extractor, which re-derives everything
- *     itself and survives client-side changes on YouTube's end.
+ *  1. **Which endpoint asks.** The `youtubei/v1/player` POST is one small JSON
+ *     round trip. The watch page — what a full extractor scrape fetches — is
+ *     several hundred kilobytes of HTML and is rate-shaped: under load Google
+ *     answers its headers immediately and then feeds the body out over tens of
+ *     seconds, or simply stops sending and never closes. That shaping is
+ *     invisible as an error and reads to a listener as endless buffering, so
+ *     the scrape is kept off the hot path entirely — see [newPipeUrl], the
+ *     failsafe of last resort.
+ *
+ *  2. **Which client asks.** Google turns identities away without notice and
+ *     without pattern: the client that works today answers `LOGIN_REQUIRED`
+ *     next month. So [CLIENTS] is walked rather than trusted, the one that last
+ *     worked is tried first, and one that is refused for a track is stood down
+ *     for that track for a while.
+ *
+ *  3. **Whether the URL is real.** Every googlevideo URL carries an `n`
+ *     parameter which, sent as-is, gets the response throttled to a crawl or
+ *     refused with 403; it has to be transformed by running YouTube's own
+ *     player JavaScript, which is what NewPipe's [YoutubeJavaScriptPlayerManager]
+ *     does. That can fail quietly, and a URL can be dead on arrival for reasons
+ *     no amount of care predicts — so nothing is handed to the player, or
+ *     cached, until a single byte has been fetched from it. See [probe].
  */
 object StreamResolver {
 
     private const val TAG = "BitChord"
+
+    /**
+     * Player clients in the order they are worth asking, cheapest and most
+     * reliable first — an order taken from what the live endpoint actually
+     * answers, not from what ought to work.
+     *
+     * The four at the top return plain `url` fields, so a stream is one POST
+     * away with no player JavaScript involved at all. The two below hand back
+     * ciphered formats, costing a download of that JavaScript and a signature
+     * to solve. See each entry in [PlayerClient].
+     *
+     * The gating that decides which of these answers is applied per network,
+     * not globally — an identity refused on one connection is served on
+     * another — which is the whole reason this is a list and why the order is
+     * only a starting guess that [clientOrder] corrects from experience.
+     */
+    private val CLIENTS = listOf(
+        PlayerClient.ANDROID_VR,
+        PlayerClient.ANDROID_VR_LEGACY,
+        PlayerClient.IOS,
+        PlayerClient.IOS_RECENT,
+        PlayerClient.ANDROID,
+        PlayerClient.WEB_REMIX,
+    )
 
     /** NewPipe needs a Downloader; reuse the app's single OkHttp client. */
     private class OkHttpDownloader : Downloader() {
@@ -81,11 +127,8 @@ object StreamResolver {
     private val init by lazy { NewPipe.init(OkHttpDownloader()) }
 
     /**
-     * @return a directly streamable URL, or throws with a reason worth showing.
-     *
-     * NewPipe goes first: it picks a client that still works, derives the
-     * signature timestamp and solves `n` itself, and is updated upstream when
-     * YouTube changes. The hand-rolled Innertube path is only a fallback.
+     * @return a directly streamable URL that has been proven to serve bytes,
+     *   or throws with a reason worth showing.
      *
      * Results are held briefly — see [recent]. Resolving is the slow part of
      * starting a track, and ExoPlayer asks again for every re-open: each seek
@@ -98,18 +141,345 @@ object StreamResolver {
             ?.takeIf { SystemClock.elapsedRealtime() - it.at < URL_TTL_MS }
             ?.let { return it.url }
 
-        val url = runCatching { newPipeUrl(videoId) }
-            .onFailure { Log.w(TAG, "NewPipe resolve failed for $videoId: ${it.message}") }
-            .getOrNull()
-            ?.also { Log.d(TAG, "resolved via NewPipe") }
+        val url = playerUrl(videoId)
             ?: run {
-                Log.d(TAG, "falling back to Innertube IOS client for $videoId")
-                innertubeUrl(videoId)
+                Log.w(TAG, "every player client failed for $videoId; falling back to extraction")
+                newPipeUrl(videoId)
             }
 
         remember(videoId, url)
         return url
     }
+
+    /**
+     * Walks [CLIENTS] until one produces a URL that actually serves audio.
+     *
+     * Every step is allowed to fail without taking the attempt with it: a
+     * client can be refused the track, hand back formats none of which can be
+     * unciphered, or mint a URL that turns out to be dead. Only running out of
+     * clients is a failure.
+     *
+     * @return the validated URL, or null to fall through to [newPipeUrl].
+     */
+    private suspend fun playerUrl(videoId: String): String? {
+        // Before anything asks. Without one, the good clients refuse outright
+        // and the rest hand back URLs that only *look* like they work — see
+        // [Innertube.ensureVisitorData].
+        Innertube.ensureVisitorData()
+
+        var timestamp: Int? = null
+        var mintedFreshVisitor = false
+
+        for (client in clientOrder()) {
+            if (isStoodDown(videoId, client)) continue
+            try {
+                // Only fetched once, and only if a client that needs it is
+                // reached — it costs a download of YouTube's player JavaScript.
+                if (client.needsSignatureTimestamp && timestamp == null) {
+                    timestamp = runCatching { YoutubeJavaScriptPlayerManager.getSignatureTimestamp(videoId) }
+                        .onFailure { Log.w(TAG, "no signature timestamp: ${it.message}") }
+                        .getOrNull()
+                        ?: continue
+                }
+
+                var response = try {
+                    Innertube.player(videoId, client, timestamp)
+                } catch (e: Innertube.UnplayableException) {
+                    // A visitor id can be burned while the session around it is
+                    // fine, and the only symptom is being called a bot. Worth
+                    // one fresh id and one more try, once per resolve.
+                    if (!e.looksLikeBotCheck || mintedFreshVisitor) throw e
+                    mintedFreshVisitor = true
+                    Log.d(TAG, "bot check from ${client.clientName}; minting a fresh visitor id")
+                    Innertube.ensureVisitorData(refresh = true)
+                    Innertube.player(videoId, client, timestamp)
+                }
+
+                val format = pickFormat(response) ?: continue
+                val url = streamUrl(videoId, format)
+                    ?.let { patchClientVersion(it, client.clientVersion) }
+                    ?: continue
+
+                when (probe(url)) {
+                    Probe.OK -> {
+                        Log.d(TAG, "resolved $videoId via ${client.clientName} @ ${format.kbps}kbps")
+                        preferred = client
+                        // The container carries no bitrate field, so this is
+                        // the only place the real figure is ever known.
+                        NerdStats.onStreamPicked(videoId, format.kbps)
+                        return url
+                    }
+                    // The client itself is being refused this track; don't
+                    // spend another round trip on it for a while.
+                    Probe.REFUSED -> standDown(videoId, client)
+                    Probe.UNREACHABLE -> Unit
+                }
+                Log.w(TAG, "${client.clientName} minted an unusable URL for $videoId")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "${client.clientName} failed for $videoId: ${e.message}")
+            }
+        }
+        return null
+    }
+
+    /**
+     * [CLIENTS], led by whichever one last worked.
+     *
+     * Google's decisions apply to the whole app for as long as they last, not
+     * to one track, so the client that served the previous song is overwhelmingly
+     * likely to serve this one — and starting there is what keeps the common
+     * case at a single round trip.
+     */
+    private fun clientOrder(): List<PlayerClient> {
+        val first = preferred ?: return CLIENTS
+        return listOf(first) + CLIENTS.filterNot { it == first }
+    }
+
+    @Volatile
+    private var preferred: PlayerClient? = null
+
+    // ---- Format selection ---------------------------------------------------
+
+    /** One audio entry of a player response, before its URL has been unlocked. */
+    private class Audio(
+        val url: String?,
+        val signatureCipher: String?,
+        val kbps: Int,
+    )
+
+    private fun pickFormat(response: JsonObject): Audio? {
+        val formats = response["streamingData"]?.jsonObject
+            ?.get("adaptiveFormats")?.jsonArray
+            ?.map { it.jsonObject }
+            ?.filter { it.str("mimeType")?.startsWith("audio/") == true }
+            ?.map {
+                Audio(
+                    url = it.str("url"),
+                    signatureCipher = it.str("signatureCipher") ?: it.str("cipher"),
+                    kbps = ((it.str("bitrate")?.toLongOrNull() ?: 0L) / 1000).toInt(),
+                )
+            }
+            ?.filter { it.url != null || it.signatureCipher != null }
+            .orEmpty()
+
+        return pickForQuality(formats.map { it.kbps to it })
+    }
+
+    private fun JsonObject.str(key: String): String? = this[key]?.jsonPrimitive?.content
+
+    /**
+     * Highest stream at or under the ceiling set for the connection in use; if
+     * everything is above it (e.g. Low on a track that only has 130kbps+), take
+     * the cheapest available rather than failing.
+     */
+    private fun <T> pickForQuality(candidates: List<Pair<Int, T>>): T? {
+        if (candidates.isEmpty()) return null
+        val ceiling = AppSettings.effectiveAudioQuality.maxKbps
+        val withinBudget = candidates.filter { it.first <= ceiling }
+        return (withinBudget.maxByOrNull { it.first } ?: candidates.minByOrNull { it.first })
+            ?.second
+    }
+
+    // ---- Unlocking ----------------------------------------------------------
+
+    /** The playable URL behind a format, or null if it can't be unlocked. */
+    private fun streamUrl(videoId: String, format: Audio): String? {
+        val direct = format.url
+        if (direct != null) return deobfuscate(videoId, direct)
+
+        val cipher = format.signatureCipher ?: return null
+        val params = cipher.split("&")
+            .mapNotNull { part ->
+                val i = part.indexOf('=').takeIf { it > 0 } ?: return@mapNotNull null
+                URLDecoder.decode(part.substring(0, i), "UTF-8") to
+                    URLDecoder.decode(part.substring(i + 1), "UTF-8")
+            }
+            .toMap()
+
+        val base = params["url"] ?: return null
+        val signature = params["s"] ?: return null
+        // Which query parameter the solved signature belongs in; YouTube has
+        // changed the name before, so it travels alongside rather than assumed.
+        val into = params["sp"] ?: "signature"
+        val solved = runCatching {
+            YoutubeJavaScriptPlayerManager.deobfuscateSignature(videoId, signature)
+        }.getOrElse {
+            Log.w(TAG, "signature cipher failed: ${it.message}")
+            return null
+        }
+        val separator = if ("?" in base) "&" else "?"
+        return deobfuscate(videoId, "$base$separator$into=$solved")
+    }
+
+    /**
+     * Transform the `n` parameter when present. If deobfuscation itself fails
+     * we still return the original URL — a throttled stream beats no stream,
+     * and [probe] gets the final say on whether it plays at all.
+     */
+    private fun deobfuscate(videoId: String, url: String): String {
+        val needsWork = url.toHttpUrlOrNull()?.queryParameter("n")?.isNotBlank() == true
+        if (!needsWork) return url
+        return runCatching {
+            YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url)
+        }.getOrElse {
+            Log.w(TAG, "n-param deobfuscation failed: ${it.message}")
+            url
+        }
+    }
+
+    /**
+     * Align the URL's `cver` with the client that actually asked.
+     *
+     * The player response fills it in from the request, but a signature or `n`
+     * transform can be solved against player JavaScript of a different vintage,
+     * and googlevideo answers a version it doesn't expect with a 403.
+     */
+    private fun patchClientVersion(url: String, clientVersion: String): String =
+        if ("cver=" in url) url.replace(Regex("cver=[^&]+"), "cver=$clientVersion") else url
+
+    // ---- Validation ---------------------------------------------------------
+
+    private enum class Probe {
+        /** Served media bytes; safe to play and to cache. */
+        OK,
+
+        /** Answered, but refused this request — the client is the problem. */
+        REFUSED,
+
+        /** Never got an answer worth interpreting; blame nothing in particular. */
+        UNREACHABLE,
+    }
+
+    /**
+     * Read the opening of a URL before trusting it.
+     *
+     * This is the whole difference between a track that fails and a track that
+     * fails *visibly and instantly*. A URL that 403s is indistinguishable from
+     * a good one until something reads from it; hand it to ExoPlayer and the
+     * failure surfaces as a track that spins and never starts.
+     *
+     * A real range, not `bytes=0-0`. A single byte is not a test: a URL minted
+     * for a session Google has reservations about will serve one to anybody and
+     * then refuse every request large enough to be actual listening, so a
+     * one-byte probe passes exactly the URLs this exists to catch. Sixteen
+     * kilobytes is past that line and still one cheap round trip.
+     *
+     * The headers are the ones the media fetch will really use — see
+     * [PlayerClient.forStreamUrl] — so this tests the request that matters
+     * rather than a more favourable version of it.
+     */
+    private fun probe(url: String): Probe {
+        val builder = okhttp3.Request.Builder().url(url)
+            .header("Range", "bytes=0-${PROBE_BYTES - 1}")
+        PlayerClient.forStreamUrl(url).mediaHeaders().forEach { (name, value) ->
+            builder.header(name, value)
+        }
+        return try {
+            prober.newCall(builder.build()).execute().use { response ->
+                when {
+                    response.code in REFUSAL_CODES -> Probe.REFUSED
+                    response.code !in 200..299 && response.code != 416 -> Probe.UNREACHABLE
+                    // A refusal dressed as a success: an error page, or the
+                    // consent/captcha interstitial, rather than audio.
+                    response.header("Content-Type")?.startsWith("audio/") != true -> Probe.REFUSED
+                    // Headers can arrive long before a body that never does —
+                    // exactly the shaping this whole path exists to sidestep.
+                    // Insisting on the whole range is the point: a trickle that
+                    // yields its first byte and stalls is a failure too.
+                    response.body?.source()?.request(PROBE_BYTES) != true -> Probe.UNREACHABLE
+                    else -> Probe.OK
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "probe failed: ${e.message}")
+            Probe.UNREACHABLE
+        }
+    }
+
+    private val REFUSAL_CODES = setOf(403, 404, 410)
+
+    /**
+     * The probe's own client: the app's, but on a short leash.
+     *
+     * [Http.client]'s 30-second read timeout is right for a stream being
+     * consumed as it arrives and far too patient for a yes/no question —
+     * waiting it out is indistinguishable from the stall being tested for.
+     * Built from the shared client, so the connection pool and DNS are the
+     * same ones the real fetch will use.
+     */
+    private val prober by lazy {
+        Http.client.newBuilder()
+            .callTimeout(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build()
+    }
+
+    private const val PROBE_TIMEOUT_SECONDS = 6L
+
+    /** Past what a grudging URL will serve, well under what any track holds. */
+    private const val PROBE_BYTES = 16L * 1024
+
+    // ---- Clients stood down -------------------------------------------------
+
+    /**
+     * Clients refused a given track, and until when.
+     *
+     * A refusal is rarely about the track alone — it usually means Google has
+     * stopped answering that identity — but it is recorded per track because
+     * that is the granularity it can be observed at. Keyed the same way it is
+     * looked up, so a stale entry costs one retry rather than a lasting hole.
+     */
+    private val standDownUntil = ConcurrentHashMap<String, Long>()
+
+    private const val STAND_DOWN_MS = 10 * 60 * 1000L
+
+    private fun key(videoId: String, client: PlayerClient) =
+        "$videoId|${client.clientName}@${client.clientVersion}"
+
+    private fun standDown(videoId: String, client: PlayerClient) {
+        standDownUntil[key(videoId, client)] = SystemClock.elapsedRealtime() + STAND_DOWN_MS
+    }
+
+    private fun isStoodDown(videoId: String, client: PlayerClient): Boolean {
+        val k = key(videoId, client)
+        val until = standDownUntil[k] ?: return false
+        if (until > SystemClock.elapsedRealtime()) return true
+        standDownUntil.remove(k)
+        return false
+    }
+
+    // ---- Failsafe -----------------------------------------------------------
+
+    /**
+     * NewPipe's full extractor, kept for the case where every player client has
+     * been turned away — it re-derives everything itself and is updated
+     * upstream when YouTube changes, so it works when nothing else does.
+     *
+     * Last rather than first because of what it costs: it scrapes the watch
+     * page, which is the request Google shapes hardest, and a shaped response
+     * can hold this call open for the better part of a minute. Worth waiting
+     * out when the alternative is silence; not worth paying for every track.
+     */
+    private fun newPipeUrl(videoId: String): String {
+        val info = StreamInfo.getInfo(
+            ServiceList.YouTube,
+            "https://www.youtube.com/watch?v=$videoId",
+        )
+        val candidates = info.audioStreams
+            // Progressive only — DASH/HLS entries carry a manifest, not a URL.
+            .filter {
+                !it.content.isNullOrBlank() &&
+                    it.deliveryMethod == DeliveryMethod.PROGRESSIVE_HTTP
+            }
+        val stream = pickForQuality(candidates.map { it.averageBitrate to it })
+            ?: error("Track unavailable: no audio streams")
+        Log.d(TAG, "NewPipe picked ${stream.format?.name} @ ${stream.averageBitrate}kbps")
+        NerdStats.onStreamPicked(videoId, stream.averageBitrate)
+        return deobfuscate(videoId, stream.content)
+    }
+
+    // ---- Cache --------------------------------------------------------------
 
     /**
      * How many bytes the whole track is, or null if the URL doesn't say.
@@ -126,7 +496,9 @@ object StreamResolver {
     private class Resolved(val url: String, val at: Long)
 
     /**
-     * Stream URLs already resolved, by videoId.
+     * Stream URLs already resolved, by videoId — and, since [resolve] only ever
+     * stores one that has served bytes, already known good rather than merely
+     * recent.
      *
      * Google issues them with several hours of validity, so the ceiling here is
      * chosen for a different reason: a URL is tied to the playback session that
@@ -148,59 +520,5 @@ object StreamResolver {
             if (recent.size >= MAX_REMEMBERED) recent.clear()
         }
         recent[videoId] = Resolved(url, SystemClock.elapsedRealtime())
-    }
-
-    private suspend fun innertubeUrl(videoId: String): String {
-        val raw = Innertube.playerStreamUrl(videoId)
-            ?: error("no audio format for $videoId")
-        return deobfuscate(videoId, raw)
-    }
-
-    private fun newPipeUrl(videoId: String): String {
-        val info = StreamInfo.getInfo(
-            ServiceList.YouTube,
-            "https://www.youtube.com/watch?v=$videoId",
-        )
-        val candidates = info.audioStreams
-            // Progressive only — DASH/HLS entries carry a manifest, not a URL.
-            .filter {
-                !it.content.isNullOrBlank() &&
-                    it.deliveryMethod == DeliveryMethod.PROGRESSIVE_HTTP
-            }
-        val stream = pickForQuality(candidates.map { it.averageBitrate to it })
-            ?: error("Track unavailable: no audio streams")
-        Log.d(TAG, "NewPipe picked ${stream.format?.name} @ ${stream.averageBitrate}kbps")
-        // The container carries no bitrate field, so this is the only place the
-        // real figure for the chosen stream is ever known.
-        NerdStats.onStreamPicked(videoId, stream.averageBitrate)
-        return deobfuscate(videoId, stream.content)
-    }
-
-    /**
-     * Highest stream at or under the ceiling set for the connection in use; if
-     * everything is above it (e.g. Low on a track that only has 130kbps+), take
-     * the cheapest available rather than failing.
-     */
-    private fun <T> pickForQuality(candidates: List<Pair<Int, T>>): T? {
-        if (candidates.isEmpty()) return null
-        val ceiling = AppSettings.effectiveAudioQuality.maxKbps
-        val withinBudget = candidates.filter { it.first <= ceiling }
-        return (withinBudget.maxByOrNull { it.first } ?: candidates.minByOrNull { it.first })
-            ?.second
-    }
-
-    /**
-     * Transform the `n` parameter when present. If deobfuscation itself fails
-     * we still return the original URL — a throttled stream beats no stream.
-     */
-    private fun deobfuscate(videoId: String, url: String): String {
-        val needsWork = url.toHttpUrlOrNull()?.queryParameter("n")?.isNotBlank() == true
-        if (!needsWork) return url
-        return runCatching {
-            YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url)
-        }.getOrElse {
-            Log.w(TAG, "n-param deobfuscation failed: ${it.message}")
-            url
-        }
     }
 }

--- a/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
@@ -5,6 +5,9 @@ import android.util.Log
 import com.music.bitchord.data.Http
 import com.music.bitchord.data.NerdStats
 import com.music.bitchord.data.settings.AppSettings
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.NewPipe
@@ -27,10 +30,16 @@ import java.util.concurrent.ConcurrentHashMap
  * by running YouTube's own player JavaScript — which is what NewPipe's
  * [YoutubeJavaScriptPlayerManager] does (and caches per player version).
  *
- * Strategy, cheapest path first:
- *  1. Innertube IOS player response → direct unciphered URL → deobfuscate `n`.
- *  2. Fall back to NewPipe's full extractor, which re-derives everything
- *     itself and survives client-side changes on YouTube's end.
+ * Strategy, most reliable path first:
+ *  1. NewPipe's full extractor, which picks a client that still works, derives
+ *     the signature timestamp and solves `n` itself. Tried [NEWPIPE_ATTEMPTS]
+ *     times, because its failures are usually transient — a timeout, or the
+ *     loader thread being interrupted — rather than a real "can't play this".
+ *  2. Only then the hand-rolled Innertube IOS player response. Google has
+ *     since tightened that client, and the URLs it mints are frequently
+ *     rejected with **HTTP 403**, so it is a last resort and not a peer of the
+ *     path above. A 403 from it is recovered by [invalidate] + a re-resolve,
+ *     driven from PlaybackService's error handler.
  */
 object StreamResolver {
 
@@ -90,25 +99,74 @@ object StreamResolver {
      * Results are held briefly — see [recent]. Resolving is the slow part of
      * starting a track, and ExoPlayer asks again for every re-open: each seek
      * outside the buffer, and each range the cache fills in.
+     *
+     * Resolution for one videoId is serialised by [locks]. Without it the
+     * player's loader and [com.music.bitchord.playback.AudioCache]'s read-ahead
+     * race to resolve the same track at the same moment, tripling the work —
+     * each extraction is several round trips plus running YouTube's player
+     * JavaScript — and making the timeouts that push us onto the failing
+     * fallback far more likely. The second caller through the gate finds the
+     * first one's result already in [recent] and pays nothing.
      */
     suspend fun resolve(videoId: String): String {
         init
 
-        recent[videoId]
-            ?.takeIf { SystemClock.elapsedRealtime() - it.at < URL_TTL_MS }
-            ?.let { return it.url }
+        cached(videoId)?.let { return it }
 
-        val url = runCatching { newPipeUrl(videoId) }
-            .onFailure { Log.w(TAG, "NewPipe resolve failed for $videoId: ${it.message}") }
-            .getOrNull()
-            ?.also { Log.d(TAG, "resolved via NewPipe") }
-            ?: run {
-                Log.d(TAG, "falling back to Innertube IOS client for $videoId")
-                innertubeUrl(videoId)
+        val lock = locks.computeIfAbsent(videoId) { Mutex() }
+        return lock.withLock {
+            // Whoever held the lock has very likely just resolved this.
+            cached(videoId) ?: extract(videoId).also { remember(videoId, it) }
+        }
+    }
+
+    /** The remembered URL for [videoId], if one is still inside its TTL. */
+    private fun cached(videoId: String): String? = recent[videoId]
+        ?.takeIf { SystemClock.elapsedRealtime() - it.at < URL_TTL_MS }
+        ?.url
+
+    /**
+     * Drops the remembered URL for [videoId], so the next [resolve] goes back
+     * out and mints a fresh one.
+     *
+     * Needed because a URL is remembered as soon as it is produced, before
+     * anything has tried to fetch it. When one turns out to be dead — a 403
+     * off the IOS fallback — the entry would otherwise keep being served from
+     * [recent] for the whole TTL, and every retry would fail identically
+     * without a single request leaving the device.
+     */
+    fun invalidate(videoId: String) {
+        recent.remove(videoId)
+    }
+
+    /**
+     * NewPipe first and repeatedly, then the IOS fallback.
+     *
+     * Cancellation is rethrown rather than retried: when ExoPlayer abandons a
+     * load it interrupts the thread this runs on, and there is nothing left to
+     * resolve for.
+     */
+    private suspend fun extract(videoId: String): String {
+        repeat(NEWPIPE_ATTEMPTS) { attempt ->
+            try {
+                return newPipeUrl(videoId).also { Log.d(TAG, "resolved via NewPipe") }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: InterruptedException) {
+                // The interrupt flag is still set; anything further fails
+                // instantly, so stop rather than burn the remaining attempts.
+                Thread.currentThread().interrupt()
+                throw e
+            } catch (e: Exception) {
+                Log.w(
+                    TAG,
+                    "NewPipe resolve failed for $videoId " +
+                        "(attempt ${attempt + 1}/$NEWPIPE_ATTEMPTS): ${e.message}",
+                )
             }
-
-        remember(videoId, url)
-        return url
+        }
+        Log.w(TAG, "falling back to Innertube IOS client for $videoId — expect 403s")
+        return innertubeUrl(videoId)
     }
 
     /**
@@ -136,10 +194,23 @@ object StreamResolver {
      */
     private val recent = ConcurrentHashMap<String, Resolved>()
 
+    /** One gate per videoId, so concurrent callers resolve it only once. */
+    private val locks = ConcurrentHashMap<String, Mutex>()
+
     private const val URL_TTL_MS = 20 * 60 * 1000L
 
     /** Enough for the queue in hand; this is a latency cache, not a store. */
     private const val MAX_REMEMBERED = 32
+
+    /**
+     * How many times NewPipe is asked before the IOS fallback.
+     *
+     * Its failures in practice are `timeout` and `interrupted` — transient, and
+     * a second ask usually succeeds. Since the fallback is the thing that
+     * returns 403s, spending another few seconds here is strictly better than
+     * reaching it.
+     */
+    private const val NEWPIPE_ATTEMPTS = 3
 
     private fun remember(videoId: String, url: String) {
         if (recent.size >= MAX_REMEMBERED) {
@@ -148,6 +219,11 @@ object StreamResolver {
             if (recent.size >= MAX_REMEMBERED) recent.clear()
         }
         recent[videoId] = Resolved(url, SystemClock.elapsedRealtime())
+        // The gates outlive the entries they guarded, so they are trimmed on
+        // the same schedule rather than growing for the life of the process.
+        if (locks.size > MAX_REMEMBERED) {
+            locks.keys.removeAll { !recent.containsKey(it) && locks[it]?.isLocked != true }
+        }
     }
 
     private suspend fun innertubeUrl(videoId: String): String {

--- a/app/src/main/java/com/music/bitchord/data/model/Models.kt
+++ b/app/src/main/java/com/music/bitchord/data/model/Models.kt
@@ -25,14 +25,42 @@ data class Song(
 /**
  * Artwork at a given pixel size.
  *
- * YouTube serves every size from one URL via a `w<n>-h<n>` hint, and the size
- * it advertises — 544px — is far short of what a full-screen player draws, so
- * the artwork arrives upscaled and soft. Asking for more is free; the source
- * images run to about 1400px. Video thumbnails carry no hint and are returned
- * unchanged.
+ * YouTube serves every size from one URL via a `w<n>-h<n>` hint, so the size
+ * an image is fetched at is the caller's to choose, and worth choosing in both
+ * directions. Up: the size YouTube advertises is far short of what a
+ * full-screen player draws, and the source images run to about 1400px, so
+ * asking for more is free and sharper. Down: a row thumbnail left at the
+ * advertised size costs an order of magnitude more bytes than the square it
+ * fills — 84kB against 7.8kB, measured on the same cover.
+ *
+ * Video thumbnails carry no hint and are returned unchanged.
  */
-fun Song.artworkAt(px: Int): String? =
-    thumbnailUrl?.replace(Regex("""w\d+-h\d+"""), "w$px-h$px")
+fun Song.artworkAt(px: Int): String? = thumbnailUrl.artworkAt(px)
+
+/** As [Song.artworkAt], for artwork that isn't a track's. */
+fun String?.artworkAt(px: Int): String? = this?.replace(SIZE_HINT, "w$px-h$px")
+
+private val SIZE_HINT = Regex("""w\d+-h\d+""")
+
+/**
+ * Artwork for a list row — 52dp at most, so about 140px on a 3x screen.
+ * Rounded up, and one value for every row in the app rather than one per
+ * row height, so they share a cache entry instead of each fetching its own.
+ */
+const val ROW_ART_PX = 160
+
+/** Artwork for a shelf card: 166dp wide, so a little under 450px at 3x. */
+const val CARD_ART_PX = 480
+
+/** Artwork for a page header, drawn near enough full width. */
+const val HEADER_ART_PX = 720
+
+/**
+ * Artwork handed to the media session — the lock screen, the notification,
+ * Android Auto. Generous because those surfaces draw it large and take one
+ * copy: unlike a list row, nothing goes back for a better one later.
+ */
+const val NOTIFICATION_ART_PX = 544
 
 enum class BrowseType { ALBUM, ARTIST, PLAYLIST, OTHER }
 

--- a/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
@@ -58,6 +58,10 @@ object AppSettings {
      * a stereo widening + cross-feed effect running inside ExoPlayer's own
      * pipeline. Not true object-based spatial audio — YouTube only ever hands
      * us a stereo stream, so there's no Atmos-style source to render.
+     *
+     * The user's wish, not the final answer: it only takes effect on a device
+     * with Dolby Atmos switched on, and [com.music.bitchord.playback.DolbyAtmos]
+     * clears it back to false the moment that stops being true.
      */
     val spatialAudio = MutableStateFlow(false)
     val playbackSpeed = MutableStateFlow(1.0f)

--- a/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
@@ -69,6 +69,12 @@ object AppSettings {
     /** Put the playing track's codec, bitrate and sample rate on the player. */
     val showNerdStats = MutableStateFlow(false)
 
+    /** Freezes the main player's mesh gradient instead of letting it drift/crossfade. */
+    val reduceAnimation = MutableStateFlow(false)
+
+    /** Drops haze blur (status bar, mini player, bottom fade, lyrics focus) for a solid-fill look. */
+    val reduceDynamicBlur = MutableStateFlow(false)
+
     /** Disk budget for cached audio. [AudioCache][com.music.bitchord.playback.AudioCache] evicts past it. */
     val audioCacheLimitBytes = MutableStateFlow(DEFAULT_CACHE_LIMIT_BYTES)
 
@@ -97,6 +103,8 @@ object AppSettings {
         }.getOrDefault(ThemeMode.SYSTEM)
         autoplay.value = prefs.getBoolean(KEY_AUTOPLAY, true)
         showNerdStats.value = prefs.getBoolean(KEY_NERD_STATS, false)
+        reduceAnimation.value = prefs.getBoolean(KEY_REDUCE_ANIMATION, false)
+        reduceDynamicBlur.value = prefs.getBoolean(KEY_REDUCE_BLUR, false)
         audioCacheLimitBytes.value = prefs.getLong(KEY_CACHE_LIMIT, DEFAULT_CACHE_LIMIT_BYTES)
             .coerceIn(DEFAULT_CACHE_LIMIT_BYTES, MAX_CACHE_LIMIT_BYTES)
         watchConnection(context)
@@ -194,6 +202,16 @@ object AppSettings {
         prefs.edit().putString(KEY_THEME, value.name).apply()
     }
 
+    fun setReduceAnimation(value: Boolean) {
+        reduceAnimation.value = value
+        prefs.edit().putBoolean(KEY_REDUCE_ANIMATION, value).apply()
+    }
+
+    fun setReduceDynamicBlur(value: Boolean) {
+        reduceDynamicBlur.value = value
+        prefs.edit().putBoolean(KEY_REDUCE_BLUR, value).apply()
+    }
+
     /** Clamped to [DEFAULT_CACHE_LIMIT_BYTES]..[MAX_CACHE_LIMIT_BYTES] — the floor is the default, not zero. */
     fun setAudioCacheLimitBytes(value: Long) {
         val clamped = value.coerceIn(DEFAULT_CACHE_LIMIT_BYTES, MAX_CACHE_LIMIT_BYTES)
@@ -215,4 +233,6 @@ object AppSettings {
     private const val KEY_AUTOPLAY = "autoplay"
     private const val KEY_NERD_STATS = "show_nerd_stats"
     private const val KEY_CACHE_LIMIT = "audio_cache_limit_bytes"
+    private const val KEY_REDUCE_ANIMATION = "reduce_animation"
+    private const val KEY_REDUCE_BLUR = "reduce_dynamic_blur"
 }

--- a/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
@@ -52,6 +52,14 @@ object AppSettings {
 
     val crossfadeSeconds = MutableStateFlow(0)
     val skipSilence = MutableStateFlow(false)
+
+    /**
+     * Widens stereo output via [com.music.bitchord.playback.SpatialAudioProcessor],
+     * a stereo widening + cross-feed effect running inside ExoPlayer's own
+     * pipeline. Not true object-based spatial audio — YouTube only ever hands
+     * us a stereo stream, so there's no Atmos-style source to render.
+     */
+    val spatialAudio = MutableStateFlow(false)
     val playbackSpeed = MutableStateFlow(1.0f)
     val themeMode = MutableStateFlow(ThemeMode.SYSTEM)
 
@@ -82,6 +90,7 @@ object AppSettings {
         audioQualityCellular.value = readQuality(KEY_QUALITY_CELLULAR)
         crossfadeSeconds.value = prefs.getInt(KEY_CROSSFADE, 0)
         skipSilence.value = prefs.getBoolean(KEY_SKIP_SILENCE, false)
+        spatialAudio.value = prefs.getBoolean(KEY_SPATIAL_AUDIO, false)
         playbackSpeed.value = prefs.getFloat(KEY_SPEED, 1.0f)
         themeMode.value = runCatching {
             ThemeMode.valueOf(prefs.getString(KEY_THEME, null) ?: "SYSTEM")
@@ -165,6 +174,11 @@ object AppSettings {
         prefs.edit().putBoolean(KEY_SKIP_SILENCE, value).apply()
     }
 
+    fun setSpatialAudio(value: Boolean) {
+        spatialAudio.value = value
+        prefs.edit().putBoolean(KEY_SPATIAL_AUDIO, value).apply()
+    }
+
     fun setPlaybackSpeed(value: Float) {
         playbackSpeed.value = value
         prefs.edit().putFloat(KEY_SPEED, value).apply()
@@ -195,6 +209,7 @@ object AppSettings {
     private const val KEY_QUALITY_CELLULAR = "audio_quality_cellular"
     private const val KEY_CROSSFADE = "crossfade_seconds"
     private const val KEY_SKIP_SILENCE = "skip_silence"
+    private const val KEY_SPATIAL_AUDIO = "spatial_audio"
     private const val KEY_SPEED = "playback_speed"
     private const val KEY_THEME = "theme_mode"
     private const val KEY_AUTOPLAY = "autoplay"

--- a/app/src/main/java/com/music/bitchord/playback/ChunkedDataSource.kt
+++ b/app/src/main/java/com/music/bitchord/playback/ChunkedDataSource.kt
@@ -1,0 +1,166 @@
+package com.music.bitchord.playback
+
+import android.net.Uri
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+import java.io.InterruptedIOException
+
+/**
+ * Fetches a stream as a run of bounded ranges instead of one open-ended read.
+ *
+ * googlevideo paces a continuous response down to roughly playback speed:
+ * ask for a whole track in one request and it arrives at about 15kB/s, barely
+ * ahead of the rate it is being consumed at. Ask for the same bytes as bounded
+ * ranges and each one is served at line rate — measured on the same track,
+ * over the same connection, seconds apart:
+ *
+ * ```
+ *   GET (unbounded)               15.5 kB/s
+ *   Range: bytes=0-2097151         5.7 MB/s
+ * ```
+ *
+ * That is the difference between a player that can build a buffer and one that
+ * can only just keep up, and it is why a stall never recovers into a cushion:
+ * there is no spare bandwidth to catch up with.
+ *
+ * [AudioCache] already fetches this way — it is why read-ahead can put a whole
+ * track on disk in the time between songs. This puts the player's own reads on
+ * the same footing, which matters for the track being listened to right now:
+ * read-ahead deliberately never touches it (Media3 locks a cache entry to one
+ * writer), so without this it is the one track that always streams throttled.
+ *
+ * Transparent to everything above it. [CacheDataSource][androidx.media3.datasource.cache.CacheDataSource]
+ * sees one continuous stream of the length it asked for, and a request that is
+ * already bounded — every read-ahead fetch — is passed straight through
+ * untouched rather than chunked twice.
+ */
+@UnstableApi
+class ChunkedDataSource(
+    private val upstream: DataSource,
+    private val chunkBytes: Long,
+) : DataSource {
+
+    private var baseSpec: DataSpec? = null
+    private var position = 0L
+    private var bytesRemaining = 0L
+    private var chunkRemaining = 0L
+    private var chunkOpen = false
+
+    /** Set when the request can't be improved on, and is simply forwarded. */
+    private var passthrough = false
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        upstream.addTransferListener(transferListener)
+    }
+
+    /**
+     * The total size has to be known up front, or there is no way to say where
+     * the last range ends. Every progressive googlevideo URL carries it as
+     * `clen`, which costs nothing to read; anything else is forwarded as-is.
+     */
+    override fun open(dataSpec: DataSpec): Long {
+        baseSpec = dataSpec
+        position = dataSpec.position
+
+        val total = dataSpec.uri.getQueryParameter("clen")?.toLongOrNull()
+        if (dataSpec.length != C.LENGTH_UNSET.toLong() || total == null) {
+            passthrough = true
+            chunkOpen = true
+            return upstream.open(dataSpec)
+        }
+
+        passthrough = false
+        bytesRemaining = (total - position).coerceAtLeast(0L)
+        if (bytesRemaining > 0) openChunk()
+        return bytesRemaining
+    }
+
+    private fun openChunk() {
+        val length = minOf(chunkBytes, bytesRemaining)
+        val spec = requireNotNull(baseSpec).buildUpon()
+            .setPosition(position)
+            .setLength(length)
+            .build()
+        try {
+            upstream.open(spec)
+        } catch (e: Exception) {
+            // Which client minted the URL is the first thing worth knowing when
+            // a range is refused, and it isn't recoverable from anywhere else by
+            // the time this surfaces as a playback error. A cancelled read-ahead
+            // arrives here too and means nothing — see [AudioCache.prefetchNext].
+            if (e !is InterruptedIOException) {
+                Log.w(
+                    TAG,
+                    "range $position-${position + length - 1} refused for " +
+                        "${spec.uri.getQueryParameter("c")}: ${e.message}",
+                )
+            }
+            throw e
+        }
+        chunkRemaining = length
+        chunkOpen = true
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        if (passthrough) return upstream.read(buffer, offset, length)
+        if (bytesRemaining == 0L) return C.RESULT_END_OF_INPUT
+
+        // A range that ends early is re-opened for the part that didn't
+        // arrive, which is also how the step to the next range happens. The
+        // attempt limit is what stops a server that has decided to send
+        // nothing from spinning here forever.
+        repeat(MAX_EMPTY_RANGES) {
+            if (chunkRemaining == 0L) {
+                closeChunk()
+                openChunk()
+            }
+            val read = upstream.read(buffer, offset, minOf(length.toLong(), chunkRemaining).toInt())
+            if (read != C.RESULT_END_OF_INPUT) {
+                position += read
+                chunkRemaining -= read
+                bytesRemaining -= read
+                return read
+            }
+            chunkRemaining = 0L
+        }
+        return C.RESULT_END_OF_INPUT
+    }
+
+    private fun closeChunk() {
+        if (chunkOpen) {
+            upstream.close()
+            chunkOpen = false
+        }
+    }
+
+    override fun getUri(): Uri? = upstream.uri ?: baseSpec?.uri
+
+    override fun getResponseHeaders(): Map<String, List<String>> = upstream.responseHeaders
+
+    override fun close() {
+        closeChunk()
+        baseSpec = null
+        bytesRemaining = 0L
+        chunkRemaining = 0L
+    }
+
+    private companion object {
+        const val TAG = "BitChord"
+
+        /** Enough to ride out a truncated range, not enough to hang on a dead one. */
+        const val MAX_EMPTY_RANGES = 3
+    }
+
+    /** Wraps [upstream]'s sources so everything opened through it is ranged. */
+    class Factory(
+        private val upstream: DataSource.Factory,
+        private val chunkBytes: Long,
+    ) : DataSource.Factory {
+        override fun createDataSource(): DataSource =
+            ChunkedDataSource(upstream.createDataSource(), chunkBytes)
+    }
+}

--- a/app/src/main/java/com/music/bitchord/playback/CrossfadeController.kt
+++ b/app/src/main/java/com/music/bitchord/playback/CrossfadeController.kt
@@ -1,7 +1,9 @@
 package com.music.bitchord.playback
 
+import android.os.SystemClock
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -10,68 +12,196 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.math.PI
 import kotlin.math.abs
-import kotlin.math.sqrt
+import kotlin.math.cos
+import kotlin.math.sin
 
 /**
- * Crossfade driven by volume automation on the *single* ExoPlayer that owns the
- * queue.
+ * A real crossfade: two tracks audible at once, the outgoing one falling as the
+ * incoming one rises, the way Spotify and Apple Music do it.
  *
- * The previous two-player design overlapped tracks for real, but the second
- * player had its own copy of the queue and kept playing whenever the user
- * touched the first one mid-fade — two tracks at once. Anything that fixes that
- * ends up re-synchronising two queues, two audio-focus requests and a
- * MediaSession that keeps changing which player it points at.
+ * ## Why there are two players
  *
- * So there is one player, it is always the session player, and it is always the
- * only thing making sound. The fade is expressed as a *pure function of the
- * current playback position* ([targetGain]) that a ticker applies to
- * [ExoPlayer.volume]:
+ * One ExoPlayer renders one queue item at a time, so at a track boundary there
+ * is exactly one source and the gain it can be given is either 1 (no fade) or 0
+ * (silence). The previous version of this class was a single-player volume
+ * ramp, and that is precisely why it never sounded like a crossfade: it dipped
+ * to silence at the join and climbed back out, leaving a hole where the blend
+ * should be. Overlap needs a second decoder. There is no way around it.
  *
- * - the last `crossfade/2` seconds of a track ramp down to silence
- * - the first `crossfade/2` seconds of the track the queue advanced to ramp up
+ * ## Which player plays what
  *
- * Because gain is recomputed from position rather than tracked in a state
- * machine, there is nothing to unwind: skip, scrub, reorder the queue or switch
- * crossfade off mid-ramp and the very next tick already computes the right
- * volume for wherever playback actually is. The transition still spans the
- * configured number of seconds — it is a butt-joint of two fades rather than an
- * overlap, so tracks no longer literally play over each other.
+ * The naive second player is a copy of the queue, and that is the design that
+ * fell over before — two players both convinced they own the playlist, two
+ * audio focus requests, and a MediaSession whose player keeps changing under
+ * it. So the split here is deliberately lopsided:
+ *
+ *  - **[player]** — the one ExoPlayer that owns the queue, backs the
+ *    MediaSession and holds audio focus, exactly as it did before this class
+ *    existed. It is the only player the rest of the app ever sees.
+ *  - **[ghost]** — a single-item, throwaway player that renders *the tail of
+ *    the track being left behind* and nothing else. It has no queue, receives
+ *    no user commands, is nobody's source of truth, and can be stopped dead at
+ *    any instant without anything needing to be unwound.
+ *
+ * At the crossfade point the session player **jumps to the next track
+ * immediately** and fades up, while the ghost carries the old track's last
+ * seconds down to silence. That ordering is the point: the queue index, the
+ * metadata, the notification and the UI all flip to the incoming song the
+ * moment it becomes audible, instead of trailing the song that is on its way
+ * out.
+ *
+ * ## The handoff
+ *
+ * The one seam in this design is the instant the outgoing track stops being
+ * rendered by [player] and starts being rendered by [ghost]. Two ExoPlayers
+ * cannot be started sample-accurately against each other, so the ghost is
+ * armed early, left free-running *silently* alongside the session player, and
+ * nudged with repeated seeks until the two agree on position to within
+ * [SYNC_TOLERANCE_MS]. Those corrections are free: nobody can hear a muted
+ * player being seeked. Only once they are aligned does the [Phase.LAPPING]
+ * step hand the outgoing track over, equal-power, across [LAP_MS] — short
+ * enough that whatever misalignment is left reads as texture rather than as a
+ * click.
+ *
+ * ## Curve
+ *
+ * `sin`/`cos` rather than the old `sqrt`: `sin²+cos²=1` exactly, so two tracks
+ * fading past each other hold constant *power* the whole way through and the
+ * transition has no dip in the middle. That is the standard crossfade law, and
+ * it is what makes a long crossfade sound like a blend instead of a dip.
  */
 @UnstableApi
 class CrossfadeController(
     private val scope: CoroutineScope,
     private val player: ExoPlayer,
+    /** Builds the tail player. Called at most once; the instance is kept warm. */
+    private val newGhost: () -> ExoPlayer,
 ) {
 
+    private enum class Phase {
+        /** Nothing in flight; watching for the next transition. */
+        IDLE,
+
+        /** Ghost is spinning up on the outgoing track and syncing to the session player. */
+        ARMING,
+
+        /** Outgoing track being handed from the session player to the ghost. */
+        LAPPING,
+
+        /** Session player rising on the new track, ghost falling on the old one. */
+        FADING,
+
+        /** Something interrupted the fade; the ghost is being ramped out of the way. */
+        BAILING,
+    }
+
+    private var phase = Phase.IDLE
+    private var ghost: ExoPlayer? = null
+
+    /** Length of the transition in flight, in ms. Fixed when it begins. */
+    private var fadeMs = 0L
+
+    /** Only for auto transitions: hold the lap until the track is really this close to ending. */
+    private var lapWhenRemainingMs = Long.MAX_VALUE
+
+    private var lapStartedAt = 0L
+    private var bailStartedAt = 0L
+    private var armDeadline = 0L
+
     /**
-     * Whether the current item was reached by the queue advancing on its own.
-     * A track the user picked should start at full volume immediately —
-     * fading in after a deliberate tap on "next" just reads as broken audio.
+     * Gain the ghost was at when the fade was interrupted. The ramp out is
+     * scaled by it, because a fade abandoned during [Phase.ARMING] is one where
+     * the ghost is still silent — ramping "down from 1" there would put the
+     * outgoing track on at full volume purely in order to fade it out again.
      */
-    private var fadeInArmed = false
+    private var bailFromGain = 0f
+
+    /** Last time the ghost was nudged, so corrections get a chance to settle. */
+    private var lastSyncAt = 0L
+
+    /**
+     * How far ahead of the session player the ghost is seeked, to cover the time
+     * a seek itself takes to come back. Learned rather than assumed — it varies
+     * with the device and with whether the track is on disk yet.
+     */
+    private var seekLeadMs = 60L
+
+    /**
+     * How long our own `seekToNextMediaItem` gets to be recognised as ours, so
+     * the lap isn't mistaken for the listener reaching for the scrubber.
+     *
+     * A window rather than a count of expected callbacks: Media3 reports the
+     * queue moving as both a discontinuity and an item transition, a seek that
+     * turns out to be a no-op reports neither, and a counter that guesses wrong
+     * either swallows the listener's next seek or bails on our own. A window
+     * clears itself however many callbacks turn up.
+     */
+    private var selfMoveUntil = 0L
+
+    /**
+     * Whether the transition now arriving is this class advancing the queue on
+     * the listener's behalf — the crossfade equivalent of a track ending.
+     * Consumed by [PlaybackService], which otherwise has no way to tell our
+     * seek apart from a manual skip and would stop honouring "sleep after this
+     * song".
+     */
+    private var autoAdvance = false
+
+    fun consumeAutoAdvance(): Boolean = autoAdvance.also { autoAdvance = false }
+
+    /**
+     * Whether a press of "next" is currently being held back waiting for the
+     * ghost. [interceptSkipToNext] tells the session player the skip is in hand,
+     * so if the blend then falls through it still has to happen — otherwise the
+     * button quietly does nothing at all.
+     */
+    private var owedSkip = false
 
     private val listener = object : Player.Listener {
-        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-            fadeInArmed = reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO
-        }
-
         override fun onPositionDiscontinuity(
             oldPosition: Player.PositionInfo,
             newPosition: Player.PositionInfo,
             reason: Int,
         ) {
-            // Scrubbing back into the opening seconds shouldn't replay the fade-in.
-            if (reason == Player.DISCONTINUITY_REASON_SEEK) fadeInArmed = false
+            // The listener moving the playhead is something no half-finished
+            // crossfade should survive; the lap's own seek is not.
+            if (reason == Player.DISCONTINUITY_REASON_SEEK && !ourOwnMove()) bail()
         }
+
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            when (reason) {
+                // Something replaced the queue out from under the fade — a new
+                // album, a new search result — so the tail still playing is a
+                // leftover of a session that no longer exists. Note that this
+                // does *not* fire when AutoPlay appends to the end, since the
+                // playing item doesn't change: extending the queue mid-fade is
+                // harmless and shouldn't cost the listener the blend.
+                Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED -> bail()
+                Player.MEDIA_ITEM_TRANSITION_REASON_SEEK -> if (!ourOwnMove()) bail()
+            }
+        }
+
+        override fun onPlayerError(error: PlaybackException) = bail()
     }
+
+    private fun ourOwnMove(): Boolean = SystemClock.elapsedRealtime() < selfMoveUntil
 
     fun start() {
         player.addListener(listener)
         scope.launch {
             while (isActive) {
-                val ramping = applyGain()
-                delay(if (ramping) RAMP_STEP_MS else IDLE_STEP_MS)
+                tick()
+                delay(
+                    when (phase) {
+                        Phase.IDLE -> IDLE_STEP_MS
+                        Phase.ARMING -> ARM_STEP_MS
+                        Phase.LAPPING -> LAP_STEP_MS
+                        Phase.FADING -> FADE_STEP_MS
+                        Phase.BAILING -> BAIL_STEP_MS
+                    },
+                )
             }
         }
     }
@@ -79,57 +209,359 @@ class CrossfadeController(
     fun release() {
         player.removeListener(listener)
         player.volume = 1f
+        ghost?.release()
+        ghost = null
     }
 
-    /** @return true while a ramp is in progress, so the ticker can speed up. */
-    private fun applyGain(): Boolean {
-        val gain = targetGain()
-        if (abs(player.volume - gain) > VOLUME_EPSILON) player.volume = gain
-        return gain < 1f
-    }
+    // ---- Entry points -------------------------------------------------------
 
-    private fun targetGain(): Float {
-        val fadeMs = AppSettings.crossfadeSeconds.value * 1000L
-        if (fadeMs <= 0L) return 1f
-        // Repeating one track would crossfade it into itself — just loop it.
-        if (player.repeatMode == Player.REPEAT_MODE_ONE) return 1f
-        if (player.mediaItemCount == 0) return 1f
-        if (player.playbackState == Player.STATE_IDLE) return 1f
+    /**
+     * Takes over a skip so it crossfades instead of cutting.
+     *
+     * Pressing "next" is how anyone actually tests this setting, and the old
+     * implementation deliberately did nothing on a manual skip — which is most
+     * of why it read as broken. Both Spotify and Apple Music blend a manual
+     * skip, so this does too.
+     *
+     * @return true when the crossfade has the skip in hand and the caller
+     *   should not also move the queue itself.
+     */
+    fun interceptSkipToNext(): Boolean {
+        // A second press during a fade means "get on with it": drop the blend
+        // and let the plain skip through.
+        if (phase != Phase.IDLE) {
+            bail()
+            return false
+        }
+        if (configuredFadeMs() <= 0L) return false
+        if (player.playbackState == Player.STATE_IDLE) return false
+        // Skipping while paused should land on the next track, not start a
+        // fade nobody is listening to.
+        if (!player.playWhenReady) return false
+        if (!player.hasNextMediaItem()) return false
 
-        val position = player.currentPosition
         val duration = player.duration
-        val hasDuration = duration != C.TIME_UNSET && duration > 0L
+        val remaining = if (duration == C.TIME_UNSET) Long.MAX_VALUE else duration - player.currentPosition
+        // Skipping into the last moment of a track has nothing left to fade out.
+        if (remaining < MIN_TAIL_MS) return false
 
-        // Half in, half out, so the whole transition still lasts the configured
-        // number of seconds. On a track shorter than the fade the two ramps
-        // would otherwise overlap into a deep dip, so clamp to half its length.
-        val rampMs = if (hasDuration) minOf(fadeMs / 2, duration / 2) else fadeMs / 2
-        if (rampMs <= 0L) return 1f
+        return begin(fade = fadeFor(duration), manual = true)
+    }
 
-        var gain = 1f
+    // ---- Ticker -------------------------------------------------------------
 
-        if (fadeInArmed && position < rampMs) {
-            gain *= curve(position.coerceAtLeast(0L).toFloat() / rampMs)
+    private fun tick() {
+        // A pause has to take the tail with it, or the track being faded out
+        // carries on alone over a stopped player. Mirrored every tick rather
+        // than handled as an event, so audio focus loss, the sleep timer and
+        // the pause button all get the same treatment for free.
+        if (phase == Phase.ARMING || phase == Phase.LAPPING || phase == Phase.FADING) {
+            ghost?.playWhenReady = player.playWhenReady
         }
 
-        // Nothing to fade into at the end of the queue — let the track finish.
-        if (hasDuration && player.hasNextMediaItem()) {
-            val remaining = duration - position
-            if (remaining < rampMs) {
-                gain *= curve(remaining.coerceAtLeast(0L).toFloat() / rampMs)
+        when (phase) {
+            Phase.IDLE -> considerAutoTransition()
+            Phase.ARMING -> driveArming()
+            Phase.LAPPING -> driveLap()
+            Phase.FADING -> driveFade()
+            Phase.BAILING -> driveBail()
+        }
+    }
+
+    /** Arms a crossfade as the playing track runs out. */
+    private fun considerAutoTransition() {
+        if (configuredFadeMs() <= 0L) return
+        if (!player.isPlaying) return
+        // Repeating one track would crossfade it into itself.
+        if (player.repeatMode == Player.REPEAT_MODE_ONE) return
+        if (!player.hasNextMediaItem()) return
+
+        val duration = player.duration
+        if (duration == C.TIME_UNSET || duration <= 0L) return
+
+        val fade = fadeFor(duration)
+        if (fade <= 0L) return
+
+        val remaining = duration - player.currentPosition
+        // Arm early: the ghost needs time to spin up and settle into sync
+        // before it is any use, and that work has to be finished by the time
+        // the fade is due rather than started then.
+        if (remaining > fade + ARM_LEAD_MS) return
+
+        lapWhenRemainingMs = fade
+        begin(fade, manual = false)
+    }
+
+    /**
+     * Spins the ghost up on the outgoing track and walks it into sync with the
+     * session player.
+     */
+    private fun begin(fade: Long, manual: Boolean): Boolean {
+        val outgoing = player.currentMediaItem ?: return false
+        val ghost = warmGhost() ?: return false
+
+        fadeMs = fade
+        armDeadline = SystemClock.elapsedRealtime() +
+            if (manual) MANUAL_ARM_TIMEOUT_MS else AUTO_ARM_TIMEOUT_MS
+        lastSyncAt = 0L
+        owedSkip = manual
+        if (manual) lapWhenRemainingMs = Long.MAX_VALUE
+
+        // Taken from the session player rather than from settings: these two
+        // change how fast a position advances against the wall clock, and the
+        // whole handoff rests on the pair agreeing about where they are.
+        ghost.skipSilenceEnabled = player.skipSilenceEnabled
+        ghost.playbackParameters = player.playbackParameters
+
+        ghost.setMediaItem(outgoing)
+        ghost.seekTo(player.currentPosition + seekLeadMs)
+        ghost.volume = 0f
+        ghost.playWhenReady = true
+        ghost.prepare()
+
+        phase = Phase.ARMING
+        return true
+    }
+
+    private fun driveArming() {
+        val ghost = ghost ?: return giveUp()
+        if (!stillWorthFading()) return giveUp()
+
+        val expired = SystemClock.elapsedRealtime() > armDeadline
+        val running = ghost.isPlaying
+
+        // A ghost that never got going has no tail to hand the track to, and
+        // lapping onto silence would be the very hole this class exists to get
+        // rid of. Give up instead and let the track change plainly.
+        if (expired && !running) return giveUp()
+        val drift = ghost.currentPosition - player.currentPosition
+        val aligned = running && abs(drift) <= SYNC_TOLERANCE_MS
+
+        if (running && !aligned) {
+            val now = SystemClock.elapsedRealtime()
+            if (now - lastSyncAt >= SYNC_SETTLE_MS) {
+                lastSyncAt = now
+                // Whatever the last seek overshot or undershot by is exactly
+                // what the next one should compensate for, so the lead tunes
+                // itself to this device rather than to a guessed constant.
+                seekLeadMs = (seekLeadMs - drift).coerceIn(0L, MAX_SEEK_LEAD_MS)
+                ghost.seekTo(player.currentPosition + seekLeadMs)
             }
         }
 
-        return gain.coerceIn(0f, 1f)
+        // Auto transitions wait for the track to actually reach the fade point;
+        // a manual skip is due the moment the ghost can carry the tail.
+        val duration = player.duration
+        val atFadePoint = duration == C.TIME_UNSET ||
+            duration - player.currentPosition <= lapWhenRemainingMs
+
+        if (!atFadePoint) return
+        // Out of time to keep tidying up: a slightly ragged handoff still beats
+        // no crossfade at all.
+        if (aligned || expired) startLap()
     }
 
-    /** Equal-power curve: -3dB at the midpoint, so the ramp reads as even. */
-    private fun curve(progress: Float): Float = sqrt(progress.coerceIn(0f, 1f))
+    private fun startLap() {
+        if (ghost == null) return giveUp()
+        lapStartedAt = SystemClock.elapsedRealtime()
+        phase = Phase.LAPPING
+    }
+
+    /**
+     * Hands the outgoing track from the session player to the ghost.
+     *
+     * Both are rendering the same audio at the same position here, so this is
+     * kept as short as it can be while still being a ramp rather than a cut —
+     * long enough to swallow any residual misalignment, too short for the two
+     * copies to comb against each other audibly.
+     */
+    private fun driveLap() {
+        val ghost = ghost ?: return giveUp()
+        // Pausing in the ninety milliseconds it takes to hand the track over
+        // means nothing has been handed over yet: the session player still has
+        // the track, so give it back rather than advancing a queue the listener
+        // has just stopped.
+        if (!player.playWhenReady) return giveUp()
+
+        val progress = (SystemClock.elapsedRealtime() - lapStartedAt).toFloat() / LAP_MS
+
+        if (progress < 1f) {
+            player.volume = fallGain(progress)
+            ghost.volume = riseGain(progress)
+            return
+        }
+
+        ghost.volume = 1f
+        player.volume = 0f
+        // The ghost has the old track. The session player is free to become the
+        // new one — and everything hanging off it (queue index, metadata, the
+        // notification, the UI) moves to the incoming song right here, while
+        // its first note is still fading up.
+        autoAdvance = lapWhenRemainingMs != Long.MAX_VALUE
+        owedSkip = false
+        selfMoveUntil = SystemClock.elapsedRealtime() + SELF_MOVE_WINDOW_MS
+        player.seekToNextMediaItem()
+        phase = Phase.FADING
+    }
+
+    /**
+     * The crossfade proper.
+     *
+     * Driven off the *incoming* track's position rather than off a clock, so a
+     * pause parks the transition where it stands and resuming picks it back up
+     * — no timer to reconcile, and no ghost left hanging at half volume while
+     * the session player waits.
+     */
+    private fun driveFade() {
+        val ghost = ghost ?: return bail()
+        // The incoming track gets the same say over the length as the outgoing
+        // one did, so a long crossfade into a short track tightens rather than
+        // swallowing it. Its duration is often still unknown when the fade
+        // starts — the stream is only being opened — so this is read every tick
+        // and simply narrows the span once the answer arrives.
+        val span = (minOf(fadeMs, fadeFor(player.duration)) - LAP_MS).coerceAtLeast(1L)
+        val progress = (player.currentPosition.coerceAtLeast(0L).toFloat() / span).coerceIn(0f, 1f)
+
+        player.volume = riseGain(progress)
+        ghost.volume = fallGain(progress)
+
+        // Whichever comes first: the fade running its course, the old track
+        // genuinely ending, the tail failing outright, or the setting being
+        // switched off mid-blend.
+        val done = progress >= 1f ||
+            ghost.playbackState == Player.STATE_ENDED ||
+            ghost.playbackState == Player.STATE_IDLE ||
+            configuredFadeMs() <= 0L
+        if (done) finish()
+    }
+
+    /** Ramps the ghost out rather than cutting it, so an interruption has no click in it. */
+    private fun driveBail() {
+        val ghost = ghost
+        if (ghost == null) {
+            finish()
+            return
+        }
+        val progress = (SystemClock.elapsedRealtime() - bailStartedAt).toFloat() / BAIL_MS
+        if (progress < 1f) {
+            ghost.volume = bailFromGain * fallGain(progress)
+            return
+        }
+        finish()
+    }
+
+    // ---- Lifecycle of a transition -----------------------------------------
+
+    /**
+     * Abandons the blend but still does what the listener asked for.
+     *
+     * Only for the crossfade deciding against itself — a ghost that won't
+     * start, the setting going off mid-arm. A fade cut short by the listener
+     * seeking or queueing something else goes through [bail] instead, since
+     * they have already moved on and a deferred skip would be one track too
+     * many.
+     */
+    private fun giveUp() {
+        val owed = owedSkip
+        bail()
+        if (!owed) return
+        selfMoveUntil = SystemClock.elapsedRealtime() + SELF_MOVE_WINDOW_MS
+        player.seekToNextMediaItem()
+    }
+
+    /**
+     * Abandons whatever is in flight. Safe to call from anywhere, at any phase:
+     * the session player is always the one holding the queue, so there is never
+     * a half-applied state to put back — only a ghost to fade out and a volume
+     * to restore.
+     */
+    private fun bail() {
+        owedSkip = false
+        if (phase == Phase.IDLE || phase == Phase.BAILING) return
+        player.volume = 1f
+        autoAdvance = false
+        bailFromGain = ghost?.volume ?: 0f
+        bailStartedAt = SystemClock.elapsedRealtime()
+        phase = Phase.BAILING
+    }
+
+    private fun finish() {
+        player.volume = 1f
+        ghost?.let {
+            it.volume = 0f
+            it.stop()
+            it.clearMediaItems()
+        }
+        lapWhenRemainingMs = Long.MAX_VALUE
+        selfMoveUntil = 0L
+        phase = Phase.IDLE
+    }
+
+    /** Still a next track, still playing, still switched on. */
+    private fun stillWorthFading(): Boolean =
+        configuredFadeMs() > 0L && player.hasNextMediaItem()
+
+    private fun warmGhost(): ExoPlayer? {
+        ghost?.let { return it }
+        return runCatching { newGhost() }.getOrNull()?.also { ghost = it }
+    }
+
+    // ---- Numbers ------------------------------------------------------------
+
+    private fun configuredFadeMs(): Long = AppSettings.crossfadeSeconds.value * 1000L
+
+    /**
+     * The configured length, kept off tracks too short to spend it on. A fade
+     * that swallows a third of a song stops being a transition and starts being
+     * the arrangement.
+     */
+    private fun fadeFor(duration: Long): Long {
+        val configured = configuredFadeMs()
+        if (duration == C.TIME_UNSET || duration <= 0L) return configured
+        return minOf(configured, duration / 3).coerceAtLeast(0L)
+    }
+
+    /** Equal-power pair: [riseGain]² + [fallGain]² = 1, so the blend never dips. */
+    private fun riseGain(progress: Float): Float =
+        sin(progress.coerceIn(0f, 1f) * PI.toFloat() / 2f)
+
+    private fun fallGain(progress: Float): Float =
+        cos(progress.coerceIn(0f, 1f) * PI.toFloat() / 2f)
 
     private companion object {
-        const val RAMP_STEP_MS = 40L
-        const val IDLE_STEP_MS = 200L
-        /** Below this the write is inaudible and only churns the audio track. */
-        const val VOLUME_EPSILON = 0.002f
+        /** Handoff of the outgoing track between the two players. */
+        const val LAP_MS = 90L
+
+        /** Ramp used when a fade is interrupted. */
+        const val BAIL_MS = 120L
+
+        /** Head start the ghost gets to spin up and settle into sync. */
+        const val ARM_LEAD_MS = 2_000L
+
+        /** How closely the two players must agree on position before the lap. */
+        const val SYNC_TOLERANCE_MS = 20L
+
+        /** Time a sync correction is given to land before it is judged. */
+        const val SYNC_SETTLE_MS = 150L
+
+        const val MAX_SEEK_LEAD_MS = 500L
+
+        /** Longest the lap will wait on a ghost that won't sync. */
+        const val AUTO_ARM_TIMEOUT_MS = 4_000L
+
+        /** Shorter for a skip: past this, the press stops feeling connected to anything. */
+        const val MANUAL_ARM_TIMEOUT_MS = 450L
+
+        /** Below this there is no tail worth handing to the ghost. */
+        const val MIN_TAIL_MS = 750L
+
+        /** How long the lap's own seek stays recognisable as ours. */
+        const val SELF_MOVE_WINDOW_MS = 150L
+
+        const val IDLE_STEP_MS = 250L
+        const val ARM_STEP_MS = 40L
+        const val LAP_STEP_MS = 10L
+        const val FADE_STEP_MS = 30L
+        const val BAIL_STEP_MS = 15L
     }
 }

--- a/app/src/main/java/com/music/bitchord/playback/CrossfadeController.kt
+++ b/app/src/main/java/com/music/bitchord/playback/CrossfadeController.kt
@@ -103,9 +103,6 @@ class CrossfadeController(
     /** Length of the transition in flight, in ms. Fixed when it begins. */
     private var fadeMs = 0L
 
-    /** Only for auto transitions: hold the lap until the track is really this close to ending. */
-    private var lapWhenRemainingMs = Long.MAX_VALUE
-
     private var lapStartedAt = 0L
     private var bailStartedAt = 0L
     private var armDeadline = 0L
@@ -150,14 +147,6 @@ class CrossfadeController(
     private var autoAdvance = false
 
     fun consumeAutoAdvance(): Boolean = autoAdvance.also { autoAdvance = false }
-
-    /**
-     * Whether a press of "next" is currently being held back waiting for the
-     * ghost. [interceptSkipToNext] tells the session player the skip is in hand,
-     * so if the blend then falls through it still has to happen — otherwise the
-     * button quietly does nothing at all.
-     */
-    private var owedSkip = false
 
     private val listener = object : Player.Listener {
         override fun onPositionDiscontinuity(
@@ -216,36 +205,23 @@ class CrossfadeController(
     // ---- Entry points -------------------------------------------------------
 
     /**
-     * Takes over a skip so it crossfades instead of cutting.
+     * A skip the listener asked for: drop any blend in flight and get out of
+     * the way.
      *
-     * Pressing "next" is how anyone actually tests this setting, and the old
-     * implementation deliberately did nothing on a manual skip — which is most
-     * of why it read as broken. Both Spotify and Apple Music blend a manual
-     * skip, so this does too.
+     * Crossfade is deliberately a property of tracks *running out*, not of
+     * being changed. Blending a manual skip means the song just left behind
+     * stays audible over the one that was asked for, which reads as the app
+     * ignoring the button rather than as a transition — the point of pressing
+     * next is usually to stop hearing the current track.
      *
-     * @return true when the crossfade has the skip in hand and the caller
-     *   should not also move the queue itself.
+     * Called before the skip is carried out, so the tail is already on its way
+     * down as the new track starts. The listener would catch the resulting seek
+     * anyway, but only outside [SELF_MOVE_WINDOW_MS]; a press landing inside
+     * that window would be mistaken for the lap's own move and leave the ghost
+     * running over the new track. Saying so explicitly closes that gap.
      */
-    fun interceptSkipToNext(): Boolean {
-        // A second press during a fade means "get on with it": drop the blend
-        // and let the plain skip through.
-        if (phase != Phase.IDLE) {
-            bail()
-            return false
-        }
-        if (configuredFadeMs() <= 0L) return false
-        if (player.playbackState == Player.STATE_IDLE) return false
-        // Skipping while paused should land on the next track, not start a
-        // fade nobody is listening to.
-        if (!player.playWhenReady) return false
-        if (!player.hasNextMediaItem()) return false
-
-        val duration = player.duration
-        val remaining = if (duration == C.TIME_UNSET) Long.MAX_VALUE else duration - player.currentPosition
-        // Skipping into the last moment of a track has nothing left to fade out.
-        if (remaining < MIN_TAIL_MS) return false
-
-        return begin(fade = fadeFor(duration), manual = true)
+    fun onSkipRequested() {
+        if (phase != Phase.IDLE) bail()
     }
 
     // ---- Ticker -------------------------------------------------------------
@@ -288,24 +264,20 @@ class CrossfadeController(
         // the fade is due rather than started then.
         if (remaining > fade + ARM_LEAD_MS) return
 
-        lapWhenRemainingMs = fade
-        begin(fade, manual = false)
+        begin(fade)
     }
 
     /**
      * Spins the ghost up on the outgoing track and walks it into sync with the
      * session player.
      */
-    private fun begin(fade: Long, manual: Boolean): Boolean {
+    private fun begin(fade: Long): Boolean {
         val outgoing = player.currentMediaItem ?: return false
         val ghost = warmGhost() ?: return false
 
         fadeMs = fade
-        armDeadline = SystemClock.elapsedRealtime() +
-            if (manual) MANUAL_ARM_TIMEOUT_MS else AUTO_ARM_TIMEOUT_MS
+        armDeadline = SystemClock.elapsedRealtime() + ARM_TIMEOUT_MS
         lastSyncAt = 0L
-        owedSkip = manual
-        if (manual) lapWhenRemainingMs = Long.MAX_VALUE
 
         // Taken from the session player rather than from settings: these two
         // change how fast a position advances against the wall clock, and the
@@ -324,8 +296,8 @@ class CrossfadeController(
     }
 
     private fun driveArming() {
-        val ghost = ghost ?: return giveUp()
-        if (!stillWorthFading()) return giveUp()
+        val ghost = ghost ?: return bail()
+        if (!stillWorthFading()) return bail()
 
         val expired = SystemClock.elapsedRealtime() > armDeadline
         val running = ghost.isPlaying
@@ -333,7 +305,7 @@ class CrossfadeController(
         // A ghost that never got going has no tail to hand the track to, and
         // lapping onto silence would be the very hole this class exists to get
         // rid of. Give up instead and let the track change plainly.
-        if (expired && !running) return giveUp()
+        if (expired && !running) return bail()
         val drift = ghost.currentPosition - player.currentPosition
         val aligned = running && abs(drift) <= SYNC_TOLERANCE_MS
 
@@ -349,11 +321,10 @@ class CrossfadeController(
             }
         }
 
-        // Auto transitions wait for the track to actually reach the fade point;
-        // a manual skip is due the moment the ghost can carry the tail.
+        // Wait for the track to actually reach the fade point.
         val duration = player.duration
         val atFadePoint = duration == C.TIME_UNSET ||
-            duration - player.currentPosition <= lapWhenRemainingMs
+            duration - player.currentPosition <= fadeMs
 
         if (!atFadePoint) return
         // Out of time to keep tidying up: a slightly ragged handoff still beats
@@ -362,7 +333,7 @@ class CrossfadeController(
     }
 
     private fun startLap() {
-        if (ghost == null) return giveUp()
+        if (ghost == null) return bail()
         lapStartedAt = SystemClock.elapsedRealtime()
         phase = Phase.LAPPING
     }
@@ -376,12 +347,12 @@ class CrossfadeController(
      * copies to comb against each other audibly.
      */
     private fun driveLap() {
-        val ghost = ghost ?: return giveUp()
+        val ghost = ghost ?: return bail()
         // Pausing in the ninety milliseconds it takes to hand the track over
         // means nothing has been handed over yet: the session player still has
         // the track, so give it back rather than advancing a queue the listener
         // has just stopped.
-        if (!player.playWhenReady) return giveUp()
+        if (!player.playWhenReady) return bail()
 
         val progress = (SystemClock.elapsedRealtime() - lapStartedAt).toFloat() / LAP_MS
 
@@ -397,8 +368,9 @@ class CrossfadeController(
         // new one — and everything hanging off it (queue index, metadata, the
         // notification, the UI) moves to the incoming song right here, while
         // its first note is still fading up.
-        autoAdvance = lapWhenRemainingMs != Long.MAX_VALUE
-        owedSkip = false
+        // Only a track running out ever gets this far, so the queue moving
+        // here is always the crossfade standing in for a track ending.
+        autoAdvance = true
         selfMoveUntil = SystemClock.elapsedRealtime() + SELF_MOVE_WINDOW_MS
         player.seekToNextMediaItem()
         phase = Phase.FADING
@@ -453,30 +425,12 @@ class CrossfadeController(
     // ---- Lifecycle of a transition -----------------------------------------
 
     /**
-     * Abandons the blend but still does what the listener asked for.
-     *
-     * Only for the crossfade deciding against itself — a ghost that won't
-     * start, the setting going off mid-arm. A fade cut short by the listener
-     * seeking or queueing something else goes through [bail] instead, since
-     * they have already moved on and a deferred skip would be one track too
-     * many.
-     */
-    private fun giveUp() {
-        val owed = owedSkip
-        bail()
-        if (!owed) return
-        selfMoveUntil = SystemClock.elapsedRealtime() + SELF_MOVE_WINDOW_MS
-        player.seekToNextMediaItem()
-    }
-
-    /**
      * Abandons whatever is in flight. Safe to call from anywhere, at any phase:
      * the session player is always the one holding the queue, so there is never
      * a half-applied state to put back — only a ghost to fade out and a volume
      * to restore.
      */
     private fun bail() {
-        owedSkip = false
         if (phase == Phase.IDLE || phase == Phase.BAILING) return
         player.volume = 1f
         autoAdvance = false
@@ -492,7 +446,6 @@ class CrossfadeController(
             it.stop()
             it.clearMediaItems()
         }
-        lapWhenRemainingMs = Long.MAX_VALUE
         selfMoveUntil = 0L
         phase = Phase.IDLE
     }
@@ -547,13 +500,7 @@ class CrossfadeController(
         const val MAX_SEEK_LEAD_MS = 500L
 
         /** Longest the lap will wait on a ghost that won't sync. */
-        const val AUTO_ARM_TIMEOUT_MS = 4_000L
-
-        /** Shorter for a skip: past this, the press stops feeling connected to anything. */
-        const val MANUAL_ARM_TIMEOUT_MS = 450L
-
-        /** Below this there is no tail worth handing to the ghost. */
-        const val MIN_TAIL_MS = 750L
+        const val ARM_TIMEOUT_MS = 4_000L
 
         /** How long the lap's own seek stays recognisable as ours. */
         const val SELF_MOVE_WINDOW_MS = 150L

--- a/app/src/main/java/com/music/bitchord/playback/DolbyAtmos.kt
+++ b/app/src/main/java/com/music/bitchord/playback/DolbyAtmos.kt
@@ -1,0 +1,242 @@
+package com.music.bitchord.playback
+
+import android.content.Context
+import android.content.Intent
+import android.database.ContentObserver
+import android.media.AudioDeviceCallback
+import android.media.AudioDeviceInfo
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.Spatializer
+import android.media.audiofx.AudioEffect
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.provider.Settings
+import androidx.annotation.RequiresApi
+import com.music.bitchord.data.settings.AppSettings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Whether the device has Dolby Atmos, and whether it is switched on right now.
+ *
+ * Spatial audio hangs off both: the app's own effect is only offered on a
+ * device that ships Atmos, and only runs while the system's Atmos switch is on
+ * — the same contract Apple Music keeps, where the row is dead on hardware that
+ * cannot do it and follows the system switch on hardware that can.
+ *
+ * Nothing here can turn Atmos *on*. No public API exposes the OEM's switch to a
+ * third-party app; [settingsIntent] is the closest thing, a jump to the panel
+ * that owns it. What this can do is notice the moment it goes off — via the
+ * platform spatializer's own callback, the vendor setting, or an output route
+ * change — and take spatial audio down with it.
+ */
+object DolbyAtmos {
+
+    /**
+     * The device can do Dolby Atmos. Near-fixed, but not quite: an HDMI or cast
+     * output that decodes Atmos can arrive after launch.
+     */
+    private val _supported = MutableStateFlow(false)
+    val supported: StateFlow<Boolean> = _supported.asStateFlow()
+
+    /** Atmos is switched on and applies to whatever audio is routed to now. */
+    private val _enabledOnDevice = MutableStateFlow(false)
+    val enabledOnDevice: StateFlow<Boolean> = _enabledOnDevice.asStateFlow()
+
+    /** What the effect should actually do: the user's switch, gated on Atmos. */
+    val spatialAudioActive: Boolean
+        get() = _supported.value && _enabledOnDevice.value && AppSettings.spatialAudio.value
+
+    private var audioManager: AudioManager? = null
+    private var spatializer: Spatializer? = null
+
+    /** The vendor setting Atmos lives in on this device, if it has one. */
+    private var vendorToggle: VendorToggle? = null
+
+    fun init(context: Context) {
+        val app = context.applicationContext
+        val manager = app.getSystemService(AudioManager::class.java) ?: return
+        audioManager = manager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
+            spatializer = runCatching { manager.spatializer }.getOrNull()
+            watchSpatializer(app)
+        }
+        // Only worth probing on a device that has Atmos to switch — elsewhere
+        // a key of the same name would be some other vendor's business.
+        if (hasAtmosHardware()) {
+            vendorToggle = findVendorToggle(app)
+            watchVendorToggle(app)
+        }
+        // Atmos is a property of the route as much as the device: plugging in
+        // headphones or handing audio to a Bluetooth sink can switch it on and
+        // off without anyone touching a setting.
+        runCatching {
+            manager.registerAudioDeviceCallback(
+                object : AudioDeviceCallback() {
+                    override fun onAudioDevicesAdded(added: Array<out AudioDeviceInfo>?) = refresh()
+                    override fun onAudioDevicesRemoved(removed: Array<out AudioDeviceInfo>?) = refresh()
+                },
+                null,
+            )
+        }
+        refresh()
+    }
+
+    /**
+     * Re-read the device's state and, if Atmos has gone away, take the user's
+     * spatial audio switch down with it — an effect that survived its
+     * precondition would be lying about what it is.
+     *
+     * Cheap enough to call on every resume, which is how a trip to the system
+     * panel and back gets noticed on devices whose Atmos switch isn't watchable.
+     */
+    fun refresh() {
+        _supported.value = hasAtmosHardware()
+        _enabledOnDevice.value = _supported.value && isAtmosOn()
+        if (!_enabledOnDevice.value && AppSettings.spatialAudio.value) {
+            AppSettings.setSpatialAudio(false)
+        }
+    }
+
+    /**
+     * Where the user turns Atmos on. Devices that ship it as an app get that
+     * app; everything else gets the system sound panel, which is where both
+     * stock Android's spatial audio switch and most OEM Atmos switches live.
+     */
+    fun settingsIntent(context: Context): Intent? {
+        val packages = context.packageManager
+        DOLBY_PACKAGES.forEach { name ->
+            packages.getLaunchIntentForPackage(name)?.let { return it }
+        }
+        val sound = Intent(Settings.ACTION_SOUND_SETTINGS)
+        return if (sound.resolveActivity(packages) != null) sound else null
+    }
+
+    /**
+     * Two ways a device says it has Atmos: it publishes a Dolby audio effect
+     * (how phones ship it), or an output claims a Dolby encoding (how a TV or
+     * an HDMI/passthrough sink does).
+     */
+    private fun hasAtmosHardware(): Boolean = hasDolbyEffect() || hasAtmosOutput()
+
+    /** The effect list is fixed at boot, so this is asked once and remembered. */
+    private val dolbyEffect: Boolean by lazy {
+        runCatching {
+            AudioEffect.queryEffects()?.any { descriptor ->
+                val identity = "${descriptor.implementor} ${descriptor.name}".lowercase()
+                DOLBY_MARKERS.any { it in identity }
+            } == true
+        }.getOrDefault(false)
+    }
+
+    private fun hasDolbyEffect(): Boolean = dolbyEffect
+
+    private fun hasAtmosOutput(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return false
+        val devices = audioManager?.getDevices(AudioManager.GET_DEVICES_OUTPUTS) ?: return false
+        return devices.any { device ->
+            device.encodings.any {
+                it == AudioFormat.ENCODING_E_AC3_JOC || it == AudioFormat.ENCODING_AC4
+            }
+        }
+    }
+
+    /**
+     * In order of how much the answer can be trusted: the OEM's own setting,
+     * then the platform spatializer. A device that offers neither has Atmos
+     * with no readable switch, so the user's choice stands rather than being
+     * silently overruled by a state we can't see.
+     */
+    private fun isAtmosOn(): Boolean {
+        vendorToggle?.let { return it.isOn() }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
+            spatializer?.let { return it.isEnabled && it.isAvailable }
+        }
+        return true
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S_V2)
+    private fun watchSpatializer(context: Context) {
+        val current = spatializer ?: return
+        runCatching {
+            current.addOnSpatializerStateChangedListener(
+                context.mainExecutor,
+                object : Spatializer.OnSpatializerStateChangedListener {
+                    override fun onSpatializerEnabledChanged(spatializer: Spatializer, enabled: Boolean) = refresh()
+                    override fun onSpatializerAvailableChanged(spatializer: Spatializer, available: Boolean) = refresh()
+                },
+            )
+        }
+    }
+
+    /**
+     * OEMs keep the Atmos switch in their own Settings row rather than anywhere
+     * standard, so the key is found by probing rather than assumed. A miss
+     * costs a handful of lookups at startup and leaves [isAtmosOn] on its other
+     * sources.
+     */
+    private fun findVendorToggle(context: Context): VendorToggle? {
+        val resolver = context.contentResolver
+        VENDOR_KEYS.forEach { key ->
+            val candidates = listOf(
+                VendorToggle(Settings.Global.getUriFor(key)) {
+                    Settings.Global.getInt(resolver, key, ABSENT)
+                },
+                VendorToggle(Settings.System.getUriFor(key)) {
+                    Settings.System.getInt(resolver, key, ABSENT)
+                },
+                VendorToggle(Settings.Secure.getUriFor(key)) {
+                    Settings.Secure.getInt(resolver, key, ABSENT)
+                },
+            )
+            candidates.forEach { candidate ->
+                if (candidate.value() != ABSENT) return candidate
+            }
+        }
+        return null
+    }
+
+    private fun watchVendorToggle(context: Context) {
+        val toggle = vendorToggle ?: return
+        runCatching {
+            context.contentResolver.registerContentObserver(
+                toggle.uri,
+                false,
+                object : ContentObserver(Handler(context.mainLooper)) {
+                    override fun onChange(selfChange: Boolean) = refresh()
+                },
+            )
+        }
+    }
+
+    /** A vendor's Atmos switch: where it lives, and how to read it. */
+    private class VendorToggle(val uri: Uri, private val read: () -> Int) {
+        fun value(): Int = runCatching(read).getOrDefault(ABSENT)
+        fun isOn(): Boolean = value().let { it != ABSENT && it != 0 }
+    }
+
+    /** Distinguishes "the key is missing" from any value it could legitimately hold. */
+    private const val ABSENT = Int.MIN_VALUE
+
+    private val DOLBY_MARKERS = listOf("dolby", "atmos", "dax")
+
+    /** Devices that ship Atmos as a separate app rather than a Settings row. */
+    private val DOLBY_PACKAGES = listOf(
+        "com.dolby.dax2appui",
+        "com.dolby.daxappui",
+        "com.dolby.dolby234",
+        "com.atc.daxappUI",
+    )
+
+    private val VENDOR_KEYS = listOf(
+        "dolby_atmos",
+        "dolby_atmos_enable",
+        "dolby_dap_enable",
+        "sound_effect_dolby",
+        "dolby_effect",
+    )
+}

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -33,6 +33,7 @@ import com.music.bitchord.R
 import com.music.bitchord.data.Http
 import com.music.bitchord.data.NerdStats
 import com.music.bitchord.data.innertube.PlaybackTracker
+import com.music.bitchord.data.innertube.PlayerClient
 import com.music.bitchord.data.innertube.StreamResolver
 import com.music.bitchord.data.settings.AppSettings
 import kotlinx.coroutines.CoroutineScope
@@ -94,15 +95,29 @@ class PlaybackService : MediaSessionService() {
                 .apply { setSmallIcon(R.drawable.ic_notification_logo) },
         )
 
+        // No user agent on the factory: the right one depends on which client
+        // minted the URL, so it is set per request below. Setting it here as
+        // well would not override that — OkHttpDataSource *appends* the
+        // factory's agent after the request's, and the fetch would go out
+        // carrying two contradictory User-Agent headers.
         val resolvingFactory = ResolvingDataSource.Factory(
-            OkHttpDataSource.Factory(Http.client)
-                // Match the client identity that minted the URL.
-                .setUserAgent(Http.IOS_USER_AGENT),
+            // Innermost, so it chunks the real googlevideo URL the resolver
+            // below has already substituted in — see [ChunkedDataSource] for
+            // why an open-ended read of one is worth avoiding.
+            ChunkedDataSource.Factory(OkHttpDataSource.Factory(Http.client), STREAM_CHUNK_BYTES),
         ) { dataSpec ->
             val videoId = dataSpec.uri.getQueryParameter("v")
                 ?: return@Factory dataSpec
             val streamUrl = runBlocking { StreamResolver.resolve(videoId) }
-            dataSpec.withUri(Uri.parse(streamUrl))
+            dataSpec.buildUpon()
+                .setUri(Uri.parse(streamUrl))
+                // googlevideo names the client that minted the URL inside the
+                // URL itself, and compares it against the request that comes
+                // back for the bytes. A mismatch is answered with a throttled
+                // trickle or a 403 rather than an error worth the name, so the
+                // fetch is dressed as whatever the URL says it should be.
+                .setHttpRequestHeaders(PlayerClient.forStreamUrl(streamUrl).mediaHeaders())
+                .build()
         }
         // Read-ahead resolves streams through the same chain the player does.
         AudioCache.setUpstream(resolvingFactory)
@@ -413,21 +428,27 @@ class PlaybackService : MediaSessionService() {
      * listener waits for sound:
      *
      *  - **Back buffer.** Media3 keeps nothing behind the playhead, so a seek
-     *    *backwards* always drops the buffer and reloads, while a seek forwards
-     *    lands in samples already held and resumes at once. The reload is the
-     *    expensive half: it restarts at the WebM cue point before the target —
-     *    YouTube spaces those ten seconds apart — and everything from there to
-     *    where the listener actually asked for has to go through the decoder
-     *    and be thrown away, at roughly 130ms of waiting per second skipped.
-     *    That asymmetry is what makes scrubbing back feel broken. Since a whole
-     *    track is only a few megabytes of Opus, keeping all of it behind the
-     *    playhead makes a backward seek exactly what a forward one already is:
-     *    an in-buffer seek, no reload and no discarded decoding at all.
+     *    *backwards* drops the buffer and reloads, while a seek forwards lands
+     *    in samples already held. Half a minute of history closes that gap for
+     *    the seek people actually make — nudging back a few seconds to catch a
+     *    lyric — and it is deliberately no longer than that. The byte ceiling
+     *    above counts *everything* the player holds, history included, so a
+     *    back buffer wide enough to keep a whole track would spend the entire
+     *    read-ahead budget on audio already heard: past the ceiling, loading
+     *    stops, and since every second played moves a second from the front of
+     *    the buffer to the back, the total never falls again and it never
+     *    restarts. Read-ahead collapses and the track stalls every couple of
+     *    seconds for the rest of its length. Seeking further back than this
+     *    window is a disk read anyway, not a network one — [AudioCache] has
+     *    written every byte already played.
      *  - **Thresholds to (re)start playback.** The defaults — 2.5s of audio
      *    before starting, 5s before resuming after a rebuffer — are sized for
      *    streaming video over a network that might stall again. Here the bytes
-     *    are almost always already on disk, so those seconds are spent waiting
-     *    on a buffer that fills instantly and are simply dead air after a seek.
+     *    are usually already on disk, so those seconds are spent waiting on a
+     *    buffer that fills instantly and are simply dead air after a seek.
+     *    Resuming is given more room than starting: a stall means the network
+     *    is genuinely struggling, and coming back with a second of audio in
+     *    hand only buys the next stall.
      */
     private fun farBufferingLoadControl() = DefaultLoadControl.Builder()
         .setBufferDurationsMs(
@@ -563,6 +584,12 @@ class PlaybackService : MediaSessionService() {
         /** How often played-seconds are sampled off the player. */
         const val PROGRESS_SAMPLE_MS = 5_000L
 
+        /**
+         * Size of each range the player fetches. The same figure read-ahead
+         * uses, and for the same reason — see [ChunkedDataSource].
+         */
+        const val STREAM_CHUNK_BYTES = 2L * 1024 * 1024
+
         /** Shortest gap "skip silence" is allowed to touch. */
         const val MIN_SILENCE_US = 1_000_000L
 
@@ -572,13 +599,16 @@ class PlaybackService : MediaSessionService() {
         /** ~6 minutes at 160kbps: a whole track, for all but the longest. */
         const val FAR_BUFFER_BYTES = 8 * 1024 * 1024
 
-        /** Past any song, so a seek back lands in the buffer rather than re-reading. */
-        const val BACK_BUFFER_MS = 15 * 60 * 1000
+        /**
+         * A short nudge backwards, and no more: this shares the byte ceiling
+         * above with the read-ahead it would otherwise starve.
+         */
+        const val BACK_BUFFER_MS = 30 * 1000
 
         /** Enough to cover the decoder's own latency, not seconds of dead air. */
         const val START_PLAYBACK_MS = 500
 
-        /** Same again after a seek or a stall — the bytes are usually on disk. */
-        const val RESUME_PLAYBACK_MS = 1_000
+        /** More room after a stall than at the start — see the load control. */
+        const val RESUME_PLAYBACK_MS = 2_000
     }
 }

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -548,11 +548,11 @@ class PlaybackService : MediaSessionService() {
      * that command is redirected rather than left to behave differently
      * depending on which back button was pressed.
      *
-     * **Next crossfades.** A skip is a track change like any other, and with
-     * crossfade on it should blend rather than cut — which means it has to go
-     * through [CrossfadeController] instead of straight to the queue. When the
-     * crossfade declines it (switched off, paused, nothing queued behind, a
-     * second impatient press) the skip falls through to the plain behaviour.
+     * **A skip cancels the crossfade.** Blending is for a track running out,
+     * not for one being changed: told to move on, the listener wants the song
+     * they were on to stop, not to keep playing over the one they asked for.
+     * So every skip tells [CrossfadeController] to drop whatever is in flight
+     * and then moves the queue plainly.
      *
      * Command availability is deliberately untouched — mutating it through a
      * [ForwardingPlayer] means intercepting listener callbacks too. The one
@@ -566,14 +566,19 @@ class PlaybackService : MediaSessionService() {
         private val crossfade: CrossfadeController,
     ) : ForwardingPlayer(player) {
 
-        override fun seekToPreviousMediaItem() = wrappedPlayer.seekToPrevious()
+        override fun seekToPreviousMediaItem() {
+            crossfade.onSkipRequested()
+            wrappedPlayer.seekToPrevious()
+        }
 
         override fun seekToNextMediaItem() {
-            if (!crossfade.interceptSkipToNext()) wrappedPlayer.seekToNextMediaItem()
+            crossfade.onSkipRequested()
+            wrappedPlayer.seekToNextMediaItem()
         }
 
         override fun seekToNext() {
-            if (!crossfade.interceptSkipToNext()) wrappedPlayer.seekToNext()
+            crossfade.onSkipRequested()
+            wrappedPlayer.seekToNext()
         }
     }
 

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -269,7 +270,7 @@ class PlaybackService : MediaSessionService() {
             player?.let { ghost.audioSessionId = it.audioSessionId }
             ghost.skipSilenceEnabled = AppSettings.skipSilence.value
             ghost.setPlaybackSpeed(AppSettings.playbackSpeed.value)
-            ghostSpatialAudioProcessor.enabled = AppSettings.spatialAudio.value
+            ghostSpatialAudioProcessor.enabled = DolbyAtmos.spatialAudioActive
         }
 
     /**
@@ -499,7 +500,7 @@ class PlaybackService : MediaSessionService() {
     private fun applySettings(player: ExoPlayer) {
         player.skipSilenceEnabled = AppSettings.skipSilence.value
         player.setPlaybackSpeed(AppSettings.playbackSpeed.value)
-        spatialAudioProcessor.enabled = AppSettings.spatialAudio.value
+        spatialAudioProcessor.enabled = DolbyAtmos.spatialAudioActive
     }
 
     private fun observeSettings() {
@@ -509,11 +510,19 @@ class PlaybackService : MediaSessionService() {
         scope.launch {
             AppSettings.playbackSpeed.collect { player?.setPlaybackSpeed(it) }
         }
+        // Spatial audio is the user's switch *and* the device's: Atmos going
+        // off in system settings mid-track has to stop the effect, not wait for
+        // the next track or the next launch.
         scope.launch {
-            AppSettings.spatialAudio.collect {
-                spatialAudioProcessor.enabled = it
-                ghostSpatialAudioProcessor.enabled = it
-            }
+            combine(
+                AppSettings.spatialAudio,
+                DolbyAtmos.supported,
+                DolbyAtmos.enabledOnDevice,
+            ) { wanted, supported, atmosOn -> wanted && supported && atmosOn }
+                .collect {
+                    spatialAudioProcessor.enabled = it
+                    ghostSpatialAudioProcessor.enabled = it
+                }
         }
     }
 

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -5,15 +5,18 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.SystemClock
+import android.util.Log
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.audio.SonicAudioProcessor
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DecoderReuseEvaluation
@@ -67,10 +70,18 @@ class PlaybackService : MediaSessionService() {
     private var mediaSession: MediaSession? = null
     private var player: ExoPlayer? = null
     private var crossfade: CrossfadeController? = null
+    private val spatialAudioProcessor = SpatialAudioProcessor()
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     /** Last sampled position of the playing track, in seconds. */
     private var lastPositionSeconds = 0L
+
+    /**
+     * Re-resolve attempts spent on the current item, reset whenever the queue
+     * moves. Bounded so a track whose URL is genuinely unplayable stops rather
+     * than looping between error and retry forever.
+     */
+    private var urlRetries = 0
 
     override fun onCreate() {
         super.onCreate()
@@ -135,11 +146,46 @@ class PlaybackService : MediaSessionService() {
                 saveQueue()
             }
 
+            /**
+             * Recovers the failure this app fails on most: a stream URL that
+             * comes back **403**.
+             *
+             * [StreamResolver] remembers a URL the moment it is minted, before
+             * anything has fetched it, so a dead one would otherwise be served
+             * back out of that cache for its whole TTL — every retry failing
+             * identically without a request leaving the device. Dropping the
+             * entry and preparing again re-resolves from scratch, which is
+             * usually enough because the URL that failed came from the IOS
+             * fallback and the retry tends to land on NewPipe instead.
+             *
+             * Read-ahead is cancelled alongside it: it resolves through the
+             * same cache and would otherwise keep pulling on the dead URL.
+             */
+            override fun onPlayerError(error: PlaybackException) {
+                val videoId = exoPlayer.currentMediaItem?.mediaId
+                Log.w(TAG, "playback error on $videoId: ${error.errorCodeName}", error)
+
+                if (!error.isStaleUrl()) return
+                if (videoId == null) return
+                if (urlRetries >= MAX_URL_RETRIES) {
+                    Log.w(TAG, "giving up on $videoId after $urlRetries re-resolves")
+                    return
+                }
+
+                urlRetries++
+                Log.d(TAG, "re-resolving $videoId (attempt $urlRetries/$MAX_URL_RETRIES)")
+                StreamResolver.invalidate(videoId)
+                AudioCache.cancel()
+                exoPlayer.prepare()
+            }
+
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                 // currentPosition already belongs to the new item by now, so
                 // the outgoing track is closed out on the last sampled value.
                 PlaybackTracker.onTrackChanged(lastPositionSeconds)
                 lastPositionSeconds = 0
+                // A new track gets its own budget of re-resolves.
+                urlRetries = 0
                 // "Sleep after this song": the queue moving on by itself is the
                 // moment the track the user meant has finished. REPEAT counts
                 // too, or the timer would never fire with repeat-one on.
@@ -221,6 +267,23 @@ class PlaybackService : MediaSessionService() {
 
     private fun registerCurrentPlay() {
         player?.currentMediaItem?.mediaId?.let(PlaybackTracker::onPlaying)
+    }
+
+    /**
+     * Whether this failure is a spent stream URL rather than an unplayable
+     * track. The HTTP status is carried a few levels down — the renderer wraps
+     * the loader's exception, which wraps the data source's — so the whole
+     * cause chain is walked rather than just the immediate cause.
+     */
+    private fun PlaybackException.isStaleUrl(): Boolean {
+        var cause: Throwable? = this
+        while (cause != null) {
+            if (cause is HttpDataSource.InvalidResponseCodeException) {
+                return cause.responseCode in STALE_URL_CODES
+            }
+            cause = cause.cause
+        }
+        return false
     }
 
     /**
@@ -400,7 +463,7 @@ class PlaybackService : MediaSessionService() {
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
             .setAudioProcessorChain(
                 DefaultAudioSink.DefaultAudioProcessorChain(
-                    emptyArray(),
+                    arrayOf(spatialAudioProcessor),
                     SilenceSkippingAudioProcessor(
                         MIN_SILENCE_US,
                         SilenceSkippingAudioProcessor.DEFAULT_SILENCE_RETENTION_RATIO,
@@ -418,6 +481,7 @@ class PlaybackService : MediaSessionService() {
     private fun applySettings(player: ExoPlayer) {
         player.skipSilenceEnabled = AppSettings.skipSilence.value
         player.setPlaybackSpeed(AppSettings.playbackSpeed.value)
+        spatialAudioProcessor.enabled = AppSettings.spatialAudio.value
     }
 
     private fun observeSettings() {
@@ -426,6 +490,9 @@ class PlaybackService : MediaSessionService() {
         }
         scope.launch {
             AppSettings.playbackSpeed.collect { player?.setPlaybackSpeed(it) }
+        }
+        scope.launch {
+            AppSettings.spatialAudio.collect { spatialAudioProcessor.enabled = it }
         }
     }
 
@@ -469,8 +536,24 @@ class PlaybackService : MediaSessionService() {
     }
 
     private companion object {
+        const val TAG = "BitChord"
         const val CHANNEL_ID = "bitchord_playback"
         const val SESSION_ID = "BitChordPlayback"
+
+        /**
+         * Re-resolves allowed per track. Two is enough to get off a bad URL
+         * from the IOS fallback and onto a NewPipe one; more than that and the
+         * track is not playable right now, and retrying is just a spinner.
+         */
+        const val MAX_URL_RETRIES = 2
+
+        /**
+         * Response codes that mean "this URL is spent", not "this track is
+         * gone". googlevideo answers an expired or wrongly-minted stream URL
+         * with 403, and occasionally 401 or 410; all three are worth a fresh
+         * resolve, while a 404 genuinely is not.
+         */
+        val STALE_URL_CODES = setOf(401, 403, 410)
 
         /** How often played-seconds are sampled off the player. */
         const val PROGRESS_SAMPLE_MS = 5_000L

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -5,18 +5,15 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.SystemClock
-import android.util.Log
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
-import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.audio.SonicAudioProcessor
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DecoderReuseEvaluation
@@ -71,17 +68,20 @@ class PlaybackService : MediaSessionService() {
     private var player: ExoPlayer? = null
     private var crossfade: CrossfadeController? = null
     private val spatialAudioProcessor = SpatialAudioProcessor()
+
+    /**
+     * The crossfade's tail player runs its own audio sink, so it needs its own
+     * instance of the effect — [SpatialAudioProcessor] carries a delay line and
+     * filter state that two sinks cannot share.
+     */
+    private val ghostSpatialAudioProcessor = SpatialAudioProcessor()
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+    /** Shared with the crossfade's tail player, so both read the same disk cache. */
+    private var mediaSourceFactory: DefaultMediaSourceFactory? = null
 
     /** Last sampled position of the playing track, in seconds. */
     private var lastPositionSeconds = 0L
-
-    /**
-     * Re-resolve attempts spent on the current item, reset whenever the queue
-     * moves. Bounded so a track whose URL is genuinely unplayable stops rather
-     * than looping between error and retry forever.
-     */
-    private var urlRetries = 0
 
     override fun onCreate() {
         super.onCreate()
@@ -106,12 +106,11 @@ class PlaybackService : MediaSessionService() {
         }
         // Read-ahead resolves streams through the same chain the player does.
         AudioCache.setUpstream(resolvingFactory)
+        mediaSourceFactory = DefaultMediaSourceFactory(AudioCache.playbackFactory(resolvingFactory))
 
         val exoPlayer = ExoPlayer.Builder(this)
-            .setRenderersFactory(silenceSkippingRenderers())
-            .setMediaSourceFactory(
-                DefaultMediaSourceFactory(AudioCache.playbackFactory(resolvingFactory)),
-            )
+            .setRenderersFactory(silenceSkippingRenderers(spatialAudioProcessor))
+            .setMediaSourceFactory(requireNotNull(mediaSourceFactory))
             .setLoadControl(farBufferingLoadControl())
             .setAudioAttributes(
                 AudioAttributes.Builder()
@@ -146,50 +145,22 @@ class PlaybackService : MediaSessionService() {
                 saveQueue()
             }
 
-            /**
-             * Recovers the failure this app fails on most: a stream URL that
-             * comes back **403**.
-             *
-             * [StreamResolver] remembers a URL the moment it is minted, before
-             * anything has fetched it, so a dead one would otherwise be served
-             * back out of that cache for its whole TTL — every retry failing
-             * identically without a request leaving the device. Dropping the
-             * entry and preparing again re-resolves from scratch, which is
-             * usually enough because the URL that failed came from the IOS
-             * fallback and the retry tends to land on NewPipe instead.
-             *
-             * Read-ahead is cancelled alongside it: it resolves through the
-             * same cache and would otherwise keep pulling on the dead URL.
-             */
-            override fun onPlayerError(error: PlaybackException) {
-                val videoId = exoPlayer.currentMediaItem?.mediaId
-                Log.w(TAG, "playback error on $videoId: ${error.errorCodeName}", error)
-
-                if (!error.isStaleUrl()) return
-                if (videoId == null) return
-                if (urlRetries >= MAX_URL_RETRIES) {
-                    Log.w(TAG, "giving up on $videoId after $urlRetries re-resolves")
-                    return
-                }
-
-                urlRetries++
-                Log.d(TAG, "re-resolving $videoId (attempt $urlRetries/$MAX_URL_RETRIES)")
-                StreamResolver.invalidate(videoId)
-                AudioCache.cancel()
-                exoPlayer.prepare()
-            }
-
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                 // currentPosition already belongs to the new item by now, so
                 // the outgoing track is closed out on the last sampled value.
                 PlaybackTracker.onTrackChanged(lastPositionSeconds)
                 lastPositionSeconds = 0
-                // A new track gets its own budget of re-resolves.
-                urlRetries = 0
                 // "Sleep after this song": the queue moving on by itself is the
                 // moment the track the user meant has finished. REPEAT counts
                 // too, or the timer would never fire with repeat-one on.
-                val ended = reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO ||
+                //
+                // A crossfade arrives as a SEEK, because moving the queue on
+                // early is exactly how it starts the next track while the last
+                // one is still fading. Indistinguishable from a manual skip
+                // from here, so the crossfade says which of the two it was.
+                val crossfaded = crossfade?.consumeAutoAdvance() == true
+                val ended = crossfaded ||
+                    reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO ||
                     reason == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT
                 if (ended && SleepTimer.afterTrack.value) {
                     exoPlayer.pause()
@@ -235,13 +206,56 @@ class PlaybackService : MediaSessionService() {
 
         reportProgress(exoPlayer)
 
-        crossfade = CrossfadeController(scope, exoPlayer).also { it.start() }
+        val controller = CrossfadeController(scope, exoPlayer, ::buildGhostPlayer)
+        crossfade = controller
+        controller.start()
 
-        mediaSession = MediaSession.Builder(this, RestartingBackPlayer(exoPlayer))
+        mediaSession = MediaSession.Builder(this, SessionPlayer(exoPlayer, controller))
             .setId(SESSION_ID)
             .setSessionActivity(sessionActivity())
             .build()
     }
+
+    /**
+     * The crossfade's tail player: plays out the last seconds of the track
+     * being left behind while the real player gets on with the next one.
+     *
+     * Deliberately not a second copy of the main player:
+     *
+     *  - **No audio focus.** Focus belongs to the session player, and two
+     *    requests from one app mean the second replaces the first — the ghost
+     *    abandoning focus as it finishes would take the whole app's focus with
+     *    it.
+     *  - **No "becoming noisy" handling, no wake mode, no session.** Unplugging
+     *    headphones pauses the session player, and the ghost dies with the fade
+     *    that owns it; a second component reacting to the same events would
+     *    only ever fight the first.
+     *  - **Same audio session id**, so the system equalizer and any other
+     *    effects attached to the app apply to the tail as well as to the track
+     *    fading up. Without it a crossfade would audibly change EQ halfway.
+     *
+     * It shares the media source factory, so the tail is served from the same
+     * on-disk cache the track was just playing from rather than re-resolving a
+     * stream URL for audio that is already local.
+     */
+    private fun buildGhostPlayer(): ExoPlayer = ExoPlayer.Builder(this)
+        .setRenderersFactory(silenceSkippingRenderers(ghostSpatialAudioProcessor))
+        .setMediaSourceFactory(requireNotNull(mediaSourceFactory))
+        .setLoadControl(farBufferingLoadControl())
+        .setAudioAttributes(
+            AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                .build(),
+            /* handleAudioFocus = */ false,
+        )
+        .build()
+        .also { ghost ->
+            player?.let { ghost.audioSessionId = it.audioSessionId }
+            ghost.skipSilenceEnabled = AppSettings.skipSilence.value
+            ghost.setPlaybackSpeed(AppSettings.playbackSpeed.value)
+            ghostSpatialAudioProcessor.enabled = AppSettings.spatialAudio.value
+        }
 
     /**
      * Where a tap on the session lands. Media3 uses this both as the media
@@ -267,23 +281,6 @@ class PlaybackService : MediaSessionService() {
 
     private fun registerCurrentPlay() {
         player?.currentMediaItem?.mediaId?.let(PlaybackTracker::onPlaying)
-    }
-
-    /**
-     * Whether this failure is a spent stream URL rather than an unplayable
-     * track. The HTTP status is carried a few levels down — the renderer wraps
-     * the loader's exception, which wraps the data source's — so the whole
-     * cause chain is walked rather than just the immediate cause.
-     */
-    private fun PlaybackException.isStaleUrl(): Boolean {
-        var cause: Throwable? = this
-        while (cause != null) {
-            if (cause is HttpDataSource.InvalidResponseCodeException) {
-                return cause.responseCode in STALE_URL_CODES
-            }
-            cause = cause.cause
-        }
-        return false
     }
 
     /**
@@ -453,7 +450,7 @@ class PlaybackService : MediaSessionService() {
      * track. Everything else about the chain stays default, so
      * `skipSilenceEnabled` keeps driving it as before.
      */
-    private fun silenceSkippingRenderers() = object : DefaultRenderersFactory(this) {
+    private fun silenceSkippingRenderers(spatial: SpatialAudioProcessor) = object : DefaultRenderersFactory(this) {
         override fun buildAudioSink(
             context: Context,
             enableFloatOutput: Boolean,
@@ -463,7 +460,7 @@ class PlaybackService : MediaSessionService() {
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
             .setAudioProcessorChain(
                 DefaultAudioSink.DefaultAudioProcessorChain(
-                    arrayOf(spatialAudioProcessor),
+                    arrayOf(spatial),
                     SilenceSkippingAudioProcessor(
                         MIN_SILENCE_US,
                         SilenceSkippingAudioProcessor.DEFAULT_SILENCE_RETENTION_RATIO,
@@ -492,7 +489,10 @@ class PlaybackService : MediaSessionService() {
             AppSettings.playbackSpeed.collect { player?.setPlaybackSpeed(it) }
         }
         scope.launch {
-            AppSettings.spatialAudio.collect { spatialAudioProcessor.enabled = it }
+            AppSettings.spatialAudio.collect {
+                spatialAudioProcessor.enabled = it
+                ghostSpatialAudioProcessor.enabled = it
+            }
         }
     }
 
@@ -514,15 +514,24 @@ class PlaybackService : MediaSessionService() {
     }
 
     /**
-     * Makes the notification, lockscreen and Bluetooth back buttons agree with
-     * the one in the app.
+     * What the MediaSession, and so every control surface, actually talks to.
      *
-     * ExoPlayer already implements restart-then-skip in [Player.seekToPrevious],
-     * gated on `maxSeekToPreviousPosition`. Those external surfaces don't use
-     * it: [DefaultMediaNotificationProvider] binds its previous button to
+     * Two behaviours are grafted onto the player here rather than left to
+     * ExoPlayer's defaults:
+     *
+     * **Back restarts the track.** ExoPlayer already implements
+     * restart-then-skip in [Player.seekToPrevious], gated on
+     * `maxSeekToPreviousPosition`. External surfaces don't use it:
+     * [DefaultMediaNotificationProvider] binds its previous button to
      * `COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM`, which skips unconditionally. So
-     * that command is redirected here rather than left to behave differently
+     * that command is redirected rather than left to behave differently
      * depending on which back button was pressed.
+     *
+     * **Next crossfades.** A skip is a track change like any other, and with
+     * crossfade on it should blend rather than cut — which means it has to go
+     * through [CrossfadeController] instead of straight to the queue. When the
+     * crossfade declines it (switched off, paused, nothing queued behind, a
+     * second impatient press) the skip falls through to the plain behaviour.
      *
      * Command availability is deliberately untouched — mutating it through a
      * [ForwardingPlayer] means intercepting listener callbacks too. The one
@@ -531,29 +540,25 @@ class PlaybackService : MediaSessionService() {
      * stays inert on those surfaces, exactly as it already was. In the app it
      * restarts, since that path asks for `COMMAND_SEEK_TO_PREVIOUS`.
      */
-    private class RestartingBackPlayer(player: Player) : ForwardingPlayer(player) {
+    private class SessionPlayer(
+        player: Player,
+        private val crossfade: CrossfadeController,
+    ) : ForwardingPlayer(player) {
+
         override fun seekToPreviousMediaItem() = wrappedPlayer.seekToPrevious()
+
+        override fun seekToNextMediaItem() {
+            if (!crossfade.interceptSkipToNext()) wrappedPlayer.seekToNextMediaItem()
+        }
+
+        override fun seekToNext() {
+            if (!crossfade.interceptSkipToNext()) wrappedPlayer.seekToNext()
+        }
     }
 
     private companion object {
-        const val TAG = "BitChord"
         const val CHANNEL_ID = "bitchord_playback"
         const val SESSION_ID = "BitChordPlayback"
-
-        /**
-         * Re-resolves allowed per track. Two is enough to get off a bad URL
-         * from the IOS fallback and onto a NewPipe one; more than that and the
-         * track is not playable right now, and retrying is just a spinner.
-         */
-        const val MAX_URL_RETRIES = 2
-
-        /**
-         * Response codes that mean "this URL is spent", not "this track is
-         * gone". googlevideo answers an expired or wrongly-minted stream URL
-         * with 403, and occasionally 401 or 410; all three are worth a fresh
-         * resolve, while a 404 genuinely is not.
-         */
-        val STALE_URL_CODES = setOf(401, 403, 410)
 
         /** How often played-seconds are sampled off the player. */
         const val PROGRESS_SAMPLE_MS = 5_000L

--- a/app/src/main/java/com/music/bitchord/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlayerConnection.kt
@@ -17,7 +17,9 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
+import com.music.bitchord.data.model.NOTIFICATION_ART_PX
 import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.model.artworkAt
 import kotlinx.coroutines.delay
 
 /** Snapshot of playback state, driven by the MediaController. */
@@ -182,7 +184,10 @@ fun Song.toMediaItem(): MediaItem = MediaItem.Builder()
         MediaMetadata.Builder()
             .setTitle(title)
             .setArtist(artist)
-            .setArtworkUri(thumbnailUrl?.toUri())
+            // Sized here rather than left as stored: this is what the lock
+            // screen, the notification and Android Auto draw, all of them
+            // large, and none of them go back for a better copy later.
+            .setArtworkUri(artworkAt(NOTIFICATION_ART_PX)?.toUri())
             // System media surfaces (One UI's Now Bar, Android Auto, Assistant)
             // classify a session by its media type; untyped sessions get treated
             // as generic audio and lose the music-specific card.

--- a/app/src/main/java/com/music/bitchord/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlayerConnection.kt
@@ -91,8 +91,12 @@ fun rememberPlayerState(controller: MediaController?): PlayerState {
 
         val listener = object : Player.Listener {
             override fun onEvents(p: Player, events: Player.Events) = sync(state.error)
+            // PlaybackService re-resolves a spent stream URL and prepares
+            // again before this ever fires, so an error reaching the UI is one
+            // that survived those retries — worth telling the listener about,
+            // in their terms rather than Media3's.
             override fun onPlayerErrorChanged(error: androidx.media3.common.PlaybackException?) {
-                sync(error?.let { "Playback failed: ${it.errorCodeName}" })
+                sync(error?.let { "Couldn't play that track. Tap play to try again." })
             }
         }
         player.addListener(listener)

--- a/app/src/main/java/com/music/bitchord/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlayerConnection.kt
@@ -91,12 +91,8 @@ fun rememberPlayerState(controller: MediaController?): PlayerState {
 
         val listener = object : Player.Listener {
             override fun onEvents(p: Player, events: Player.Events) = sync(state.error)
-            // PlaybackService re-resolves a spent stream URL and prepares
-            // again before this ever fires, so an error reaching the UI is one
-            // that survived those retries — worth telling the listener about,
-            // in their terms rather than Media3's.
             override fun onPlayerErrorChanged(error: androidx.media3.common.PlaybackException?) {
-                sync(error?.let { "Couldn't play that track. Tap play to try again." })
+                sync(error?.let { "Playback failed: ${it.errorCodeName}" })
             }
         }
         player.addListener(listener)

--- a/app/src/main/java/com/music/bitchord/playback/SpatialAudioProcessor.kt
+++ b/app/src/main/java/com/music/bitchord/playback/SpatialAudioProcessor.kt
@@ -1,0 +1,116 @@
+package com.music.bitchord.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.BaseAudioProcessor
+import androidx.media3.common.util.UnstableApi
+import java.nio.ByteOrder
+import kotlin.math.roundToInt
+
+/**
+ * Cheap stand-in for "spatial audio": widens the mid/side image and mixes in
+ * a short, low-passed cross-feed between channels — the same trick most
+ * consumer virtual-surround plugins use. O(1) per sample, no FFT or
+ * convolution, so it costs nothing worth measuring on a phone CPU.
+ *
+ * Exists because the platform [android.media.audiofx.Virtualizer] produced no
+ * audible difference on the reference device — likely swallowed by the OEM's
+ * own audio effect chain — so this runs inside ExoPlayer's own audio
+ * processor pipeline instead, where nothing else can intercept it.
+ */
+@UnstableApi
+class SpatialAudioProcessor : BaseAudioProcessor() {
+
+    @Volatile
+    var enabled: Boolean = false
+
+    /** How much wider the stereo image gets. 1.0 = untouched. */
+    private val widthGain = 2.5f
+
+    /** Makeup attenuation after widening, so the wider side energy doesn't clip. */
+    private val outputGain = 0.82f
+
+    /** How much of the delayed, low-passed opposite channel gets mixed back in. */
+    private val crossfeedGain = 0.2f
+
+    /** One-pole lowpass factor applied to the cross-fed signal — dulls it, like a far ear would. */
+    private val lowpassCoeff = 0.3f
+
+    private var delayLeft = ShortArray(0)
+    private var delayRight = ShortArray(0)
+    private var delayIndex = 0
+    private var lowpassLeft = 0f
+    private var lowpassRight = 0f
+
+    override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
+        if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT || inputAudioFormat.channelCount != 2) {
+            throw AudioProcessor.UnhandledAudioFormatException(inputAudioFormat)
+        }
+        val delaySamples = (inputAudioFormat.sampleRate * DELAY_MS / 1000f)
+            .roundToInt()
+            .coerceAtLeast(1)
+        delayLeft = ShortArray(delaySamples)
+        delayRight = ShortArray(delaySamples)
+        delayIndex = 0
+        lowpassLeft = 0f
+        lowpassRight = 0f
+        return inputAudioFormat
+    }
+
+    override fun onFlush() {
+        delayLeft.fill(0)
+        delayRight.fill(0)
+        delayIndex = 0
+        lowpassLeft = 0f
+        lowpassRight = 0f
+    }
+
+    override fun queueInput(inputBuffer: java.nio.ByteBuffer) {
+        val frameCount = inputBuffer.remaining() / BYTES_PER_FRAME
+        if (frameCount == 0) return
+        val outputBuffer = replaceOutputBuffer(frameCount * BYTES_PER_FRAME)
+
+        if (!enabled) {
+            outputBuffer.put(inputBuffer)
+            outputBuffer.flip()
+            return
+        }
+
+        inputBuffer.order(ByteOrder.nativeOrder())
+        outputBuffer.order(ByteOrder.nativeOrder())
+
+        val delaySize = delayLeft.size
+        repeat(frameCount) {
+            val left = inputBuffer.short.toInt()
+            val right = inputBuffer.short.toInt()
+
+            val mid = (left + right) * 0.5f
+            val side = (left - right) * 0.5f * widthGain
+            var widenedLeft = mid + side
+            var widenedRight = mid - side
+
+            val delayedRight = delayRight[delayIndex].toFloat()
+            val delayedLeft = delayLeft[delayIndex].toFloat()
+            lowpassLeft += lowpassCoeff * (delayedRight - lowpassLeft)
+            lowpassRight += lowpassCoeff * (delayedLeft - lowpassRight)
+            widenedLeft += lowpassLeft * crossfeedGain
+            widenedRight += lowpassRight * crossfeedGain
+
+            delayLeft[delayIndex] = left.toShort()
+            delayRight[delayIndex] = right.toShort()
+            delayIndex = (delayIndex + 1) % delaySize
+
+            outputBuffer.putShort(clampToShort(widenedLeft * outputGain))
+            outputBuffer.putShort(clampToShort(widenedRight * outputGain))
+        }
+        outputBuffer.flip()
+    }
+
+    private fun clampToShort(value: Float): Short =
+        value.coerceIn(Short.MIN_VALUE.toFloat(), Short.MAX_VALUE.toFloat()).toInt().toShort()
+
+    private companion object {
+        const val BYTES_PER_FRAME = 4 // stereo, 16-bit
+        const val DELAY_MS = 15
+    }
+}

--- a/app/src/main/java/com/music/bitchord/ui/MainViewModel.kt
+++ b/app/src/main/java/com/music/bitchord/ui/MainViewModel.kt
@@ -20,13 +20,19 @@ import com.music.bitchord.data.model.SearchResult
 import com.music.bitchord.data.model.Song
 import com.music.bitchord.data.model.UiState
 import com.music.bitchord.data.settings.SearchHistory
+import android.util.LruCache
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
 
 class MainViewModel(app: Application) : AndroidViewModel(app) {
 
@@ -64,6 +70,34 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     /** Songs is the default tab; there is no "All" tab any more. */
     private val _filter = MutableStateFlow(SearchFilter.SONGS)
     val filter: StateFlow<SearchFilter> = _filter.asStateFlow()
+
+    // The search pipeline's own state. Declared here, above [init], because
+    // that is where the collector is started from and a property declared
+    // below it would still be null when it runs. See [startSearchPipeline].
+
+    /**
+     * Buffered so a keystroke is never lost, and [BufferOverflow.DROP_OLDEST]
+     * so a fast typist's backlog collapses to the query they ended on rather
+     * than being worked through one at a time.
+     */
+    private val searchRequests = MutableSharedFlow<SearchRequest>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    private val newestRequestId = AtomicLong(0L)
+
+    /**
+     * Results of recent searches, so a query typed before is answered without
+     * asking again.
+     *
+     * Its real work is [prefixMatch]: typing "blinding" runs through five
+     * queries on the way, and each one's results are a good enough answer for
+     * the next keystroke to be worth showing while the real one is in flight.
+     * That is the difference between a list that refines as you type and one
+     * that blanks to a spinner on every letter.
+     */
+    private val searchCache = LruCache<String, List<SearchResult>>(SEARCH_CACHE_ENTRIES)
 
     /** Synced lyrics for whatever is playing; null while unknown or absent. */
     private val _lyrics = MutableStateFlow<List<LyricLine>?>(null)
@@ -112,12 +146,12 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     private val _detailStack = MutableStateFlow<List<DetailPage>>(emptyList())
     val detailStack: StateFlow<List<DetailPage>> = _detailStack.asStateFlow()
 
-    private var searchJob: Job? = null
 
     /** Set once per launch if GitHub has a release newer than this build. */
     val updateAvailable: StateFlow<AppUpdateChecker.UpdateInfo?> = AppUpdateChecker.available
 
     init {
+        startSearchPipeline()
         loadHome()
         loadExplore()
         if (_signedIn.value) {
@@ -270,7 +304,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
     fun onQueryChange(value: String) {
         _query.value = value
-        runSearch(debounce = true)
+        runSearch()
     }
 
     /**
@@ -285,7 +319,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     fun searchFor(term: String) {
         _query.value = term
         SearchHistory.record(term)
-        runSearch(debounce = false)
+        runSearch()
     }
 
     fun removeSearch(term: String) = SearchHistory.remove(term)
@@ -295,26 +329,97 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     fun onFilterChange(value: SearchFilter) {
         if (_filter.value == value) return
         _filter.value = value
-        runSearch(debounce = false)
+        runSearch()
     }
 
-    private fun runSearch(debounce: Boolean) {
-        val value = _query.value
-        searchJob?.cancel()
-        if (value.isBlank()) {
+    /**
+     * Every keystroke, as a request the pipeline below decides what to do with.
+     *
+     * [requestId] is what makes a late answer harmless: a response is only
+     * written to the screen if its id is still the newest one asked for.
+     */
+    private data class SearchRequest(val query: String, val filter: SearchFilter, val requestId: Long)
+
+    private fun cacheKey(query: String, filter: SearchFilter) = "${filter.name}:$query"
+
+    /**
+     * The results of the longest earlier query this one starts with — what was
+     * on screen a keystroke ago, near enough to leave up meanwhile.
+     */
+    private fun prefixMatch(query: String, filter: SearchFilter): List<SearchResult>? {
+        val prefix = "${filter.name}:"
+        return searchCache.snapshot()
+            .filterKeys { it.startsWith(prefix) && query.startsWith(it.removePrefix(prefix), true) }
+            .maxByOrNull { it.key.length }
+            ?.value
+    }
+
+    private fun runSearch() {
+        val query = _query.value
+        if (query.isBlank()) {
+            // Nothing in flight can still be waiting to overwrite this: the
+            // id it would be checked against has already moved past it.
+            newestRequestId.incrementAndGet()
             _results.value = null
             return
         }
-        _results.value = UiState.Loading
-        searchJob = viewModelScope.launch {
-            if (debounce) delay(350) // debounce keystrokes
-            _results.value = YtMusicRepository.search(value, _filter.value).fold(
-                onSuccess = { rows ->
-                    if (rows.isEmpty()) UiState.Error("No results") else UiState.Success(rows)
-                },
-                onFailure = { UiState.Error(it.friendly()) },
-            )
-        }
+        val id = newestRequestId.incrementAndGet()
+        searchRequests.tryEmit(SearchRequest(query, _filter.value, id))
+    }
+
+    /**
+     * The search pipeline, started once and left running for the lifetime of
+     * the view model.
+     *
+     * The point of it being one long-lived collector is that a keystroke no
+     * longer cancels the request before it. Cancelling a call mid-flight tears
+     * down its socket, and on a pooled HTTP client that is felt by whatever
+     * picks that connection up next — which is how typing a word could end in
+     * "Software caused connection abort" for a request that was never itself
+     * in any trouble. [debounce] collapses a burst of keystrokes into one
+     * query before any request is made, and [collectLatest] only abandons a
+     * search once a genuinely newer one has survived that window.
+     */
+    @OptIn(FlowPreview::class)
+    private fun startSearchPipeline() = viewModelScope.launch {
+        searchRequests
+            .debounce(SEARCH_DEBOUNCE_MS)
+            .collectLatest { request ->
+                val key = cacheKey(request.query, request.filter)
+                // Something to look at immediately: the exact answer if this
+                // query has been run before, otherwise the closest earlier
+                // one. Only fall back to a spinner with neither.
+                val exact = searchCache.get(key)
+                val cached = exact ?: prefixMatch(request.query, request.filter)
+                _results.value = cached?.let { UiState.Success(it) } ?: UiState.Loading
+                if (exact != null) return@collectLatest
+
+                val result = YtMusicRepository.search(request.query, request.filter)
+                // A search the user has already typed past shouldn't land on
+                // screen, whether it succeeded or failed.
+                if (request.requestId != newestRequestId.get()) return@collectLatest
+                _results.value = result.fold(
+                    onSuccess = { rows ->
+                        if (rows.isEmpty()) {
+                            UiState.Error("No results")
+                        } else {
+                            searchCache.put(key, rows)
+                            UiState.Success(rows)
+                        }
+                    },
+                    onFailure = { UiState.Error(it.friendly()) },
+                )
+            }
+    }
+
+    private companion object {
+        /**
+         * Short enough that it reads as instant, long enough that a word typed
+         * at speed is one request rather than one per letter.
+         */
+        const val SEARCH_DEBOUNCE_MS = 80L
+
+        const val SEARCH_CACHE_ENTRIES = 100
     }
 
     fun openDetail(
@@ -341,6 +446,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
             // own picture and name once they arrive.
             var artwork: String? = null
             var name: String? = null
+            /** Set when the track list carries on past its first response. */
+            var more: String? = null
             val state = if (resolved == BrowseType.ARTIST) {
                 YtMusicRepository.artistPage(browseId).fold(
                     onSuccess = { page ->
@@ -357,11 +464,12 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
                 )
             } else {
                 YtMusicRepository.browseSongs(browseId).fold(
-                    onSuccess = { songs ->
-                        if (songs.isEmpty()) {
+                    onSuccess = { page ->
+                        if (page.songs.isEmpty()) {
                             UiState.Error("No tracks here")
                         } else {
-                            UiState.Success(songs.withArtwork(thumbnailUrl))
+                            more = page.continuation
+                            UiState.Success(page.songs.withArtwork(thumbnailUrl))
                         }
                     },
                     onFailure = { UiState.Error(it.friendly()) },
@@ -379,6 +487,48 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
                 } else {
                     it
                 }
+            }
+            // Only once the first page is on screen: [fillIn] appends to it,
+            // and has nothing to append to before this.
+            more?.let { fillIn(browseId, it, thumbnailUrl) }
+        }
+    }
+
+    /**
+     * Follows a detail page's continuations in the background, appending each
+     * page to what is already being read.
+     *
+     * A playlist of a few hundred tracks is several round trips, and taking
+     * them before showing anything meant a spinner for all of them. Growing
+     * the list underneath the reader is also what makes it safe to keep
+     * following continuations [YtMusicRepository.MAX_PAGES] deep — nobody is
+     * waiting on the last one.
+     *
+     * Stops the moment the page leaves the stack: there is no one to append
+     * for.
+     */
+    private fun fillIn(browseId: String, token: String, artworkFallback: String?) {
+        viewModelScope.launch {
+            var next: String? = token
+            var page = 1
+            while (next != null && page++ < YtMusicRepository.MAX_PAGES) {
+                val fetched = YtMusicRepository.moreSongs(next).getOrNull() ?: return@launch
+                val stack = _detailStack.value
+                val index = stack.indexOfFirst { it.browseId == browseId }
+                if (index < 0) return@launch
+                val current = stack[index]
+                val existing = (current.songs as? UiState.Success)?.data ?: return@launch
+                val known = existing.mapTo(HashSet()) { it.videoId }
+                val added = fetched.songs
+                    .filter { known.add(it.videoId) }
+                    .withArtwork(artworkFallback)
+                // A page with nothing new on it means the feed has looped back
+                // rather than run dry with a token still attached.
+                if (added.isEmpty()) return@launch
+                _detailStack.value = stack.toMutableList().also {
+                    it[index] = current.copy(songs = UiState.Success(existing + added))
+                }
+                next = fetched.continuation
             }
         }
     }

--- a/app/src/main/java/com/music/bitchord/ui/components/BottomFadeBlur.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/BottomFadeBlur.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.music.bitchord.data.settings.AppSettings
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
@@ -52,6 +54,11 @@ fun BottomFadeBlur(
     modifier: Modifier = Modifier,
     withMiniPlayer: Boolean = false,
 ) {
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
+    // The floating bars fill themselves solid instead when blur is reduced,
+    // so this frosted floor underneath them has nothing left to do.
+    if (reduceDynamicBlur) return
+
     // The gesture bar sits below the tab pill and wants blurring too, so it is
     // added on rather than being part of the fade's own run.
     val inset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()

--- a/app/src/main/java/com/music/bitchord/ui/components/Common.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/Common.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -39,7 +38,31 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.music.bitchord.data.model.ROW_ART_PX
 import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.model.artworkAt
+
+/**
+ * The left and right inset every page's content sits at.
+ *
+ * It is the same inset the mini player and the tab bar float at, so the edge of
+ * a track row, a card or a heading lines up with the edge of the bars stacked
+ * below them rather than stepping in from them. One constant, shared by the
+ * bars and the pages, is what keeps that true.
+ */
+val PAGE_GUTTER = 10.dp
+
+/** Where a divider under a track row starts: clear of the 52dp of artwork. */
+val ROW_DIVIDER_INSET = PAGE_GUTTER + 68.dp
+
+/**
+ * Width of a card in the compact carousels — home shelves, library shelves and
+ * the artist page's releases alike.
+ *
+ * Sized so a phone-width row shows two cards whole with the edge of a third
+ * showing: enough to say the row scrolls without a card being half a card.
+ */
+val SHELF_CARD_WIDTH = 150.dp
 
 /**
  * One track row, used by search, library and detail pages.
@@ -92,7 +115,7 @@ private fun QueueSwipeBackground() {
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.18f))
-            .padding(horizontal = 26.dp, vertical = 8.dp),
+            .padding(horizontal = PAGE_GUTTER + 6.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -131,11 +154,11 @@ private fun SongRowContent(
         modifier = modifier
             .fillMaxWidth()
             .combinedClickable(onClick = onClick, onLongClick = onLongPress)
-            .padding(horizontal = 20.dp, vertical = 8.dp),
+            .padding(horizontal = PAGE_GUTTER, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(
-            model = song.thumbnailUrl,
+            model = song.artworkAt(ROW_ART_PX),
             contentDescription = null,
             modifier = Modifier
                 .size(52.dp)
@@ -217,24 +240,13 @@ fun PullToRefresh(
     }
 }
 
-@Composable
-fun LoadingState(modifier: Modifier = Modifier) {
-    Box(modifier.fillMaxWidth().padding(48.dp), contentAlignment = Alignment.Center) {
-        CircularProgressIndicator(
-            color = MaterialTheme.colorScheme.primary,
-            strokeWidth = 2.5.dp,
-            modifier = Modifier.size(28.dp),
-        )
-    }
-}
-
 /** Slim dismissible-looking prompt shown atop Home while signed out. */
 @Composable
 fun SignInBanner(onSignIn: () -> Unit, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .padding(horizontal = PAGE_GUTTER, vertical = 8.dp)
             .clip(RoundedCornerShape(16.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant)
             .clickable(onClick = onSignIn)
@@ -270,7 +282,7 @@ fun MessageState(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 32.dp, vertical = 48.dp),
+            .padding(horizontal = PAGE_GUTTER + 12.dp, vertical = 48.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/app/src/main/java/com/music/bitchord/ui/components/FloatingBottomBar.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/FloatingBottomBar.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.music.bitchord.data.settings.AppSettings
 
 data class BottomTab(
     val label: String,
@@ -60,7 +62,14 @@ fun FloatingBottomBar(
     // Fully rounded ends, whatever the bar's height works out to.
     val pillShape = RoundedCornerShape(percent = 50)
     val container = MaterialTheme.colorScheme.surface
-    val glass = container.copy(alpha = if (container.luminance() >= 0.5f) 0.6f else 0.65f)
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
+    // With the frosted floor beneath it gone, the pill needs a solid fill of
+    // its own instead of a tint meant to sit on top of that blur.
+    val glass = if (reduceDynamicBlur) {
+        container
+    } else {
+        container.copy(alpha = if (container.luminance() >= 0.5f) 0.6f else 0.65f)
+    }
     Row(
         modifier = modifier
             .navigationBarsPadding()

--- a/app/src/main/java/com/music/bitchord/ui/components/FloatingBottomBar.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/FloatingBottomBar.kt
@@ -73,7 +73,7 @@ fun FloatingBottomBar(
     Row(
         modifier = modifier
             .navigationBarsPadding()
-            .padding(horizontal = 10.dp)
+            .padding(horizontal = PAGE_GUTTER)
             // Sits close to the gesture bar, Apple-style.
             .padding(bottom = 2.dp)
             .fillMaxWidth()

--- a/app/src/main/java/com/music/bitchord/ui/components/FrostedTopBar.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/FrostedTopBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -34,8 +35,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.music.bitchord.BuildConfig
 import com.music.bitchord.R
+import com.music.bitchord.data.settings.AppSettings
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
@@ -75,13 +78,20 @@ fun FrostedTopBar(
         animationSpec = tween(220),
         label = "topBarDivider",
     )
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
 
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .hazeEffect(
-                state = hazeState,
-                style = HazeMaterials.ultraThin(MaterialTheme.colorScheme.surface),
+            .then(
+                if (reduceDynamicBlur) {
+                    Modifier.background(MaterialTheme.colorScheme.surface)
+                } else {
+                    Modifier.hazeEffect(
+                        state = hazeState,
+                        style = HazeMaterials.ultraThin(MaterialTheme.colorScheme.surface),
+                    )
+                },
             ),
     ) {
         Box(

--- a/app/src/main/java/com/music/bitchord/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/MiniPlayer.kt
@@ -22,14 +22,17 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.settings.AppSettings
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
@@ -64,12 +67,19 @@ fun MiniPlayer(
     onExpand: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
     val shape = RoundedCornerShape(BAR_CORNER)
     Box(
         modifier = modifier
             .padding(horizontal = 10.dp)
             .clip(shape)
-            .hazeEffect(state = hazeState, style = HazeMaterials.thin(MaterialTheme.colorScheme.surface))
+            .then(
+                if (reduceDynamicBlur) {
+                    Modifier.background(MaterialTheme.colorScheme.surface)
+                } else {
+                    Modifier.hazeEffect(state = hazeState, style = HazeMaterials.thin(MaterialTheme.colorScheme.surface))
+                },
+            )
             .border(0.5.dp, Color.White.copy(alpha = 0.10f), shape)
             .clickable(onClick = onExpand),
     ) {

--- a/app/src/main/java/com/music/bitchord/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/MiniPlayer.kt
@@ -31,7 +31,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.music.bitchord.data.model.ROW_ART_PX
 import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.model.artworkAt
 import com.music.bitchord.data.settings.AppSettings
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
@@ -71,7 +73,7 @@ fun MiniPlayer(
     val shape = RoundedCornerShape(BAR_CORNER)
     Box(
         modifier = modifier
-            .padding(horizontal = 10.dp)
+            .padding(horizontal = PAGE_GUTTER)
             .clip(shape)
             .then(
                 if (reduceDynamicBlur) {
@@ -90,7 +92,7 @@ fun MiniPlayer(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             AsyncImage(
-                model = song.thumbnailUrl,
+                model = song.artworkAt(ROW_ART_PX),
                 contentDescription = null,
                 modifier = Modifier
                     .size(40.dp)

--- a/app/src/main/java/com/music/bitchord/ui/components/Skeletons.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/Skeletons.kt
@@ -1,0 +1,284 @@
+package com.music.bitchord.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Grey stand-ins for content still on the wire, laid out to the same metrics as
+ * the real rows and cards so nothing jumps when the data lands.
+ */
+
+/** How long one highlight sweep takes to cross a placeholder. */
+private const val SHIMMER_PERIOD_MS = 1400
+
+private val BlockShape = RoundedCornerShape(6.dp)
+private val LineShape = RoundedCornerShape(4.dp)
+
+// Ragged widths, so a run of rows reads as text rather than as a barcode.
+private val TitleWidths = listOf(0.68f, 0.46f, 0.58f, 0.74f, 0.52f)
+private val SubtitleWidths = listOf(0.34f, 0.44f, 0.27f, 0.38f, 0.31f)
+
+/**
+ * One placeholder block, with a highlight sweeping across it.
+ *
+ * The sweep is read inside the draw block rather than the composable body: a
+ * screenful of these would otherwise recompose on every animation frame, and
+ * all any of them needs per frame is a fresh gradient.
+ */
+@Composable
+fun ShimmerBox(modifier: Modifier = Modifier, shape: Shape = BlockShape) {
+    val base = MaterialTheme.colorScheme.surfaceVariant
+    val highlight = MaterialTheme.colorScheme.onSurfaceVariant
+        .copy(alpha = 0.16f)
+        .compositeOver(base)
+    val sweep = rememberInfiniteTransition(label = "skeleton").animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(SHIMMER_PERIOD_MS, easing = LinearEasing)),
+        label = "sweep",
+    )
+    Box(
+        modifier
+            .clip(shape)
+            .drawWithCache {
+                // The band travels from fully off one edge to fully off the
+                // other, which leaves a beat of flat grey between passes rather
+                // than a highlight permanently parked somewhere on the block.
+                val band = size.width * 0.5f
+                val startX = -band + sweep.value * (size.width + band * 2)
+                val brush = Brush.horizontalGradient(
+                    colors = listOf(base, highlight, base),
+                    startX = startX,
+                    endX = startX + band,
+                )
+                onDrawBehind { drawRect(brush) }
+            },
+    )
+}
+
+/** A placeholder for one line of text, sized as a fraction of its parent. */
+@Composable
+private fun SkeletonLine(fraction: Float, height: Dp, modifier: Modifier = Modifier) {
+    ShimmerBox(
+        modifier = modifier.fillMaxWidth(fraction).height(height),
+        shape = LineShape,
+    )
+}
+
+/**
+ * Stands in for a section heading. Only the title line is drawn — most shelves
+ * come back without a subtitle, and guessing wrong shifts everything under it.
+ */
+@Composable
+private fun SectionHeaderSkeleton(index: Int = 0) {
+    Column(Modifier.padding(horizontal = PAGE_GUTTER, vertical = 10.dp)) {
+        SkeletonLine(fraction = TitleWidths[index % TitleWidths.size] * 0.7f, height = 18.dp)
+    }
+}
+
+/**
+ * Stands in for one `SongRow`, down to the 52dp of artwork and the 20dp gutter.
+ * [circular] matches the browse rows, where artists are drawn as circles.
+ */
+@Composable
+fun SongRowSkeleton(index: Int = 0, circular: Boolean = false, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = PAGE_GUTTER, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ShimmerBox(Modifier.size(52.dp), if (circular) CircleShape else RoundedCornerShape(8.dp))
+        Spacer(Modifier.width(14.dp))
+        Column(Modifier.weight(1f)) {
+            SkeletonLine(fraction = TitleWidths[index % TitleWidths.size], height = 14.dp)
+            Spacer(Modifier.height(7.dp))
+            SkeletonLine(fraction = SubtitleWidths[index % SubtitleWidths.size], height = 11.dp)
+        }
+    }
+}
+
+/** A run of track-row placeholders, for search hits and release track lists. */
+fun LazyListScope.songListSkeleton(
+    count: Int = 8,
+    keyPrefix: String = "skeleton:song",
+    circular: Boolean = false,
+) {
+    items(count, key = { "$keyPrefix:$it" }) { index ->
+        SongRowSkeleton(index = index, circular = circular)
+    }
+}
+
+/**
+ * The lead shelf on Home and Explore: near-page-width cards that page sideways.
+ *
+ * Both carousels below are built on a [LazyRow] with scrolling off rather than a
+ * plain [Row], so a card running past the right edge is measured and clipped
+ * exactly as the real shelf's is — which is the whole point of a skeleton.
+ */
+@Composable
+private fun HeroShelfSkeleton() {
+    Column(Modifier.padding(bottom = 26.dp)) {
+        SectionHeaderSkeleton()
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = PAGE_GUTTER),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            userScrollEnabled = false,
+        ) {
+            items(2) {
+                ShimmerBox(
+                    modifier = Modifier.fillParentMaxWidth(0.82f).aspectRatio(0.92f),
+                    shape = RoundedCornerShape(18.dp),
+                )
+            }
+        }
+    }
+}
+
+/** The compact carousel of square cards used by every shelf below the first. */
+@Composable
+fun ShelfSkeleton(index: Int = 0, cardWidth: Dp = SHELF_CARD_WIDTH, cardCorner: Dp = 12.dp) {
+    Column(Modifier.padding(bottom = 26.dp)) {
+        SectionHeaderSkeleton(index = index)
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = PAGE_GUTTER),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            userScrollEnabled = false,
+        ) {
+            items(3) { card ->
+                Column(Modifier.width(cardWidth)) {
+                    ShimmerBox(
+                        modifier = Modifier.width(cardWidth).aspectRatio(1f),
+                        shape = RoundedCornerShape(cardCorner),
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    SkeletonLine(fraction = TitleWidths[card % TitleWidths.size], height = 13.dp)
+                    Spacer(Modifier.height(6.dp))
+                    SkeletonLine(fraction = SubtitleWidths[card % SubtitleWidths.size], height = 11.dp)
+                }
+            }
+        }
+    }
+}
+
+/** Home and Explore while the first page of shelves is still loading. */
+fun LazyListScope.feedSkeleton(shelves: Int = 3) {
+    item(key = "skeleton:hero") { HeroShelfSkeleton() }
+    items(shelves - 1, key = { "skeleton:shelf:$it" }) { index ->
+        ShelfSkeleton(index = index + 1)
+    }
+}
+
+/** Appended to the feed while a further page of shelves is on its way. */
+fun LazyListScope.feedMoreSkeleton() {
+    item(key = "skeleton:more") { ShelfSkeleton() }
+}
+
+/** The signed-in library: saved collections, then the run of liked tracks. */
+fun LazyListScope.librarySkeleton() {
+    item(key = "skeleton:library:shelf") { ShelfSkeleton() }
+    item(key = "skeleton:library:header") { SectionHeaderSkeleton(index = 1) }
+    songListSkeleton(count = 7, keyPrefix = "skeleton:library:song")
+}
+
+/** The Play / Shuffle pair, which only appears once there is something to play. */
+@Composable
+private fun DetailActionsSkeleton() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = PAGE_GUTTER, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        repeat(2) {
+            ShimmerBox(
+                modifier = Modifier.weight(1f).height(40.dp),
+                shape = RoundedCornerShape(percent = 50),
+            )
+        }
+    }
+}
+
+/**
+ * An album, playlist or artist page below its header — the header itself is
+ * drawn from what the row that was tapped already knew, so it never waits.
+ */
+fun LazyListScope.detailSkeleton(isArtist: Boolean) {
+    if (isArtist) {
+        item(key = "skeleton:detail:top") {
+            Column {
+                SectionHeaderSkeleton()
+                // Top songs page four at a time, in columns 88% of the width.
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = PAGE_GUTTER),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    userScrollEnabled = false,
+                ) {
+                    item {
+                        Column(Modifier.fillParentMaxWidth(0.88f)) {
+                            repeat(4) { index -> CompactSongRowSkeleton(index) }
+                        }
+                    }
+                }
+            }
+        }
+        item(key = "skeleton:detail:sections") {
+            ShelfSkeleton(index = 2, cardCorner = 10.dp)
+        }
+        return
+    }
+    item(key = "skeleton:detail:actions") {
+        Column {
+            DetailActionsSkeleton()
+            Spacer(Modifier.height(10.dp))
+        }
+    }
+    songListSkeleton(count = 8, keyPrefix = "skeleton:detail:song")
+}
+
+/** The tighter row used inside the artist page's top-songs pager. */
+@Composable
+private fun CompactSongRowSkeleton(index: Int) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ShimmerBox(Modifier.size(48.dp), RoundedCornerShape(7.dp))
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            SkeletonLine(fraction = TitleWidths[index % TitleWidths.size], height = 14.dp)
+            Spacer(Modifier.height(6.dp))
+            SkeletonLine(fraction = SubtitleWidths[index % SubtitleWidths.size], height = 11.dp)
+        }
+    }
+}

--- a/app/src/main/java/com/music/bitchord/ui/components/SongActionsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/SongActionsSheet.kt
@@ -40,7 +40,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.music.bitchord.data.model.ROW_ART_PX
 import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.model.artworkAt
 import com.music.bitchord.playback.SleepTimer
 import kotlinx.coroutines.delay
 
@@ -76,7 +78,7 @@ fun SongActionsSheet(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             AsyncImage(
-                model = song.thumbnailUrl,
+                model = song.artworkAt(ROW_ART_PX),
                 contentDescription = null,
                 modifier = Modifier
                     .size(52.dp)

--- a/app/src/main/java/com/music/bitchord/ui/components/UpdateAvailableDialog.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/UpdateAvailableDialog.kt
@@ -1,0 +1,189 @@
+package com.music.bitchord.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.music.bitchord.data.settings.AppSettings
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
+
+/** UIAlertController's own metrics: fixed narrow width, 14pt corner, 44pt rows. */
+private val ALERT_WIDTH = 270.dp
+private val ALERT_CORNER = 14.dp
+private val ACTION_HEIGHT = 44.dp
+
+/**
+ * The dim behind the alert. Flat on purpose — the glass is the card, and
+ * blurring the wallpaper *behind* it too leaves nothing for the card to be
+ * frosted against, which is what made this read as a grey box before.
+ */
+private val SCRIM_COLOR = Color.Black.copy(alpha = 0.28f)
+
+/**
+ * Once-per-launch nudge that a newer build is on GitHub Releases — the top
+ * bar's [Icons.Rounded.SystemUpdate][androidx.compose.material.icons.rounded.SystemUpdate]
+ * icon is the quiet, always-there version of this; this is the one-time,
+ * hard-to-miss version shown the moment the check comes back.
+ *
+ * Shaped like an iOS system alert, which is the same lineage as the rest of the
+ * app's Apple Music styling: frosted card, hairline rules, full-width actions
+ * stacked under the message rather than a Material button pair in the corner.
+ *
+ * Sits over the whole app as an overlay rather than an Android [Dialog][androidx.compose.ui.window.Dialog]
+ * so its glass can sample the same [HazeState] the rest of the app's frosted
+ * surfaces use, the way [FrostedTopBar] and [MiniPlayer] already do.
+ */
+@OptIn(ExperimentalHazeMaterialsApi::class)
+@Composable
+fun UpdateAvailableDialog(
+    version: String,
+    hazeState: HazeState,
+    onDismiss: () -> Unit,
+    onUpdate: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
+    val shape = RoundedCornerShape(ALERT_CORNER)
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(SCRIM_COLOR)
+            // Tapping the scrim reads the same as Remind Me Later — nothing
+            // about this update is mandatory, so backing out of it should be as
+            // easy as getting into it.
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = onDismiss,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .width(ALERT_WIDTH)
+                .clip(shape)
+                .then(
+                    if (reduceDynamicBlur) {
+                        Modifier.background(MaterialTheme.colorScheme.surface)
+                    } else {
+                        Modifier.hazeEffect(state = hazeState, style = HazeMaterials.regular(MaterialTheme.colorScheme.surface))
+                    },
+                )
+                // Swallows the tap before it reaches the scrim behind, so
+                // touching the card itself never dismisses it.
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = {},
+                ),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 19.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = "Software Update",
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.W600,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "BitChord $version is available to download.",
+                    modifier = Modifier.padding(top = 4.dp),
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontSize = 13.sp,
+                        lineHeight = 17.sp,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            AlertRule()
+            AlertAction(label = "Download Now", emphasised = true, onClick = onUpdate)
+            AlertRule()
+            AlertAction(label = "Remind Me Later", emphasised = false, onClick = onDismiss)
+        }
+    }
+}
+
+/**
+ * Full-bleed action row. Tinted rather than filled, so the two read as equals
+ * in weight and only the font differentiates the default action — the alert's
+ * whole point is that neither choice is a trap.
+ */
+@Composable
+private fun AlertAction(
+    label: String,
+    emphasised: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(ACTION_HEIGHT)
+            // iOS washes the whole row instead of drawing a ripple inside it.
+            .background(
+                if (pressed) MaterialTheme.colorScheme.onSurface.copy(alpha = 0.09f) else Color.Transparent,
+            )
+            .clickable(
+                indication = null,
+                interactionSource = interactionSource,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontSize = 17.sp,
+                fontWeight = if (emphasised) FontWeight.W600 else FontWeight.W400,
+            ),
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+/** Hairline separator — [HorizontalDivider][androidx.compose.material3.HorizontalDivider]'s 1dp reads as a bar at this scale. */
+@Composable
+private fun AlertRule() {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .height(0.5.dp)
+            .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f)),
+    )
+}

--- a/app/src/main/java/com/music/bitchord/ui/player/MeshGradient.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/MeshGradient.kt
@@ -3,7 +3,9 @@ package com.music.bitchord.ui.player
 import android.graphics.Bitmap
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -25,12 +27,14 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.ColorUtils
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.palette.graphics.Palette
 import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
 import coil3.toBitmap
+import com.music.bitchord.data.settings.AppSettings
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.cos
@@ -67,24 +71,32 @@ fun MeshGradientBackground(
     trackKey: Any? = null,
     driftMillis: Int = 8_000,
 ) {
+    val reduceAnimation by AppSettings.reduceAnimation.collectAsStateWithLifecycle()
+
     val tuned = (palette.colors.ifEmpty { FallbackColors } + FallbackColors)
         .take(4)
         .map { it.tuned() }
 
-    // Each colour slot crossfades independently when the track (palette) changes.
+    // Each colour slot crossfades independently when the track (palette) changes,
+    // unless "reduce animation" is on, in which case colours snap straight to target.
+    val colorSpec: AnimationSpec<Color> = if (reduceAnimation) snap() else tween(1400)
     val animatedColors = tuned.mapIndexed { index, color ->
-        animateColorAsState(color, tween(1400), label = "meshColor$index").value
+        animateColorAsState(color, colorSpec, label = "meshColor$index").value
     }
-    val baseColor by animateColorAsState(tuned.first().dimmed(), tween(1400), label = "meshBase")
+    val baseColor by animateColorAsState(tuned.first().dimmed(), colorSpec, label = "meshBase")
 
     // Read in the draw lambda, not here: an Animatable read during draw
     // invalidates only the drawing, leaving composition out of the loop.
     val phase = remember { Animatable(0f) }
-    LaunchedEffect(trackKey) {
-        phase.animateTo(
-            targetValue = phase.value + DRIFT_RADIANS,
-            animationSpec = tween(driftMillis, easing = FastOutSlowInEasing),
-        )
+    LaunchedEffect(trackKey, reduceAnimation) {
+        if (reduceAnimation) {
+            phase.snapTo(0f)
+        } else {
+            phase.animateTo(
+                targetValue = phase.value + DRIFT_RADIANS,
+                animationSpec = tween(driftMillis, easing = FastOutSlowInEasing),
+            )
+        }
     }
 
     // Scale up slightly so the blur's clamped edges never show, then blur the

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -923,6 +923,7 @@ private fun LyricsPanel(
     val listState = rememberLazyListState()
     val keepScroll = remember(listState) { keepScrollInList(listState) }
     var browsing by remember { mutableStateOf(false) }
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
 
     // Only a finger on the list counts as browsing — watching
     // isScrollInProgress would trip on our own auto-scroll.
@@ -1004,7 +1005,7 @@ private fun LyricsPanel(
             // padding, so there is room for the spill.
             val blur by animateDpAsState(
                 targetValue = when {
-                    browsing || isActive -> 0.dp
+                    reduceDynamicBlur || browsing || isActive -> 0.dp
                     else -> (distance * 1.6f).coerceAtMost(7f).dp
                 },
                 label = "lyricBlur",

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.DragInteraction
@@ -52,6 +53,7 @@ import androidx.compose.material.icons.automirrored.rounded.VolumeDown
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.Cast
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FastRewind
 import androidx.compose.material.icons.rounded.GraphicEq
@@ -103,6 +105,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
 import androidx.media3.common.Player
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
@@ -118,6 +121,7 @@ import com.music.bitchord.playback.BACK_RESTARTS_AFTER_MS
 import com.music.bitchord.playback.autoplaySectionStart
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /** Collapsed-header geometry, shared by the layout and its animation. */
@@ -286,6 +290,7 @@ fun NowPlayingScreen(
     onToggleAutoplay: () -> Unit,
     onJumpTo: (Int) -> Unit,
     onRemoveFromQueue: (Int) -> Unit,
+    onMoveInQueue: (Int, Int) -> Unit,
     onClearQueue: () -> Unit,
     onOpenMenu: () -> Unit,
     onOpenAlbum: (String) -> Unit,
@@ -685,6 +690,7 @@ fun NowPlayingScreen(
                             autoplayEnabled = autoplayEnabled,
                             onJumpTo = onJumpTo,
                             onRemove = onRemoveFromQueue,
+                            onMove = onMoveInQueue,
                             onClear = onClearQueue,
                             modifier = Modifier.weight(1f),
                         )
@@ -1386,6 +1392,7 @@ private fun InlineQueue(
     autoplayEnabled: Boolean,
     onJumpTo: (Int) -> Unit,
     onRemove: (Int) -> Unit,
+    onMove: (Int, Int) -> Unit,
     onClear: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -1403,6 +1410,46 @@ private fun InlineQueue(
             listState.scrollToItem(currentIndex + if (currentIndex >= autoplayStart) 1 else 0)
         }
     }
+
+    // Each section reorders on its own — a drag never crosses the line
+    // between what was queued by hand and what AutoPlay picked, same as
+    // [addToQueue] and [playNext] already respect it.
+    //
+    // Both draw straight from the live [queue], never from a snapshot taken
+    // when the drag began: the boundary between the sections moves on its own
+    // as tracks play, so a frozen copy of either one goes stale the moment it
+    // does — AutoPlay's section would keep listing tracks that have long
+    // since played, and the row indices behind `onJumpTo`/`onRemove` would
+    // start pointing at the wrong songs. Each swap is sent to the player as
+    // it happens instead, and the rows animate into place off the live order.
+    val manualRows = queue.subList(0, autoplayStart)
+    val autoplayRows = queue.subList(autoplayStart, queue.size)
+    // A song can be queued twice, so videoId alone isn't always a unique key
+    // — LazyColumn throws on a repeat. Suffixing by how many times that id
+    // has already been seen keeps every key unique while staying stable
+    // across a reorder, which plain videoId+index (the previous key) wasn't:
+    // that changed on every swap and silently broke animateItem's ability to
+    // tell "this row moved" from "this row was replaced".
+    val manualKeys = remember(manualRows) { manualRows.stableQueueKeys() }
+    val autoplayKeys = remember(autoplayRows) { autoplayRows.stableQueueKeys("autoplay/") }
+
+    // The heading is a row of the same LazyColumn, so it shifts every
+    // AutoPlay index below it along by one — hence the offset back to queue
+    // indices, which is what [onMove] and the rest of the callbacks take.
+    val headingShown = autoplayEnabled || autoplayStart < queue.size
+    val headingCount = if (headingShown) 1 else 0
+    val manualDrag = rememberQueueDragState(
+        listState = listState,
+        lazyRange = 0 until autoplayStart,
+        lazyOffset = 0,
+        onMove = onMove,
+    )
+    val autoplayDrag = rememberQueueDragState(
+        listState = listState,
+        lazyRange = (autoplayStart + headingCount) until (autoplayStart + headingCount + autoplayRows.size),
+        lazyOffset = headingCount,
+        onMove = onMove,
+    )
 
     Column(modifier.fillMaxWidth()) {
         Row(
@@ -1439,18 +1486,37 @@ private fun InlineQueue(
         ) {
             // What was asked for: the album, playlist or station the queue was
             // started from, plus anything queued by hand since.
-            itemsIndexed(queue.subList(0, autoplayStart)) { index, song ->
+            itemsIndexed(
+                items = manualRows,
+                key = { index, _ -> manualKeys[index] },
+            ) { index, song ->
+                val key = manualKeys[index]
+                val dragging = manualDrag.draggedKey == key
                 InlineQueueRow(
                     song = song,
                     isCurrent = index == currentIndex,
                     onClick = { onJumpTo(index) },
                     onRemove = { onRemove(index) },
+                    // Everything but the track playing right now. Moving that
+                    // one shifts the very boundary the sections are drawn from,
+                    // which would resize this section mid-gesture.
+                    draggable = index != currentIndex,
+                    dragging = dragging,
+                    onDragStart = { manualDrag.onDragStart(key) },
+                    onDrag = manualDrag::onDrag,
+                    onDragEnd = manualDrag::onDragEnd,
+                    modifier = Modifier
+                        .zIndex(if (dragging) 1f else 0f)
+                        .graphicsLayer { translationY = if (dragging) manualDrag.dragOffset else 0f }
+                        // The dragged row follows the finger, so it is the one
+                        // row that must not also be animating to a slot.
+                        .then(if (dragging) Modifier else Modifier.animateItem()),
                 )
             }
             // Heading first, then what AutoPlay has lined up under it. With
             // nothing lined up yet it closes the queue as a promise instead.
             if (autoplayEnabled || autoplayStart < queue.size) {
-                item {
+                item(key = "autoplay-heading") {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -1483,16 +1549,129 @@ private fun InlineQueue(
                     }
                 }
             }
-            itemsIndexed(queue.subList(autoplayStart, queue.size)) { index, song ->
+            itemsIndexed(
+                items = autoplayRows,
+                key = { index, _ -> autoplayKeys[index] },
+            ) { index, song ->
                 val at = autoplayStart + index
+                val key = autoplayKeys[index]
+                val dragging = autoplayDrag.draggedKey == key
                 InlineQueueRow(
                     song = song,
                     isCurrent = at == currentIndex,
                     onClick = { onJumpTo(at) },
                     onRemove = { onRemove(at) },
+                    draggable = true,
+                    dragging = dragging,
+                    onDragStart = { autoplayDrag.onDragStart(key) },
+                    onDrag = autoplayDrag::onDrag,
+                    onDragEnd = autoplayDrag::onDragEnd,
+                    modifier = Modifier
+                        .zIndex(if (dragging) 1f else 0f)
+                        .graphicsLayer { translationY = if (dragging) autoplayDrag.dragOffset else 0f }
+                        .then(if (dragging) Modifier else Modifier.animateItem()),
                 )
             }
         }
+    }
+}
+
+/**
+ * A key per row, stable across a reorder and unique even when the same song
+ * appears twice — the Nth time a given videoId is seen gets suffixed with
+ * that count, so two copies of one song each keep their own identity instead
+ * of colliding on the same LazyColumn key.
+ */
+private fun List<Song>.stableQueueKeys(prefix: String = ""): List<String> {
+    val seen = HashMap<String, Int>()
+    return map { song ->
+        val n = seen.getOrDefault(song.videoId, 0)
+        seen[song.videoId] = n + 1
+        if (n == 0) "$prefix${song.videoId}" else "$prefix${song.videoId}#$n"
+    }
+}
+
+/**
+ * Drag-to-reorder for one contiguous section of [InlineQueue]'s LazyColumn —
+ * the user's own queue and AutoPlay's each get their own instance, since a
+ * drag never crosses the boundary between them.
+ *
+ * Each swap goes to the player the moment the dragged row crosses a
+ * neighbour, so the live queue is always what's on screen and the rows the
+ * drag displaces animate to their new slots off it. The dragged row is
+ * tracked by its LazyColumn key rather than by index, because the index under
+ * it changes with every swap; [dragOffset] is corrected by the same distance
+ * the row jumps so it stays put under the finger while its slot moves.
+ *
+ * [lazyRange] is the section's span of LazyColumn indices, and [lazyOffset]
+ * the distance from those to queue indices — the AutoPlay heading is a row
+ * of the list too, so below it the two no longer line up.
+ */
+@Composable
+private fun rememberQueueDragState(
+    listState: LazyListState,
+    lazyRange: IntRange,
+    lazyOffset: Int,
+    onMove: (Int, Int) -> Unit,
+): QueueDragState {
+    val state = remember(listState) { QueueDragState(listState) }
+    state.lazyRange = lazyRange
+    state.lazyOffset = lazyOffset
+    state.onMove = onMove
+    return state
+}
+
+private class QueueDragState(private val listState: LazyListState) {
+    var lazyRange: IntRange = IntRange.EMPTY
+    var lazyOffset: Int = 0
+    var onMove: (Int, Int) -> Unit = { _, _ -> }
+
+    /** LazyColumn key of the row being dragged; null at rest. */
+    var draggedKey by mutableStateOf<Any?>(null)
+        private set
+    var dragOffset by mutableFloatStateOf(0f)
+        private set
+
+    /** Where the last swap put the row, until the list is laid out with it. */
+    private var awaiting: Int? = null
+
+    fun onDragStart(key: Any) {
+        draggedKey = key
+        dragOffset = 0f
+        awaiting = null
+    }
+
+    fun onDrag(deltaY: Float) {
+        val key = draggedKey ?: return
+        dragOffset += deltaY
+        val items = listState.layoutInfo.visibleItemsInfo
+        val dragged = items.find { it.key == key } ?: return
+        // A swap already sent but not yet laid out: deciding the next one off
+        // a position the list has moved on from would send a second move for
+        // a swap that has already happened, and the two would fight.
+        awaiting?.let { if (dragged.index != it) return else awaiting = null }
+        val draggedCenter = dragged.offset + dragged.size / 2f + dragOffset
+        // Only rows of this section are fair targets — the heading and the
+        // other section's rows share the LazyColumn but not this range.
+        val target = items
+            .filter { it.index in lazyRange && it.index != dragged.index }
+            .minByOrNull { abs((it.offset + it.size / 2f) - draggedCenter) }
+            ?: return
+        // Held short of halfway the rows would swap back and forth over a
+        // single pixel of travel; a full half-height of overlap is what makes
+        // one swap per row crossed.
+        if (abs(draggedCenter - (target.offset + target.size / 2f)) > target.size / 2f) return
+        onMove(dragged.index - lazyOffset, target.index - lazyOffset)
+        // The row is about to land where the target was — fold that jump back
+        // into the offset so it doesn't move out from under the finger.
+        dragOffset += (dragged.offset - target.offset)
+        awaiting = target.index
+    }
+
+    fun onDragEnd() {
+        draggedKey = null
+        dragOffset = 0f
+        awaiting = null
     }
 }
 
@@ -1502,15 +1681,47 @@ private fun InlineQueueRow(
     isCurrent: Boolean,
     onClick: () -> Unit,
     onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
+    draggable: Boolean = false,
+    dragging: Boolean = false,
+    onDragStart: () -> Unit = {},
+    onDrag: (Float) -> Unit = {},
+    onDragEnd: () -> Unit = {},
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
+            .background(if (dragging) Color.White.copy(alpha = 0.06f) else Color.Transparent)
             .clickable(onClick = onClick)
             .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        if (draggable) {
+            Icon(
+                Icons.Rounded.DragHandle,
+                contentDescription = "Drag to reorder",
+                tint = Color.White.copy(alpha = 0.4f),
+                modifier = Modifier
+                    .size(20.dp)
+                    // DragHandle's glyph sits well inset from the edges of
+                    // its own bounding box — this pulls it back to the row's
+                    // actual left edge instead of leaving a gap in front of it.
+                    .offset(x = (-4).dp)
+                    .pointerInput(Unit) {
+                        detectDragGestures(
+                            onDragStart = { onDragStart() },
+                            onDragEnd = { onDragEnd() },
+                            onDragCancel = { onDragEnd() },
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                onDrag(dragAmount.y)
+                            },
+                        )
+                    },
+            )
+            Spacer(Modifier.width(4.dp))
+        }
         AsyncImage(
             model = song.thumbnailUrl,
             contentDescription = null,

--- a/app/src/main/java/com/music/bitchord/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/DetailScreen.kt
@@ -46,12 +46,19 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.music.bitchord.data.model.BrowseType
 import com.music.bitchord.data.model.DetailPage
+import com.music.bitchord.data.model.CARD_ART_PX
+import com.music.bitchord.data.model.HEADER_ART_PX
+import com.music.bitchord.data.model.ROW_ART_PX
 import com.music.bitchord.data.model.ShelfItem
 import com.music.bitchord.data.model.Song
 import com.music.bitchord.data.model.UiState
-import com.music.bitchord.ui.components.LoadingState
+import com.music.bitchord.data.model.artworkAt
 import com.music.bitchord.ui.components.MessageState
+import com.music.bitchord.ui.components.PAGE_GUTTER
+import com.music.bitchord.ui.components.ROW_DIVIDER_INSET
+import com.music.bitchord.ui.components.SHELF_CARD_WIDTH
 import com.music.bitchord.ui.components.SongRow
+import com.music.bitchord.ui.components.detailSkeleton
 
 private const val MAX_ARTIST_SONGS = 20
 private const val SONGS_PER_COLUMN = 4
@@ -85,11 +92,11 @@ fun DetailScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 34.dp),
+                    .padding(horizontal = PAGE_GUTTER + 14.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 AsyncImage(
-                    model = page.thumbnailUrl,
+                    model = page.thumbnailUrl.artworkAt(HEADER_ART_PX),
                     contentDescription = null,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -126,7 +133,7 @@ fun DetailScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 20.dp, vertical = 4.dp),
+                        .padding(horizontal = PAGE_GUTTER, vertical = 4.dp),
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     Button(
@@ -158,7 +165,7 @@ fun DetailScreen(
         }
 
         when (val state = page.songs) {
-            is UiState.Loading -> item { LoadingState() }
+            is UiState.Loading -> detailSkeleton(isArtist)
             is UiState.Error -> item { MessageState(state.message) }
             is UiState.Success -> if (isArtist) {
                 // An artist's full song list would bury the album shelves, so
@@ -169,12 +176,12 @@ fun DetailScreen(
                         style = MaterialTheme.typography.headlineMedium,
                         color = MaterialTheme.colorScheme.onBackground,
                         modifier = Modifier.padding(
-                            start = 20.dp, end = 20.dp, top = 10.dp, bottom = 8.dp,
+                            start = PAGE_GUTTER, end = PAGE_GUTTER, top = 10.dp, bottom = 8.dp,
                         ),
                     )
                     val top = state.data.take(MAX_ARTIST_SONGS)
                     LazyRow(
-                        contentPadding = PaddingValues(horizontal = 20.dp),
+                        contentPadding = PaddingValues(horizontal = PAGE_GUTTER),
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         items(top.chunked(SONGS_PER_COLUMN)) { column ->
@@ -201,7 +208,7 @@ fun DetailScreen(
                     )
                     if (index < state.data.lastIndex) {
                         HorizontalDivider(
-                            modifier = Modifier.padding(start = 88.dp),
+                            modifier = Modifier.padding(start = ROW_DIVIDER_INSET),
                             thickness = 0.5.dp,
                             color = MaterialTheme.colorScheme.outline,
                         )
@@ -217,10 +224,10 @@ fun DetailScreen(
                     text = shelf.title,
                     style = MaterialTheme.typography.headlineMedium,
                     color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp),
+                    modifier = Modifier.padding(horizontal = PAGE_GUTTER, vertical = 10.dp),
                 )
                 LazyRow(
-                    contentPadding = PaddingValues(horizontal = 20.dp),
+                    contentPadding = PaddingValues(horizontal = PAGE_GUTTER),
                     horizontalArrangement = Arrangement.spacedBy(14.dp),
                 ) {
                     items(shelf.items) { item ->
@@ -249,7 +256,7 @@ private fun CompactSongRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(
-            model = song.thumbnailUrl,
+            model = song.artworkAt(ROW_ART_PX),
             contentDescription = null,
             modifier = Modifier
                 .size(48.dp)
@@ -294,14 +301,14 @@ private fun CompactSongRow(
 private fun SectionCard(item: ShelfItem, onClick: () -> Unit) {
     Column(
         modifier = Modifier
-            .width(150.dp)
+            .width(SHELF_CARD_WIDTH)
             .clickable(onClick = onClick),
     ) {
         AsyncImage(
-            model = item.thumbnailUrl,
+            model = item.thumbnailUrl.artworkAt(CARD_ART_PX),
             contentDescription = null,
             modifier = Modifier
-                .width(150.dp)
+                .width(SHELF_CARD_WIDTH)
                 .aspectRatio(1f)
                 .clip(RoundedCornerShape(10.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant),

--- a/app/src/main/java/com/music/bitchord/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/HomeScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -38,13 +37,19 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.music.bitchord.data.model.CARD_ART_PX
+import com.music.bitchord.data.model.HEADER_ART_PX
 import com.music.bitchord.data.model.HomeShelf
 import com.music.bitchord.data.model.ShelfItem
 import com.music.bitchord.data.model.UiState
-import com.music.bitchord.ui.components.LoadingState
+import com.music.bitchord.data.model.artworkAt
 import com.music.bitchord.ui.components.MessageState
+import com.music.bitchord.ui.components.PAGE_GUTTER
 import com.music.bitchord.ui.components.PullToRefresh
+import com.music.bitchord.ui.components.SHELF_CARD_WIDTH
 import com.music.bitchord.ui.components.SignInBanner
+import com.music.bitchord.ui.components.feedMoreSkeleton
+import com.music.bitchord.ui.components.feedSkeleton
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,7 +86,7 @@ fun HomeScreen(
                     text = title,
                     style = MaterialTheme.typography.displayLarge,
                     color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                    modifier = Modifier.padding(horizontal = PAGE_GUTTER, vertical = 8.dp),
                 )
             }
             if (!signedIn && onSignIn != null) {
@@ -90,22 +95,13 @@ fun HomeScreen(
                 }
             }
             when (state) {
-                is UiState.Loading -> item { LoadingState() }
+                is UiState.Loading -> feedSkeleton()
                 is UiState.Error -> item {
                     MessageState(state.message, actionLabel = "Retry", onAction = onRetry)
                 }
                 is UiState.Success -> {
                     itemsIndexedShelves(state.data, onItemClick)
-                    if (loadingMore) {
-                        item {
-                            Box(
-                                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
-                            }
-                        }
-                    }
+                    if (loadingMore) feedMoreSkeleton()
                 }
             }
         }
@@ -151,7 +147,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.itemsIndexedShelves(
 /** Shared by the home feed, Explore and Library so headings line up across tabs. */
 @Composable
 internal fun SectionHeader(title: String, subtitle: String = "") {
-    Column(Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
+    Column(Modifier.padding(horizontal = PAGE_GUTTER, vertical = 10.dp)) {
         Text(
             text = title,
             style = MaterialTheme.typography.headlineMedium,
@@ -177,7 +173,7 @@ private fun HeroShelf(shelf: HomeShelf, onItemClick: (ShelfItem) -> Unit) {
         SectionHeader(shelf.title, shelf.subtitle)
         LazyRow(
             state = rememberLazyListState(),
-            contentPadding = PaddingValues(horizontal = 20.dp),
+            contentPadding = PaddingValues(horizontal = PAGE_GUTTER),
             horizontalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             items(shelf.items) { item ->
@@ -202,7 +198,7 @@ private fun HeroCard(item: ShelfItem, onClick: () -> Unit, modifier: Modifier = 
             .clickable(onClick = onClick),
     ) {
         AsyncImage(
-            model = item.thumbnailUrl,
+            model = item.thumbnailUrl.artworkAt(HEADER_ART_PX),
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
@@ -210,7 +206,7 @@ private fun HeroCard(item: ShelfItem, onClick: () -> Unit, modifier: Modifier = 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .align(androidx.compose.ui.Alignment.BottomStart)
+                .align(Alignment.BottomStart)
                 .background(
                     Brush.verticalGradient(
                         listOf(Color.Transparent, Color.Black.copy(alpha = 0.78f)),
@@ -243,7 +239,7 @@ internal fun Shelf(shelf: HomeShelf, onItemClick: (ShelfItem) -> Unit) {
     Column(Modifier.padding(bottom = 26.dp)) {
         SectionHeader(shelf.title, shelf.subtitle)
         LazyRow(
-            contentPadding = PaddingValues(horizontal = 20.dp),
+            contentPadding = PaddingValues(horizontal = PAGE_GUTTER),
             horizontalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             items(shelf.items) { item ->
@@ -257,15 +253,15 @@ internal fun Shelf(shelf: HomeShelf, onItemClick: (ShelfItem) -> Unit) {
 private fun ShelfCard(item: ShelfItem, onClick: () -> Unit) {
     Column(
         modifier = Modifier
-            .width(166.dp)
+            .width(SHELF_CARD_WIDTH)
             .clickable(onClick = onClick),
     ) {
         AsyncImage(
-            model = item.thumbnailUrl,
+            model = item.thumbnailUrl.artworkAt(CARD_ART_PX),
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = Modifier
-                .width(166.dp)
+                .width(SHELF_CARD_WIDTH)
                 .aspectRatio(1f)
                 .clip(RoundedCornerShape(12.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant),

--- a/app/src/main/java/com/music/bitchord/ui/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/LibraryScreen.kt
@@ -19,10 +19,12 @@ import com.music.bitchord.data.model.LibraryPage
 import com.music.bitchord.data.model.ShelfItem
 import com.music.bitchord.data.model.Song
 import com.music.bitchord.data.model.UiState
-import com.music.bitchord.ui.components.LoadingState
 import com.music.bitchord.ui.components.MessageState
+import com.music.bitchord.ui.components.PAGE_GUTTER
 import com.music.bitchord.ui.components.PullToRefresh
+import com.music.bitchord.ui.components.ROW_DIVIDER_INSET
 import com.music.bitchord.ui.components.SongRow
+import com.music.bitchord.ui.components.librarySkeleton
 
 /**
  * The signed-in library: saved collections as shelves of cards, then the
@@ -63,7 +65,7 @@ fun LibraryScreen(
                     text = "Library",
                     style = MaterialTheme.typography.displayLarge,
                     color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                    modifier = Modifier.padding(horizontal = PAGE_GUTTER, vertical = 8.dp),
                 )
             }
             if (!signedIn) {
@@ -78,7 +80,7 @@ fun LibraryScreen(
                 return@LazyColumn
             }
             when (state) {
-                is UiState.Loading -> item { LoadingState() }
+                is UiState.Loading -> librarySkeleton()
                 is UiState.Error -> item {
                     MessageState(state.message, actionLabel = "Retry", onAction = onRetry)
                 }
@@ -115,7 +117,7 @@ private fun LazyListScope.songSection(
         )
         if (index < songs.lastIndex) {
             HorizontalDivider(
-                modifier = Modifier.padding(start = 88.dp),
+                modifier = Modifier.padding(start = ROW_DIVIDER_INSET),
                 thickness = 0.5.dp,
                 color = MaterialTheme.colorScheme.outline,
             )

--- a/app/src/main/java/com/music/bitchord/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SearchScreen.kt
@@ -44,13 +44,17 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.music.bitchord.data.model.BrowseItem
 import com.music.bitchord.data.model.BrowseType
+import com.music.bitchord.data.model.ROW_ART_PX
 import com.music.bitchord.data.model.SearchFilter
+import com.music.bitchord.data.model.artworkAt
 import com.music.bitchord.data.model.SearchResult
 import com.music.bitchord.data.model.Song
 import com.music.bitchord.data.model.UiState
-import com.music.bitchord.ui.components.LoadingState
 import com.music.bitchord.ui.components.MessageState
+import com.music.bitchord.ui.components.PAGE_GUTTER
+import com.music.bitchord.ui.components.ROW_DIVIDER_INSET
 import com.music.bitchord.ui.components.SongRow
+import com.music.bitchord.ui.components.songListSkeleton
 
 @Composable
 fun SearchScreen(
@@ -82,7 +86,7 @@ fun SearchScreen(
                 query = query,
                 onQueryChange = onQueryChange,
                 onSubmit = onSubmit,
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                modifier = Modifier.padding(horizontal = PAGE_GUTTER, vertical = 8.dp),
             )
         }
         // The filters only mean something once there is a result set to narrow;
@@ -91,7 +95,7 @@ fun SearchScreen(
         if (results != null) {
             item {
                 LazyRow(
-                    contentPadding = PaddingValues(horizontal = 20.dp),
+                    contentPadding = PaddingValues(horizontal = PAGE_GUTTER),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     modifier = Modifier.padding(bottom = 6.dp),
                 ) {
@@ -112,7 +116,7 @@ fun SearchScreen(
             } else {
                 recentSearches(history, onHistoryClick, onHistoryRemove, onHistoryClear)
             }
-            is UiState.Loading -> item { LoadingState() }
+            is UiState.Loading -> songListSkeleton(circular = filter == SearchFilter.ARTISTS)
             is UiState.Error -> item { MessageState(results.message) }
             is UiState.Success -> {
                 // Tapping a track plays the tracks around it, not the browse rows.
@@ -136,7 +140,7 @@ fun SearchScreen(
                     }
                     if (index < results.data.lastIndex) {
                         HorizontalDivider(
-                            modifier = Modifier.padding(start = 88.dp),
+                            modifier = Modifier.padding(start = ROW_DIVIDER_INSET),
                             thickness = 0.5.dp,
                             color = MaterialTheme.colorScheme.outline,
                         )
@@ -162,7 +166,7 @@ private fun LazyListScope.recentSearches(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 10.dp),
+                .padding(horizontal = PAGE_GUTTER, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -197,7 +201,7 @@ private fun RecentSearchRow(term: String, onClick: () -> Unit, onRemove: () -> U
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(start = 20.dp, end = 8.dp, top = 6.dp, bottom = 6.dp),
+            .padding(start = PAGE_GUTTER, end = 8.dp, top = 6.dp, bottom = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
@@ -238,11 +242,11 @@ private fun BrowseRow(item: BrowseItem, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 20.dp, vertical = 8.dp),
+            .padding(horizontal = PAGE_GUTTER, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(
-            model = item.thumbnailUrl,
+            model = item.thumbnailUrl.artworkAt(ROW_ART_PX),
             contentDescription = null,
             modifier = Modifier
                 .size(52.dp)

--- a/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -65,9 +66,16 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.SingletonImageLoader
 import coil3.compose.AsyncImage
@@ -76,6 +84,7 @@ import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.AudioQuality
 import com.music.bitchord.data.settings.ThemeMode
 import com.music.bitchord.playback.AudioCache
+import com.music.bitchord.playback.DolbyAtmos
 import kotlin.math.roundToInt
 
 /**
@@ -103,6 +112,8 @@ fun SettingsScreen(
     val crossfade by AppSettings.crossfadeSeconds.collectAsStateWithLifecycle()
     val skipSilence by AppSettings.skipSilence.collectAsStateWithLifecycle()
     val spatialAudio by AppSettings.spatialAudio.collectAsStateWithLifecycle()
+    val atmosSupported by DolbyAtmos.supported.collectAsStateWithLifecycle()
+    val atmosEnabled by DolbyAtmos.enabledOnDevice.collectAsStateWithLifecycle()
     val nerdStats by AppSettings.showNerdStats.collectAsStateWithLifecycle()
     val reduceAnimation by AppSettings.reduceAnimation.collectAsStateWithLifecycle()
     val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
@@ -112,6 +123,14 @@ fun SettingsScreen(
     val cacheLimitBytes by AppSettings.audioCacheLimitBytes.collectAsStateWithLifecycle()
 
     var picking by remember { mutableStateOf<QualityTarget?>(null) }
+
+    // Coming back from the system Atmos panel is the one moment the answer is
+    // most likely to have changed, and on devices whose Atmos switch isn't
+    // watchable it's the only moment we'd hear about it at all.
+    LifecycleResumeEffect(Unit) {
+        DolbyAtmos.refresh()
+        onPauseOrDispose {}
+    }
 
     val version = remember(context) {
         runCatching {
@@ -199,18 +218,33 @@ fun SettingsScreen(
             SettingsRow(
                 icon = Icons.Rounded.SurroundSound,
                 title = "Spatial audio",
-                subtitle = "Widens stereo tracks for a more immersive feel",
+                subtitle = when {
+                    !atmosSupported -> "Needs a device with Dolby Atmos"
+                    !atmosEnabled -> "Turn on Dolby Atmos to use it"
+                    else -> "Widens stereo tracks for a more immersive feel"
+                },
+                enabled = atmosSupported,
                 trailing = {
                     Switch(
-                        checked = spatialAudio,
-                        onCheckedChange = AppSettings::setSpatialAudio,
+                        checked = spatialAudio && atmosEnabled,
+                        onCheckedChange = { wanted ->
+                            if (atmosEnabled) AppSettings.setSpatialAudio(wanted) else openAtmosSettings(context)
+                        },
+                        enabled = atmosSupported,
                         colors = SwitchDefaults.colors(
                             checkedTrackColor = MaterialTheme.colorScheme.primary,
                             checkedBorderColor = MaterialTheme.colorScheme.primary,
                         ),
                     )
                 },
-                onClick = { AppSettings.setSpatialAudio(!spatialAudio) },
+                // With Atmos off, the switch has nothing to switch — the row
+                // sends the user to the panel that does, and the state it comes
+                // back with is picked up on resume.
+                onClick = when {
+                    !atmosSupported -> null
+                    !atmosEnabled -> ({ openAtmosSettings(context) })
+                    else -> ({ AppSettings.setSpatialAudio(!spatialAudio) })
+                },
             )
             RowDivider()
             SettingsRow(
@@ -334,7 +368,23 @@ fun SettingsScreen(
         }
 
         Text(
-            text = "BitChord $version\nUnofficial YouTube Music client by Kushagra Singh\n~YouTube Music Backend",
+            text = buildAnnotatedString {
+                append("BitChord $version  ")
+                val linkStyles = TextLinkStyles(
+                    style = SpanStyle(
+                        color = MaterialTheme.colorScheme.primary,
+                        textDecoration = TextDecoration.Underline,
+                    ),
+                )
+                withLink(LinkAnnotation.Url("https://github.com/kushagrasinghx/BitChord", linkStyles)) {
+                    append("GitHub")
+                }
+                append("  ")
+                withLink(LinkAnnotation.Url("https://github.com/kushagrasinghx", linkStyles)) {
+                    append("Developer")
+                }
+                append("\n~YouTube Music Backend")
+            },
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
@@ -389,6 +439,22 @@ private fun openEqualizer(context: Context, sessionId: Int) {
     }
     runCatching { context.startActivity(intent) }.onFailure {
         Toast.makeText(context, "No system equalizer on this device", Toast.LENGTH_SHORT).show()
+    }
+}
+
+/**
+ * Hands the user to whatever owns Dolby Atmos on this device. Nothing in the
+ * public API lets an app flip that switch itself, so the honest move is to open
+ * the panel rather than pretend the row can do it.
+ */
+private fun openAtmosSettings(context: Context) {
+    val intent = DolbyAtmos.settingsIntent(context)
+    if (intent == null) {
+        Toast.makeText(context, "No Dolby Atmos panel on this device", Toast.LENGTH_SHORT).show()
+        return
+    }
+    runCatching { context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }.onFailure {
+        Toast.makeText(context, "Couldn't open Dolby Atmos settings", Toast.LENGTH_SHORT).show()
     }
 }
 
@@ -620,13 +686,15 @@ private fun SettingsRow(
     subtitle: String? = null,
     value: String? = null,
     badge: String? = null,
+    enabled: Boolean = true,
     onClick: (() -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .then(if (onClick != null && enabled) Modifier.clickable(onClick = onClick) else Modifier)
+            .alpha(if (enabled) 1f else 0.45f)
             .heightIn(min = 52.dp)
             .padding(horizontal = ROW_INSET, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
@@ -26,11 +26,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.VolumeOff
+import androidx.compose.material.icons.rounded.BlurOff
 import androidx.compose.material.icons.rounded.Brightness4
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.DeleteSweep
 import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.MotionPhotosOff
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.SignalCellularAlt
 import androidx.compose.material.icons.rounded.Speed
@@ -102,6 +104,8 @@ fun SettingsScreen(
     val skipSilence by AppSettings.skipSilence.collectAsStateWithLifecycle()
     val spatialAudio by AppSettings.spatialAudio.collectAsStateWithLifecycle()
     val nerdStats by AppSettings.showNerdStats.collectAsStateWithLifecycle()
+    val reduceAnimation by AppSettings.reduceAnimation.collectAsStateWithLifecycle()
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
     val speed by AppSettings.playbackSpeed.collectAsStateWithLifecycle()
     val theme by AppSettings.themeMode.collectAsStateWithLifecycle()
     val sessionId by AppSettings.audioSessionId.collectAsStateWithLifecycle()
@@ -241,6 +245,40 @@ fun SettingsScreen(
                 selectedIndex = ThemeMode.entries.indexOf(theme),
                 onSelect = { AppSettings.setThemeMode(ThemeMode.entries[it]) },
                 modifier = Modifier.padding(start = ROW_INSET, end = ROW_INSET, bottom = 14.dp),
+            )
+            RowDivider()
+            SettingsRow(
+                icon = Icons.Rounded.MotionPhotosOff,
+                title = "Reduce animation",
+                subtitle = "Freezes the main player's gradient instead of drifting",
+                trailing = {
+                    Switch(
+                        checked = reduceAnimation,
+                        onCheckedChange = AppSettings::setReduceAnimation,
+                        colors = SwitchDefaults.colors(
+                            checkedTrackColor = MaterialTheme.colorScheme.primary,
+                            checkedBorderColor = MaterialTheme.colorScheme.primary,
+                        ),
+                    )
+                },
+                onClick = { AppSettings.setReduceAnimation(!reduceAnimation) },
+            )
+            RowDivider()
+            SettingsRow(
+                icon = Icons.Rounded.BlurOff,
+                title = "Reduce dynamic blur",
+                subtitle = "Swaps frosted glass for solid fills across the app",
+                trailing = {
+                    Switch(
+                        checked = reduceDynamicBlur,
+                        onCheckedChange = AppSettings::setReduceDynamicBlur,
+                        colors = SwitchDefaults.colors(
+                            checkedTrackColor = MaterialTheme.colorScheme.primary,
+                            checkedBorderColor = MaterialTheme.colorScheme.primary,
+                        ),
+                    )
+                },
+                onClick = { AppSettings.setReduceDynamicBlur(!reduceDynamicBlur) },
             )
         }
 

--- a/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.SignalCellularAlt
 import androidx.compose.material.icons.rounded.Speed
 import androidx.compose.material.icons.rounded.Storage
+import androidx.compose.material.icons.rounded.SurroundSound
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material.icons.rounded.Waves
 import androidx.compose.material.icons.rounded.Wifi
@@ -99,6 +100,7 @@ fun SettingsScreen(
     val metered by AppSettings.meteredConnection.collectAsStateWithLifecycle()
     val crossfade by AppSettings.crossfadeSeconds.collectAsStateWithLifecycle()
     val skipSilence by AppSettings.skipSilence.collectAsStateWithLifecycle()
+    val spatialAudio by AppSettings.spatialAudio.collectAsStateWithLifecycle()
     val nerdStats by AppSettings.showNerdStats.collectAsStateWithLifecycle()
     val speed by AppSettings.playbackSpeed.collectAsStateWithLifecycle()
     val theme by AppSettings.themeMode.collectAsStateWithLifecycle()
@@ -188,6 +190,23 @@ fun SettingsScreen(
                     )
                 },
                 onClick = { AppSettings.setSkipSilence(!skipSilence) },
+            )
+            RowDivider()
+            SettingsRow(
+                icon = Icons.Rounded.SurroundSound,
+                title = "Spatial audio",
+                subtitle = "Widens stereo tracks for a more immersive feel",
+                trailing = {
+                    Switch(
+                        checked = spatialAudio,
+                        onCheckedChange = AppSettings::setSpatialAudio,
+                        colors = SwitchDefaults.colors(
+                            checkedTrackColor = MaterialTheme.colorScheme.primary,
+                            checkedBorderColor = MaterialTheme.colorScheme.primary,
+                        ),
+                    )
+                },
+                onClick = { AppSettings.setSpatialAudio(!spatialAudio) },
             )
             RowDivider()
             SettingsRow(


### PR DESCRIPTION
Merges the v1.2 line into `main`: rewritten stream resolution, a real two-player crossfade, spatial audio, queue reordering, skeleton loading and a round of performance work. 35 files, ~3.4k insertions across 6 commits.

Release notes below match the draft [BitChord v1.2](https://github.com/kushagrasinghx/BitChord/releases) release.

---

Third release of BitChord. This one is about the two things you actually notice: tracks that **start** and keep going, and a crossfade that finally **overlaps** instead of dipping.

## Highlights

**🎚️ A crossfade you can hear**
The old crossfade was one player ramping its own volume, which meant it faded down to silence at the join and climbed back out — a hole where the blend should have been. There are now two decoders: the queue advances to the next track immediately and fades up, while a throwaway tail player carries the outgoing track's last seconds down. Both sides ride an equal-power sin/cos curve, so the transition holds constant loudness the whole way through. Because the queue moves on at the start of the fade, the notification, the artwork and the queue index flip to the song you're about to hear rather than trailing the one that's leaving.

**▶️ Tracks that actually play**
Stream resolution was the single biggest source of "it loads and then doesn't play". A `player` request sent without a visitor id gets answered one of two ways — an honest `LOGIN_REQUIRED`, or a perfectly normal-looking response whose URLs serve one byte and then 403 every real read. BitChord now mints a visitor id deliberately instead of hoping a browse response carries one, walks a **list** of player client identities rather than betting on a single one, remembers which one last worked, stands down the ones that get refused, and never hands the player a URL — or caches it — until a byte has actually been fetched from it.

**⚡ Streaming at line rate**
googlevideo paces an open-ended response down to roughly playback speed. Measured on the same track, over the same connection, seconds apart: **15.5 kB/s** for an unbounded GET against **5.7 MB/s** for the same bytes requested as a bounded range. That is the difference between a player that can build a buffer and one that can only just keep up, and it's why a stall used to never recover. Player reads are now fetched as a run of ranges, the same way read-ahead already worked.

**🔊 Spatial audio**
Settings → Playback gains a **Spatial audio** row: a stereo-widening and cross-feed effect running inside the player's own audio pipeline. It's offered only on devices that ship Dolby Atmos and only runs while the system Atmos switch is on — with Atmos off, the row hands you to the panel that owns that switch, and turning Atmos off mid-track takes the effect down with it rather than waiting for the next song.

**✋ Drag to reorder the queue**
Queue rows can now be dragged into a new order. Your own queue and AutoPlay's section reorder separately — a drag never crosses the line between them — and each swap goes to the player as it happens, so what's on screen is always the real running order.

**💀 Skeletons instead of spinners**
Home, search, library and album/artist pages now fill with grey placeholders laid out to the same metrics as the real rows, so nothing jumps when the data lands. Album and playlist pages also stop waiting for the whole track list: the first page is shown at once and the rest fills in underneath while you're already reading.

**🔍 Search that refines as you type**
Results are cached and matched by prefix, so typing "blinding" shows the results from "blind" while the real query is in flight instead of blanking to a spinner on every letter. The pipeline is one long-lived collector with an 80ms debounce, which also puts an end to the "Software caused connection abort" errors that came from every keystroke tearing down a pooled connection someone else was using.

**🖼️ Artwork at the size it's drawn**
Covers were being fetched at 544px for squares the size of a fingertip — 84kB where 7.8kB would do. Each surface now asks for what it draws: rows small, cards medium, page headers and the player large, the notification generous. Coil also gets a real cache — 100MB on disk, 20% of memory — so covers survive to tomorrow instead of being evicted at the 10MB default floor.

**⚙️ Performance settings**
Two new switches under Appearance for older or slower devices: **Reduce animation** freezes the player's mesh gradient instead of letting it drift, and **Reduce dynamic blur** swaps every frosted surface — status bar, mini player, bottom fade, lyric focus — for solid fills.

**🔔 Update alert**
The top bar's update icon now comes with a once-per-launch iOS-style alert when a newer build is out. Both read the same gate, so the icon can't announce it a beat before the alert does, and neither shows up over a page of skeletons.

## Also in this release

- Album and single pages now credit their tracks to the artist named in the page header, instead of listing bare titles as "Unknown artist" — and the long-press menu can still open that artist
- Repeat-all now drops AutoPlay's tracks when switched on, and AutoPlay stops extending the queue while it's on, so repeat-all can actually reach the end it's meant to wrap from
- The sleep timer's "after this song" is honoured across a crossfade, which arrives looking exactly like a manual skip from the outside
- Transport failures — a connection reset on mobile data — are retried instead of surfacing as an error; HTTP error statuses still aren't, since repeating the question won't change the answer
- One page gutter shared by every screen and by the floating bars, so row, card and heading edges line up with the bars stacked below them
- Settings footer now links to the GitHub repo and the developer
- A queued song appearing twice no longer collides on the same list key
- NewPipeExtractor 0.26.3 → 0.26.4


<details>
<summary><b>Full changelog (technical)</b></summary>

### Added
- `PlayerClient` — one client identity for the `player` endpoint, carrying the user agent, origin and signature-timestamp requirement that must travel together; `StreamResolver` walks `CLIENTS` (ANDROID_VR first) with per-network gating, a learned order, and a `probe` that fetches a byte before anything is handed to the player or cached
- `Innertube.ensureVisitorData` / `fetchVisitorData` — mints a visitor id off `sw.js_data`, found by shape rather than by a path that would rot, with a one-shot refresh when a response accuses the session of being a bot
- `ChunkedDataSource` — bounded-range fetching for player reads, passing already-bounded requests straight through; `PlaybackService` sets the media request's headers per URL from `PlayerClient.forStreamUrl`
- `CrossfadeController` rewritten around a ghost player: `ARMING`/`LAPPING`/`FADING`/`BAILING` phases, silent seek-sync to `SYNC_TOLERANCE_MS` with a learned seek lead, equal-power `sin`/`cos` curve, `consumeAutoAdvance()` so `PlaybackService` can tell the lap's seek from a manual skip, and `onSkipRequested()` to bail before one
- `PlaybackService.buildGhostPlayer` — no audio focus, no noisy handling, no session, same audio session id (so the EQ doesn't change halfway), sharing the main media source factory so the tail plays from disk
- `SpatialAudioProcessor` — mid/side widening plus a delayed, low-passed cross-feed as an ExoPlayer `AudioProcessor`; one instance per sink, since the delay line can't be shared
- `DolbyAtmos` — support and on/off detection via the platform `Spatializer`, the vendor setting and output route changes, `settingsIntent()` to the OEM panel, and a manifest `<queries>` block so API 30+ doesn't hide those packages; retires `AppSettings.spatialAudio` the moment Atmos goes off
- `Skeletons.kt` — shimmer placeholders for the feed, library, song lists and detail pages, drawn from inside the draw block so a screenful doesn't recompose per frame
- `UpdateAvailableDialog` — iOS-shaped alert rendered as an overlay so its glass samples the app's own `HazeState`; shown once per launch, gated behind Home settling
- `Innertube.SongPage` + `browseSongs` / `moreSongs`, and `MainViewModel.fillIn` — detail pages render their first page and follow continuations in the background, up to `MAX_PAGES`
- `Innertube.withRetry` — retries transport failures only, never HTTP statuses, never through cancellation
- Search pipeline: `searchRequests` (`DROP_OLDEST`), an LRU `searchCache`, `prefixMatch`, and `newestRequestId` so a late answer can't overwrite a newer one
- `InnertubeParser.pageCredit` — release-page header credit applied to rows that carry none, with the artist's browse id; releases only, never playlists
- `Song.artworkAt` / `String?.artworkAt` and the `ROW_ART_PX` / `CARD_ART_PX` / `HEADER_ART_PX` / `NOTIFICATION_ART_PX` constants
- `BitChordApplication` implements `SingletonImageLoader.Factory` — 20% memory cache, 100MB named disk cache, 200ms crossfade
- `AppSettings.spatialAudio`, `reduceAnimation`, `reduceDynamicBlur`, with their settings rows
- `rememberQueueDragState` + `stableQueueKeys` — per-section drag-to-reorder off the live queue, keyed stably across reorders and duplicate songs

### Changed
- `Innertube.player` takes a client identity as an argument instead of hardcoding iOS
- Back buffer 15 min → 30 s: the byte ceiling counts history too, so a track-wide back buffer spent the whole read-ahead budget on audio already heard and never restarted loading
- After-rebuffer buffer raised again — a stall means the network is genuinely struggling
- `RestartingBackPlayer` → `SessionPlayer`, which also tells the crossfade about a skip before carrying it out
- Thumbnails are taken exactly as offered by the parser; the size is chosen at the point of draw instead of being rewritten to 544px on the way past
- `LoadingState` removed in favour of per-surface skeletons
- `PAGE_GUTTER` (10dp), `ROW_DIVIDER_INSET` and `SHELF_CARD_WIDTH` replace the per-screen 20/26/32/34dp paddings and 150/166dp card widths
- `versionCode` 2 → 3, `versionName` 1.1 → 1.2

### Fixed
- Streams that resolved fine and then 403'd every read, from a `player` request with no visitor id
- Playback throttled to roughly its own consumption rate, so a stall could never recover into a cushion
- Rebuffering every couple of seconds for the length of a track, from a back buffer that exhausted the load ceiling
- Crossfade dipping to silence at the join instead of overlapping
- A crossfade being counted as a manual skip, which stopped "sleep after this song" from firing
- A user skip, scrub, queue replacement or playback error mid-fade leaving a tail audible over the new track
- Album and single track rows showing "Unknown artist" where the credit was only in the page header
- "Software caused connection abort" while typing a search, from each keystroke cancelling a request on a pooled connection
- Long playlists spending up to ten round trips on a spinner before showing anything
- Duplicate songs in the queue colliding on one list key, and reorder animations mistaking a moved row for a replaced one
- Repeat-all never wrapping, because AutoPlay kept extending the queue past its end
- Spatial audio staying on in preferences after Atmos was switched off in system settings

</details>
