### PR TITLE
Scrobbling support, playback fixes, and player UX improvements

### DIFF
--- a/app/src/main/java/com/music/bitchord/BitChordApplication.kt
+++ b/app/src/main/java/com/music/bitchord/BitChordApplication.kt
@@ -15,6 +15,7 @@ import com.music.bitchord.playback.AudioCache
 import com.music.bitchord.playback.DolbyAtmos
 import com.music.bitchord.playback.LastPlayed
 import com.music.bitchord.data.innertube.Innertube
+import com.music.bitchord.data.scrobbling.LastFM
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.SearchHistory
 
@@ -36,6 +37,8 @@ class BitChordApplication : Application(), SingletonImageLoader.Factory {
         // One cache directory can only be opened once per process, and
         // PlaybackService shares this one — so it's opened here, not there.
         AudioCache.init(this)
+        // Initialize LastFM with saved settings if available
+        initLastfm()
     }
 
     /**
@@ -64,6 +67,20 @@ class BitChordApplication : Application(), SingletonImageLoader.Factory {
             // it scrolls; a short fade reads as them developing.
             .crossfade(200)
             .build()
+
+    private fun initLastfm() {
+        val sessionKey = AppSettings.lastfmSessionKey.value
+        if (sessionKey.isBlank()) return
+        val endpoint = AppSettings.lastfmEndpoint.value.ifBlank { LastFM.DEFAULT_API_ENDPOINT }
+        val apiKey = AppSettings.lastfmApiKey.value.ifBlank { LastFM.FALLBACK_COMPAT_API_KEY }
+        val secret = AppSettings.lastfmSecret.value.ifBlank { LastFM.FALLBACK_COMPAT_SECRET }
+        LastFM.configure(
+            endpoint = endpoint,
+            apiKey = apiKey,
+            secret = secret,
+            sessionKey = sessionKey,
+        )
+    }
 
     companion object {
         lateinit var authStore: AuthStore

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -67,6 +67,7 @@ import com.music.bitchord.data.model.Song
 import com.music.bitchord.data.model.UiState
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.ThemeMode
+import com.music.bitchord.ui.screens.AccountAndScrobblingScreen
 import com.music.bitchord.ui.screens.SettingsScreen
 import com.music.bitchord.playback.QueueBuilder
 import com.music.bitchord.playback.QueueShuffle
@@ -128,6 +129,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
     var showNowPlaying by remember { mutableStateOf(false) }
     var showLogin by remember { mutableStateOf(false) }
     var showSettings by remember { mutableStateOf(false) }
+    var showAccountScrobbling by remember { mutableStateOf(false) }
     var songActions by remember { mutableStateOf<Song?>(null) }
     val autoplay by AppSettings.autoplay.collectAsStateWithLifecycle()
 
@@ -181,6 +183,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
     // selected. A pushed album/artist page (from the player, search, etc.)
     // should surface above it rather than being hidden behind it.
     LaunchedEffect(detail) { if (detail != null) showSettings = false }
+    LaunchedEffect(showSettings) { if (!showSettings) showAccountScrobbling = false }
 
     val controller = rememberMediaController()
     val player = rememberPlayerState(controller)
@@ -240,7 +243,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
     val libraryPull = rememberPullToRefreshState()
     val refreshing by viewModel.refreshing.collectAsStateWithLifecycle()
     val currentFeed = when {
-        showSettings || detail != null -> null
+        showSettings || showAccountScrobbling || detail != null -> null
         selectedTab == TAB_HOME -> MainViewModel.Feed.HOME
         selectedTab == TAB_EXPLORE -> MainViewModel.Feed.EXPLORE
         selectedTab == TAB_LIBRARY -> MainViewModel.Feed.LIBRARY
@@ -385,11 +388,15 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
         // A pushed album/artist/playlist page replaces the tab content but
         // leaves the tab bar and mini player in place.
         BackHandler(enabled = detail != null) { viewModel.closeDetail() }
+        BackHandler(enabled = detail == null && showAccountScrobbling) {
+            showAccountScrobbling = false
+        }
         // One back step out of Settings, or out of any tab but Home, lands on
         // Home rather than exiting — only Home itself hands back to the system,
         // which is what actually closes/minimizes the app.
-        BackHandler(enabled = detail == null && showSettings) {
+        BackHandler(enabled = detail == null && showSettings && !showAccountScrobbling) {
             showSettings = false
+            showAccountScrobbling = false
             selectedTab = TAB_HOME
         }
         BackHandler(enabled = detail == null && !showSettings && selectedTab != TAB_HOME) {
@@ -399,6 +406,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
 
         AnimatedContent(
             targetState = when {
+                showAccountScrobbling -> "account_scrobbling"
                 showSettings -> "settings"
                 detail != null -> detail.browseId
                 else -> "tab:$selectedTab"
@@ -407,8 +415,20 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
             modifier = Modifier.hazeSource(hazeState),
             label = "content",
         ) { key ->
-            val page = detailStack.lastOrNull()?.takeIf { it.browseId == key && key != "settings" }
-            if (key == "settings") {
+            val page = detailStack.lastOrNull()?.takeIf { it.browseId == key && key != "settings" && key != "account_scrobbling" }
+            if (key == "account_scrobbling") {
+                AccountAndScrobblingScreen(
+                    signedIn = signedIn,
+                    account = account,
+                    onSignIn = {
+                        showAccountScrobbling = false
+                        showSettings = false
+                        showLogin = true
+                    },
+                    onSignOut = { viewModel.signOut() },
+                    contentPadding = listPadding,
+                )
+            } else if (key == "settings") {
                 SettingsScreen(
                     signedIn = signedIn,
                     account = account,
@@ -417,6 +437,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                         showLogin = true
                     },
                     onSignOut = { viewModel.signOut() },
+                    onAccountScrobbling = { showAccountScrobbling = true },
                     contentPadding = listPadding,
                 )
             } else if (page != null) {
@@ -570,6 +591,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
 
         FrostedTopBar(
             title = when {
+                showAccountScrobbling -> "Account & scrobbling"
                 showSettings -> "Settings"
                 detail != null -> detail.title
                 else -> tabs[selectedTab].let {
@@ -579,11 +601,12 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
             hazeState = hazeState,
             // Search has no large in-list header to hand the title back to —
             // the field takes that space — so its bar title is always up.
-            scrolled = scrolled || detail != null || showSettings ||
+            scrolled = scrolled || detail != null || showSettings || showAccountScrobbling ||
                 selectedTab == TAB_SEARCH,
             refreshing = currentFeed != null && currentFeed in refreshing,
             pullFraction = { currentPull?.distanceFraction ?: 0f },
             onBack = when {
+                showAccountScrobbling -> ({ showAccountScrobbling = false })
                 showSettings -> ({ showSettings = false })
                 detail != null -> ({ viewModel.closeDetail(); Unit })
                 else -> null
@@ -592,7 +615,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
             actions = {
                 // Only worth surfacing where there's room for it and it won't
                 // be mistaken for a per-page action — Home, at rest.
-                if (!showSettings && detail == null && selectedTab == TAB_HOME) {
+                if (!showSettings && !showAccountScrobbling && detail == null && selectedTab == TAB_HOME) {
                     updateNotice?.let { update ->
                         IconButton(onClick = {
                             context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(update.releaseUrl)))
@@ -605,7 +628,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                         }
                     }
                 }
-                if (!showSettings) IconButton(onClick = { showSettings = true }) {
+                if (!showSettings && !showAccountScrobbling) IconButton(onClick = { showSettings = true }) {
                     Icon(
                         Icons.Rounded.MoreVert,
                         contentDescription = "Settings",
@@ -652,6 +675,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                     // switching tabs.
                     viewModel.clearDetail()
                     showSettings = false
+                    showAccountScrobbling = false
                     selectedTab = it
                 },
             )

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -30,7 +30,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
-import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.SystemUpdate
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -630,7 +630,7 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                 }
                 if (!showSettings && !showAccountScrobbling) IconButton(onClick = { showSettings = true }) {
                     Icon(
-                        Icons.Rounded.MoreVert,
+                        Icons.Rounded.Settings,
                         contentDescription = "Settings",
                         tint = MaterialTheme.colorScheme.onBackground,
                     )

--- a/app/src/main/java/com/music/bitchord/data/innertube/PlayerClient.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/PlayerClient.kt
@@ -76,24 +76,24 @@ data class PlayerClient(
          * The version is the whole ballgame. Anything Google considers stale is
          * refused with an HTTP 400 before playability is looked at, which is
          * not a "try the next format" failure but a "this identity is dead"
-         * one. 19.29.1 is already past that line; these two are not.
+         * one. These are current as of July 2026.
          */
         val IOS = PlayerClient(
             clientName = "IOS",
-            clientVersion = "20.03.02",
+            clientVersion = "21.26.4",
             clientId = "5",
-            userAgent = "com.google.ios.youtube/20.03.02 (iPhone16,2; U; CPU iOS 18_2_1 like Mac OS X;)",
+            userAgent = "com.google.ios.youtube/21.26.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)",
             osName = "iPhone",
-            osVersion = "18.2.1.22C161",
+            osVersion = "18.3.2.22D82",
             deviceMake = "Apple",
             deviceModel = "iPhone16,2",
         )
 
         /** A newer build of the same app: refused on a different schedule. */
         val IOS_RECENT = IOS.copy(
-            clientVersion = "20.10.4",
-            userAgent = "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)",
-            osVersion = "18.3.2.22D82",
+            clientVersion = "21.29.1",
+            userAgent = "com.google.ios.youtube/21.29.1 (iPhone16,2; U; CPU iOS 18_5 like Mac OS X;)",
+            osVersion = "18.5.22F70",
         )
 
         /**
@@ -104,9 +104,9 @@ data class PlayerClient(
          */
         val ANDROID = PlayerClient(
             clientName = "ANDROID",
-            clientVersion = "21.10.38",
+            clientVersion = "21.26.364",
             clientId = "3",
-            userAgent = "com.google.android.youtube/21.10.38 " +
+            userAgent = "com.google.android.youtube/21.26.364 " +
                 "(Linux; U; Android 15; en_US; Pixel 9 Pro; Build/AP4A.250205.002; Cronet/132.0.6834.79) gzip",
             osName = "Android",
             osVersion = "15",
@@ -114,6 +114,25 @@ data class PlayerClient(
             deviceModel = "Pixel 9 Pro",
             androidSdkVersion = "35",
             needsSignatureTimestamp = true,
+        )
+
+        /**
+         * YouTube Music Android app. Returns plain URLs without ciphering.
+         * As of mid-2026, this client is not subject to the po_token
+         * enforcement that blocks stream fetches from other clients —
+         * the only known client that still serves HTTPS streams freely.
+         */
+        val ANDROID_MUSIC = PlayerClient(
+            clientName = "ANDROID_MUSIC",
+            clientVersion = "8.39.42",
+            clientId = "21",
+            userAgent = "com.google.android.apps.youtube.music/8.39.42 " +
+                "(Linux; U; Android 15; en_US; Pixel 9 Pro; Build/AP4A.250205.002) gzip",
+            osName = "Android",
+            osVersion = "15",
+            deviceMake = "Google",
+            deviceModel = "Pixel 9 Pro",
+            androidSdkVersion = "35",
         )
 
         /**
@@ -128,15 +147,18 @@ data class PlayerClient(
          * hard-used address with `LOGIN_REQUIRED` / "Sign in to confirm you're
          * not a bot". A check run from anywhere but the device is measuring
          * the wrong thing.
+         *
+         * Version MUST be ≤1.65.10 — versions >1.65 trigger SABR-only
+         * streaming (no HTTPS URLs returned).
          */
         val ANDROID_VR = PlayerClient(
             clientName = "ANDROID_VR",
-            clientVersion = "1.61.48",
+            clientVersion = "1.65.10",
             clientId = "28",
-            userAgent = "com.google.android.apps.youtube.vr.oculus/1.61.48 " +
-                "(Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
+            userAgent = "com.google.android.apps.youtube.vr.oculus/1.65.10 " +
+                "(Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip",
             osName = "Android",
-            osVersion = "12",
+            osVersion = "12L",
             deviceMake = "Oculus",
             deviceModel = "Quest 3",
             androidSdkVersion = "32",
@@ -152,7 +174,7 @@ data class PlayerClient(
         /** Last resort: the web player itself. Always ciphered, and usually refused. */
         val WEB_REMIX = PlayerClient(
             clientName = "WEB_REMIX",
-            clientVersion = "1.20260114.01.00",
+            clientVersion = "1.20260707.12.00",
             clientId = "67",
             userAgent = WEB_USER_AGENT,
             origin = MUSIC_ORIGIN,
@@ -166,15 +188,19 @@ data class PlayerClient(
          */
         private val WEB = PlayerClient(
             clientName = "WEB",
-            clientVersion = "2.20260114.00.00",
+            clientVersion = "2.20260708.00.00",
             clientId = "1",
             userAgent = WEB_USER_AGENT,
             origin = YOUTUBE_ORIGIN,
         )
 
-        private val TVHTML5 = PlayerClient(
+        /**
+         * TV Cobalt v7 — the most reliable client for flagged IPs. No PO Token
+         * needed, no login required. Uses cookie-based auth when available.
+         */
+        val TVHTML5 = PlayerClient(
             clientName = "TVHTML5",
-            clientVersion = "7.20260114.00.00",
+            clientVersion = "7.20260707.07.00",
             clientId = "7",
             userAgent = "Mozilla/5.0(SMART-TV; Linux; Tizen 4.0.0.2) AppleWebkit/605.1.15 " +
                 "(KHTML, like Gecko) SamsungBrowser/9.2 TV Safari/605.1.15",
@@ -199,6 +225,7 @@ data class PlayerClient(
                     if (version == IOS_RECENT.clientVersion) IOS_RECENT else IOS
                 name == "ANDROID_VR" ->
                     if (version == ANDROID_VR_LEGACY.clientVersion) ANDROID_VR_LEGACY else ANDROID_VR
+                name == "ANDROID_MUSIC" -> ANDROID_MUSIC
                 name.startsWith("ANDROID") -> ANDROID
                 name.startsWith("TVHTML5") -> TVHTML5
                 name == "WEB_REMIX" -> WEB_REMIX

--- a/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
@@ -72,8 +72,13 @@ object StreamResolver {
      * not globally — an identity refused on one connection is served on
      * another — which is the whole reason this is a list and why the order is
      * only a starting guess that [clientOrder] corrects from experience.
+     *
+     * TVHTML5 (Cobalt v7) is first because it works on flagged IPs without
+     * PO Token — the most reliable client as of July 2026.
      */
     private val CLIENTS = listOf(
+        PlayerClient.ANDROID_MUSIC,
+        PlayerClient.TVHTML5,
         PlayerClient.ANDROID_VR,
         PlayerClient.ANDROID_VR_LEGACY,
         PlayerClient.IOS,

--- a/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/StreamResolver.kt
@@ -365,11 +365,14 @@ object StreamResolver {
      * a good one until something reads from it; hand it to ExoPlayer and the
      * failure surfaces as a track that spins and never starts.
      *
-     * A real range, not `bytes=0-0`. A single byte is not a test: a URL minted
-     * for a session Google has reservations about will serve one to anybody and
-     * then refuse every request large enough to be actual listening, so a
-     * one-byte probe passes exactly the URLs this exists to catch. Sixteen
-     * kilobytes is past that line and still one cheap round trip.
+     * The range has to be as large as the real fetch will ask for, not a token
+     * one. A URL minted for a session Google has reservations about serves
+     * small ranges to anybody — enough to pass a small probe — and then refuses
+     * the multi-megabyte ranges actual listening is made of with a 403.
+     * [PROBE_RANGE_BYTES] matches the chunk size the player and read-ahead
+     * fetch with, so a grudging URL fails here instead of on the playback path.
+     * Sixteen kilobytes of the answer still have to actually arrive, so a
+     * response that stalls after its headers is a failure too.
      *
      * The headers are the ones the media fetch will really use — see
      * [PlayerClient.forStreamUrl] — so this tests the request that matters
@@ -377,7 +380,7 @@ object StreamResolver {
      */
     private fun probe(url: String): Probe {
         val builder = okhttp3.Request.Builder().url(url)
-            .header("Range", "bytes=0-${PROBE_BYTES - 1}")
+            .header("Range", "bytes=0-${PROBE_RANGE_BYTES - 1}")
         PlayerClient.forStreamUrl(url).mediaHeaders().forEach { (name, value) ->
             builder.header(name, value)
         }
@@ -391,9 +394,9 @@ object StreamResolver {
                     response.header("Content-Type")?.startsWith("audio/") != true -> Probe.REFUSED
                     // Headers can arrive long before a body that never does —
                     // exactly the shaping this whole path exists to sidestep.
-                    // Insisting on the whole range is the point: a trickle that
+                    // Insisting on the bytes is the point: a trickle that
                     // yields its first byte and stalls is a failure too.
-                    response.body?.source()?.request(PROBE_BYTES) != true -> Probe.UNREACHABLE
+                    response.body?.source()?.request(PROBE_READ_BYTES) != true -> Probe.UNREACHABLE
                     else -> Probe.OK
                 }
             }
@@ -422,8 +425,18 @@ object StreamResolver {
 
     private const val PROBE_TIMEOUT_SECONDS = 6L
 
-    /** Past what a grudging URL will serve, well under what any track holds. */
-    private const val PROBE_BYTES = 16L * 1024
+    /**
+     * How much the probe asks for, in one range.
+     *
+     * Has to match what the real fetch asks for ([ChunkedDataSource] and
+     * [AudioCache] both fetch two-megabyte ranges), or a URL that grudges real
+     * listening-sized requests — while still serving token ones — sails through
+     * the probe and dies on the playback path instead.
+     */
+    private const val PROBE_RANGE_BYTES = 2L * 1024 * 1024
+
+    /** How much of the answer must actually arrive, to catch a stalled body. */
+    private const val PROBE_READ_BYTES = 16L * 1024
 
     // ---- Clients stood down -------------------------------------------------
 

--- a/app/src/main/java/com/music/bitchord/data/scrobbling/LastFM.kt
+++ b/app/src/main/java/com/music/bitchord/data/scrobbling/LastFM.kt
@@ -1,0 +1,296 @@
+package com.music.bitchord.data.scrobbling
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Parameters
+import io.ktor.http.isSuccess
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.net.URI
+import java.security.MessageDigest
+
+object LastFM {
+    const val DEFAULT_API_ENDPOINT = "https://ws.audioscrobbler.com/2.0/"
+    const val LIBREFM_API_ENDPOINT = "https://libre.fm/2.0/"
+    const val FALLBACK_COMPAT_API_KEY = "bitchord"
+    const val FALLBACK_COMPAT_SECRET = "bitchord"
+
+    @Serializable
+    data class Session(val name: String, val key: String, val subscriber: Int)
+
+    @Serializable
+    data class Authentication(val session: Session)
+
+    @Serializable
+    data class TokenResponse(val token: String)
+
+    @Serializable
+    data class LastFmError(val error: Int, val message: String)
+
+    data class RuntimeConfig(
+        val endpoint: String,
+        val apiKey: String,
+        val secret: String,
+        val sessionKey: String?,
+    )
+
+    @Volatile
+    private var runtimeConfig =
+        RuntimeConfig(
+            endpoint = DEFAULT_API_ENDPOINT,
+            apiKey = "",
+            secret = "",
+            sessionKey = null,
+        )
+
+    var sessionKey: String?
+        get() = runtimeConfig.sessionKey
+        set(value) {
+            runtimeConfig = runtimeConfig.copy(sessionKey = value)
+        }
+
+    private val json =
+        Json {
+            isLenient = true
+            ignoreUnknownKeys = true
+        }
+
+    private val client by lazy {
+        HttpClient(OkHttp) {
+            install(ContentNegotiation) {
+                json(json)
+            }
+            expectSuccess = false
+        }
+    }
+
+    private fun Map<String, String>.apiSig(secret: String): String {
+        val sorted = toSortedMap()
+        val toHash = sorted.entries.joinToString("") { it.key + it.value } + secret
+        val digest = MessageDigest.getInstance("MD5").digest(toHash.toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun HttpRequestBuilder.lastfmParams(
+        method: String,
+        apiKey: String,
+        secret: String,
+        sessionKey: String? = null,
+        extra: Map<String, String> = emptyMap(),
+        format: String = "json",
+    ) {
+        headers.append(HttpHeaders.UserAgent, "BitChord (https://github.com/kushagrasinghx/BitChord)")
+        val paramsForSig =
+            mutableMapOf(
+                "method" to method,
+                "api_key" to apiKey,
+            ).apply {
+                sessionKey?.let { put("sk", it) }
+                putAll(extra)
+            }
+        val apiSig = paramsForSig.apiSig(secret)
+
+        setBody(
+            FormDataContent(
+                Parameters.build {
+                    paramsForSig.forEach { (key, value) -> append(key, value) }
+                    append("api_sig", apiSig)
+                    append("format", format)
+                },
+            ),
+        )
+    }
+
+    suspend fun getToken() =
+        runCatching {
+            postAndDecode<TokenResponse>(
+                method = "auth.getToken",
+            )
+        }
+
+    suspend fun getSession(token: String) =
+        runCatching {
+            postAndDecode<Authentication>(
+                method = "auth.getSession",
+                extra = mapOf("token" to token),
+            )
+        }
+
+    fun getAuthUrl(token: String): String {
+        val config = runtimeConfig
+        return if (config.endpoint == LIBREFM_API_ENDPOINT) {
+            "https://libre.fm/api/auth?api_key=${config.apiKey}&token=$token"
+        } else {
+            "https://www.last.fm/api/auth/?api_key=${config.apiKey}&token=$token"
+        }
+    }
+
+    suspend fun getMobileSession(
+        username: String,
+        password: String,
+    ) = runCatching {
+        postAndDecode<Authentication>(
+            method = "auth.getMobileSession",
+            extra = mapOf("username" to username, "password" to password),
+        )
+    }
+
+    class LastFmException(
+        val code: Int,
+        override val message: String,
+    ) : Exception(message)
+
+    suspend fun updateNowPlaying(
+        artist: String,
+        track: String,
+        album: String? = null,
+        trackNumber: Int? = null,
+        duration: Int? = null,
+    ) = runCatching {
+        postAndRead(
+            method = "track.updateNowPlaying",
+            sessionKey = requireSessionKey(),
+            extra =
+                buildMap {
+                    put("artist", artist)
+                    put("track", track)
+                    album?.let { put("album", it) }
+                    trackNumber?.let { put("trackNumber", it.toString()) }
+                    duration?.let { put("duration", it.toString()) }
+                },
+        )
+    }
+
+    suspend fun scrobble(
+        artist: String,
+        track: String,
+        timestamp: Long,
+        album: String? = null,
+        trackNumber: Int? = null,
+        duration: Int? = null,
+    ) = runCatching {
+        postAndRead(
+            method = "track.scrobble",
+            sessionKey = requireSessionKey(),
+            extra =
+                buildMap {
+                    put("artist[0]", artist)
+                    put("track[0]", track)
+                    put("timestamp[0]", timestamp.toString())
+                    album?.let { put("album[0]", it) }
+                    trackNumber?.let { put("trackNumber[0]", it.toString()) }
+                    duration?.let { put("duration[0]", it.toString()) }
+                },
+        )
+    }
+
+    fun initialize(
+        apiKey: String,
+        secret: String,
+    ) {
+        configure(
+            endpoint = runtimeConfig.endpoint,
+            apiKey = apiKey,
+            secret = secret,
+            sessionKey = runtimeConfig.sessionKey,
+        )
+    }
+
+    fun configure(
+        endpoint: String,
+        apiKey: String,
+        secret: String,
+        sessionKey: String? = runtimeConfig.sessionKey,
+    ) {
+        runtimeConfig =
+            RuntimeConfig(
+                endpoint = normalizeEndpoint(endpoint),
+                apiKey = apiKey,
+                secret = secret,
+                sessionKey = sessionKey,
+            )
+    }
+
+    fun currentConfig(): RuntimeConfig = runtimeConfig
+
+    fun isInitialized(): Boolean = runtimeConfig.apiKey.isNotEmpty() && runtimeConfig.secret.isNotEmpty()
+
+    fun normalizeEndpoint(endpoint: String): String {
+        val uri = URI(endpoint.trim())
+        val scheme = uri.scheme?.lowercase()
+        require(scheme == "http" || scheme == "https")
+        require(!uri.host.isNullOrBlank())
+        require(uri.query == null && uri.fragment == null)
+
+        val path =
+            uri.path
+                ?.takeIf { it.isNotBlank() && it != "/" }
+                ?.trimEnd('/')
+                ?: "/2.0"
+
+        return URI(
+            scheme,
+            uri.userInfo,
+            uri.host,
+            uri.port,
+            "$path/",
+            null,
+            null,
+        ).toString()
+    }
+
+    private fun requireSessionKey(): String = runtimeConfig.sessionKey ?: throw LastFmException(9, "Session key missing")
+
+    private suspend inline fun <reified T> postAndDecode(
+        method: String,
+        sessionKey: String? = null,
+        extra: Map<String, String> = emptyMap(),
+    ): T =
+        json.decodeFromString(
+            postAndRead(
+                method = method,
+                sessionKey = sessionKey,
+                extra = extra,
+            ),
+        )
+
+    private suspend fun postAndRead(
+        method: String,
+        sessionKey: String? = null,
+        extra: Map<String, String> = emptyMap(),
+    ): String {
+        val config = runtimeConfig
+        val response =
+            client.post(config.endpoint) {
+                lastfmParams(
+                    method = method,
+                    apiKey = config.apiKey,
+                    secret = config.secret,
+                    sessionKey = sessionKey,
+                    extra = extra,
+                )
+            }
+
+        val responseText = response.bodyAsText()
+        if (!response.status.isSuccess()) {
+            throw LastFmException(response.status.value, response.status.description)
+        }
+        if (responseText.contains("\"error\"")) {
+            val error = json.decodeFromString<LastFmError>(responseText)
+            throw LastFmException(error.error, error.message)
+        }
+        return responseText
+    }
+
+    const val DEFAULT_SCROBBLE_DELAY_PERCENT = 0.5f
+    const val DEFAULT_SCROBBLE_MIN_SONG_DURATION = 30
+    const val DEFAULT_SCROBBLE_DELAY_SECONDS = 180
+}

--- a/app/src/main/java/com/music/bitchord/data/scrobbling/ListenBrainzManager.kt
+++ b/app/src/main/java/com/music/bitchord/data/scrobbling/ListenBrainzManager.kt
@@ -1,0 +1,112 @@
+package com.music.bitchord.data.scrobbling
+
+import android.util.Log
+import com.music.bitchord.data.model.Song
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import com.music.bitchord.data.Http
+
+object ListenBrainzManager {
+    private const val TAG = "ListenBrainzManager"
+    private const val API_URL = "https://api.listenbrainz.org/1/submit-listens"
+
+    suspend fun submitPlayingNow(
+        token: String,
+        song: Song?,
+        positionMs: Long,
+    ): Boolean {
+        if (token.isBlank() || song == null) return false
+        return withContext(Dispatchers.IO) {
+            try {
+                val durationMs = parseDurationMs(song.durationText)
+                val releaseName = song.albumName.orEmpty()
+                val releasePart = if (releaseName.isBlank()) "" else "\"release_name\":\"${escapeJson(releaseName)}\","
+                val trackMetadata = """{"track_metadata":{"artist_name":"${escapeJson(song.artist)}","track_name":"${escapeJson(song.title)}",$releasePart"additional_info":{"duration_ms":$durationMs,"position_ms":$positionMs,"submission_client":"BitChord"}}}"""
+                val bodyJson = "{\"listen_type\":\"playing_now\",\"payload\":[$trackMetadata]}"
+                Log.d(TAG, "submitPlayingNow: $bodyJson")
+                val body = bodyJson.toRequestBody("application/json".toMediaType())
+                val request =
+                    Request.Builder()
+                        .url(API_URL)
+                        .post(body)
+                        .addHeader("Content-Type", "application/json")
+                        .addHeader("Authorization", "Token $token")
+                        .build()
+
+                Http.client.newCall(request).execute().use { resp ->
+                    if (resp.isSuccessful) {
+                        Log.d(TAG, "playing_now submitted for ${song.title}")
+                        true
+                    } else {
+                        val bodyText = try { resp.body?.string() ?: "" } catch (_: Exception) { "" }
+                        Log.w(TAG, "playing_now submit failed: ${resp.code} - $bodyText")
+                        false
+                    }
+                }
+            } catch (ex: Exception) {
+                Log.e(TAG, "submitPlayingNow failed", ex)
+                false
+            }
+        }
+    }
+
+    suspend fun submitFinished(
+        token: String,
+        song: Song?,
+        startMs: Long,
+        endMs: Long,
+    ): Boolean {
+        if (token.isBlank() || song == null) return false
+        return withContext(Dispatchers.IO) {
+            try {
+                val durationMs = parseDurationMs(song.durationText)
+                val releaseName = song.albumName.orEmpty()
+                val releasePart = if (releaseName.isBlank()) "" else "\"release_name\":\"${escapeJson(releaseName)}\","
+                var listenedAtStart = startMs / 1000L
+                val MIN_LISTEN_TS = 1033430400L
+                if (listenedAtStart < MIN_LISTEN_TS) {
+                    listenedAtStart = System.currentTimeMillis() / 1000L
+                }
+                val trackMetadata = """{"listened_at":$listenedAtStart,"track_metadata":{"artist_name":"${escapeJson(song.artist)}","track_name":"${escapeJson(song.title)}",$releasePart"additional_info":{"duration_ms":$durationMs,"start_ms":$startMs,"end_ms":$endMs,"submission_client":"BitChord"}}}"""
+                val bodyJson = "{\"listen_type\":\"single\",\"payload\":[$trackMetadata]}"
+                Log.d(TAG, "submitFinished: $bodyJson")
+                val body = bodyJson.toRequestBody("application/json".toMediaType())
+                val request =
+                    Request.Builder()
+                        .url(API_URL)
+                        .post(body)
+                        .addHeader("Content-Type", "application/json")
+                        .addHeader("Authorization", "Token $token")
+                        .build()
+
+                Http.client.newCall(request).execute().use { resp ->
+                    if (resp.isSuccessful) {
+                        Log.d(TAG, "finished listen submitted for ${song.title}")
+                        true
+                    } else {
+                        val bodyText = try { resp.body?.string() ?: "" } catch (_: Exception) { "" }
+                        Log.w(TAG, "finished listen submit failed: ${resp.code} - $bodyText")
+                        false
+                    }
+                }
+            } catch (ex: Exception) {
+                Log.e(TAG, "submitFinished failed", ex)
+                false
+            }
+        }
+    }
+
+    private fun parseDurationMs(text: String?): Long {
+        if (text == null) return 0L
+        val parts = text.split(":")
+        if (parts.size != 2) return 0L
+        val minutes = parts[0].toLongOrNull() ?: return 0L
+        val seconds = parts[1].toLongOrNull() ?: return 0L
+        return (minutes * 60 + seconds) * 1000
+    }
+
+    private fun escapeJson(s: String): String = s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+}

--- a/app/src/main/java/com/music/bitchord/data/scrobbling/ListenBrainzManager.kt
+++ b/app/src/main/java/com/music/bitchord/data/scrobbling/ListenBrainzManager.kt
@@ -17,14 +17,18 @@ object ListenBrainzManager {
         token: String,
         song: Song?,
         positionMs: Long,
+        durationMsOverride: Long? = null,
     ): Boolean {
         if (token.isBlank() || song == null) return false
         return withContext(Dispatchers.IO) {
             try {
-                val durationMs = parseDurationMs(song.durationText)
+                val durationMs = durationMsOverride ?: parseDurationMs(song.durationText)
+                // The API rejects a zero/negative duration_ms, and it is
+                // optional — so only send it when it is actually known.
+                val durationPart = if (durationMs > 0) "\"duration_ms\":$durationMs," else ""
                 val releaseName = song.albumName.orEmpty()
                 val releasePart = if (releaseName.isBlank()) "" else "\"release_name\":\"${escapeJson(releaseName)}\","
-                val trackMetadata = """{"track_metadata":{"artist_name":"${escapeJson(song.artist)}","track_name":"${escapeJson(song.title)}",$releasePart"additional_info":{"duration_ms":$durationMs,"position_ms":$positionMs,"submission_client":"BitChord"}}}"""
+                val trackMetadata = """{"track_metadata":{"artist_name":"${escapeJson(song.artist)}","track_name":"${escapeJson(song.title)}",$releasePart"additional_info":{${durationPart}"position_ms":$positionMs,"submission_client":"BitChord"}}}"""
                 val bodyJson = "{\"listen_type\":\"playing_now\",\"payload\":[$trackMetadata]}"
                 Log.d(TAG, "submitPlayingNow: $bodyJson")
                 val body = bodyJson.toRequestBody("application/json".toMediaType())
@@ -58,11 +62,13 @@ object ListenBrainzManager {
         song: Song?,
         startMs: Long,
         endMs: Long,
+        durationMsOverride: Long? = null,
     ): Boolean {
         if (token.isBlank() || song == null) return false
         return withContext(Dispatchers.IO) {
             try {
-                val durationMs = parseDurationMs(song.durationText)
+                val durationMs = durationMsOverride ?: parseDurationMs(song.durationText)
+                val durationPart = if (durationMs > 0) "\"duration_ms\":$durationMs," else ""
                 val releaseName = song.albumName.orEmpty()
                 val releasePart = if (releaseName.isBlank()) "" else "\"release_name\":\"${escapeJson(releaseName)}\","
                 var listenedAtStart = startMs / 1000L
@@ -70,7 +76,7 @@ object ListenBrainzManager {
                 if (listenedAtStart < MIN_LISTEN_TS) {
                     listenedAtStart = System.currentTimeMillis() / 1000L
                 }
-                val trackMetadata = """{"listened_at":$listenedAtStart,"track_metadata":{"artist_name":"${escapeJson(song.artist)}","track_name":"${escapeJson(song.title)}",$releasePart"additional_info":{"duration_ms":$durationMs,"start_ms":$startMs,"end_ms":$endMs,"submission_client":"BitChord"}}}"""
+                val trackMetadata = """{"listened_at":$listenedAtStart,"track_metadata":{"artist_name":"${escapeJson(song.artist)}","track_name":"${escapeJson(song.title)}",$releasePart"additional_info":{${durationPart}"start_ms":$startMs,"end_ms":$endMs,"submission_client":"BitChord"}}}"""
                 val bodyJson = "{\"listen_type\":\"single\",\"payload\":[$trackMetadata]}"
                 Log.d(TAG, "submitFinished: $bodyJson")
                 val body = bodyJson.toRequestBody("application/json".toMediaType())

--- a/app/src/main/java/com/music/bitchord/data/scrobbling/ScrobbleManager.kt
+++ b/app/src/main/java/com/music/bitchord/data/scrobbling/ScrobbleManager.kt
@@ -1,0 +1,182 @@
+package com.music.bitchord.data.scrobbling
+
+import android.util.Log
+import com.music.bitchord.data.model.Song
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.min
+import kotlin.math.roundToLong
+
+class ScrobbleManager(
+    private val scope: CoroutineScope,
+    var minSongDuration: Int = 30,
+    var scrobbleDelayPercent: Float = 0.5f,
+    var scrobbleDelaySeconds: Int = 180,
+) {
+    private var scrobbleJob: Job? = null
+    private var scrobbleRemainingMillis: Long = 0L
+    private var scrobbleTimerStartedAt: Long = 0L
+    private var songStartedAt: Long = 0L
+    private var songStarted = false
+    var useNowPlaying = true
+
+    fun destroy() {
+        scrobbleJob?.cancel()
+        scrobbleRemainingMillis = 0L
+        scrobbleTimerStartedAt = 0L
+        songStartedAt = 0L
+        songStarted = false
+    }
+
+    fun onSongStart(
+        song: Song?,
+        durationMs: Long? = null,
+    ) {
+        if (song == null) return
+        songStartedAt = System.currentTimeMillis() / 1000
+        songStarted = true
+        startScrobbleTimer(song, durationMs)
+        if (useNowPlaying) {
+            updateNowPlaying(song)
+        }
+    }
+
+    fun onSongResume(song: Song) {
+        resumeScrobbleTimer(song)
+    }
+
+    fun onSongPause() {
+        pauseScrobbleTimer()
+    }
+
+    fun onSongStop() {
+        stopScrobbleTimer()
+        songStarted = false
+    }
+
+    private fun startScrobbleTimer(
+        song: Song,
+        durationMs: Long? = null,
+    ) {
+        scrobbleJob?.cancel()
+        val resolvedDurationSeconds = durationMs?.toInt()?.div(1000)
+            ?: song.durationText?.let { parseDurationSeconds(it) }
+            ?: return
+
+        if (resolvedDurationSeconds <= minSongDuration) return
+
+        val thresholdMs = (resolvedDurationSeconds * 1000L * scrobbleDelayPercent).roundToLong()
+        scrobbleRemainingMillis = min(thresholdMs, scrobbleDelaySeconds * 1000L)
+
+        if (scrobbleRemainingMillis <= 0) {
+            scrobbleSong(song, resolvedDurationSeconds)
+            return
+        }
+        scrobbleTimerStartedAt = System.currentTimeMillis()
+        scrobbleJob =
+            scope.launch {
+                delay(scrobbleRemainingMillis)
+                scrobbleSong(song, resolvedDurationSeconds)
+                scrobbleJob = null
+            }
+    }
+
+    private fun pauseScrobbleTimer() {
+        scrobbleJob?.cancel()
+        if (scrobbleTimerStartedAt != 0L) {
+            val elapsed = System.currentTimeMillis() - scrobbleTimerStartedAt
+            scrobbleRemainingMillis -= elapsed
+            if (scrobbleRemainingMillis < 0) scrobbleRemainingMillis = 0
+            scrobbleTimerStartedAt = 0L
+        }
+    }
+
+    private fun resumeScrobbleTimer(song: Song) {
+        if (scrobbleRemainingMillis <= 0) return
+        scrobbleJob?.cancel()
+        scrobbleTimerStartedAt = System.currentTimeMillis()
+        scrobbleJob =
+            scope.launch {
+                delay(scrobbleRemainingMillis)
+                val durationSeconds = song.durationText?.let { parseDurationSeconds(it) } ?: 0
+                scrobbleSong(song, durationSeconds)
+                scrobbleJob = null
+            }
+    }
+
+    private fun stopScrobbleTimer() {
+        scrobbleJob?.cancel()
+        scrobbleJob = null
+        scrobbleRemainingMillis = 0
+    }
+
+    private fun scrobbleSong(song: Song, durationSeconds: Int) {
+        scope.launch {
+            LastFM
+                .scrobble(
+                    artist = song.artist,
+                    track = song.title,
+                    duration = durationSeconds,
+                    timestamp = songStartedAt,
+                    album = song.albumName,
+                ).onSuccess {
+                    Log.d(TAG, "Scrobbled: ${song.title} by ${song.artist}")
+                }.onFailure { throwable ->
+                    if (throwable is CancellationException) throw throwable
+                    Log.e(TAG, "Failed to scrobble: ${song.title}", throwable)
+                }
+        }
+    }
+
+    private fun updateNowPlaying(song: Song) {
+        scope.launch {
+            LastFM
+                .updateNowPlaying(
+                    artist = song.artist,
+                    track = song.title,
+                    album = song.albumName,
+                    duration = song.durationText?.let { parseDurationSeconds(it) },
+                ).onSuccess {
+                    Log.d(TAG, "Updated now playing: ${song.title}")
+                }.onFailure { throwable ->
+                    if (throwable is CancellationException) throw throwable
+                    Log.e(TAG, "Failed to update now playing: ${song.title}", throwable)
+                }
+        }
+    }
+
+    fun onPlayerStateChanged(
+        isPlaying: Boolean,
+        song: Song?,
+        durationMs: Long? = null,
+    ) {
+        if (song == null) return
+        if (isPlaying) {
+            if (!songStarted) {
+                onSongStart(song, durationMs)
+            } else {
+                onSongResume(song)
+            }
+        } else {
+            onSongPause()
+        }
+    }
+
+    /**
+     * Parse "M:SS" or "MM:SS" duration text to total seconds.
+     */
+    private fun parseDurationSeconds(text: String): Int {
+        val parts = text.split(":")
+        if (parts.size != 2) return 0
+        val minutes = parts[0].toIntOrNull() ?: return 0
+        val seconds = parts[1].toIntOrNull() ?: return 0
+        return minutes * 60 + seconds
+    }
+
+    companion object {
+        private const val TAG = "ScrobbleManager"
+    }
+}

--- a/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
@@ -82,6 +82,22 @@ object AppSettings {
     /** Disk budget for cached audio. [AudioCache][com.music.bitchord.playback.AudioCache] evicts past it. */
     val audioCacheLimitBytes = MutableStateFlow(DEFAULT_CACHE_LIMIT_BYTES)
 
+    // ── Scrobbling ──────────────────────────────────────────────────────
+
+    val lastfmEnabled = MutableStateFlow(false)
+    val lastfmUsername = MutableStateFlow("")
+    val lastfmSessionKey = MutableStateFlow("")
+    val lastfmApiKey = MutableStateFlow("")
+    val lastfmSecret = MutableStateFlow("")
+    val lastfmEndpoint = MutableStateFlow("")
+    val lastfmScrobbleEnabled = MutableStateFlow(false)
+    val lastfmNowPlaying = MutableStateFlow(false)
+    val scrobbleMinDuration = MutableStateFlow(30)
+    val scrobbleDelayPercent = MutableStateFlow(0.5f)
+    val scrobbleDelaySeconds = MutableStateFlow(180)
+    val listenBrainzEnabled = MutableStateFlow(false)
+    val listenBrainzToken = MutableStateFlow("")
+
     /** Published by PlaybackService so the UI can open the system equalizer. */
     val audioSessionId = MutableStateFlow(0)
 
@@ -111,6 +127,19 @@ object AppSettings {
         reduceDynamicBlur.value = prefs.getBoolean(KEY_REDUCE_BLUR, false)
         audioCacheLimitBytes.value = prefs.getLong(KEY_CACHE_LIMIT, DEFAULT_CACHE_LIMIT_BYTES)
             .coerceIn(DEFAULT_CACHE_LIMIT_BYTES, MAX_CACHE_LIMIT_BYTES)
+        lastfmEnabled.value = prefs.getBoolean(KEY_LASTFM_ENABLED, false)
+        lastfmUsername.value = prefs.getString(KEY_LASTFM_USERNAME, "").orEmpty()
+        lastfmSessionKey.value = prefs.getString(KEY_LASTFM_SESSION_KEY, "").orEmpty()
+        lastfmApiKey.value = prefs.getString(KEY_LASTFM_API_KEY, "").orEmpty()
+        lastfmSecret.value = prefs.getString(KEY_LASTFM_SECRET, "").orEmpty()
+        lastfmEndpoint.value = prefs.getString(KEY_LASTFM_ENDPOINT, "").orEmpty()
+        lastfmScrobbleEnabled.value = prefs.getBoolean(KEY_LASTFM_SCROBBLE_ENABLED, false)
+        lastfmNowPlaying.value = prefs.getBoolean(KEY_LASTFM_NOW_PLAYING, false)
+        scrobbleMinDuration.value = prefs.getInt(KEY_SCROBBLE_MIN_DURATION, 30)
+        scrobbleDelayPercent.value = prefs.getFloat(KEY_SCROBBLE_DELAY_PERCENT, 0.5f)
+        scrobbleDelaySeconds.value = prefs.getInt(KEY_SCROBBLE_DELAY_SECONDS, 180)
+        listenBrainzEnabled.value = prefs.getBoolean(KEY_LISTENBRAINZ_ENABLED, false)
+        listenBrainzToken.value = prefs.getString(KEY_LISTENBRAINZ_TOKEN, "").orEmpty()
         watchConnection(context)
     }
 
@@ -223,6 +252,71 @@ object AppSettings {
         prefs.edit().putLong(KEY_CACHE_LIMIT, clamped).apply()
     }
 
+    fun setLastfmEnabled(value: Boolean) {
+        lastfmEnabled.value = value
+        prefs.edit().putBoolean(KEY_LASTFM_ENABLED, value).apply()
+    }
+
+    fun setLastfmUsername(value: String) {
+        lastfmUsername.value = value
+        prefs.edit().putString(KEY_LASTFM_USERNAME, value).apply()
+    }
+
+    fun setLastfmSessionKey(value: String) {
+        lastfmSessionKey.value = value
+        prefs.edit().putString(KEY_LASTFM_SESSION_KEY, value).apply()
+    }
+
+    fun setLastfmApiKey(value: String) {
+        lastfmApiKey.value = value
+        prefs.edit().putString(KEY_LASTFM_API_KEY, value).apply()
+    }
+
+    fun setLastfmSecret(value: String) {
+        lastfmSecret.value = value
+        prefs.edit().putString(KEY_LASTFM_SECRET, value).apply()
+    }
+
+    fun setLastfmEndpoint(value: String) {
+        lastfmEndpoint.value = value
+        prefs.edit().putString(KEY_LASTFM_ENDPOINT, value).apply()
+    }
+
+    fun setLastfmScrobbleEnabled(value: Boolean) {
+        lastfmScrobbleEnabled.value = value
+        prefs.edit().putBoolean(KEY_LASTFM_SCROBBLE_ENABLED, value).apply()
+    }
+
+    fun setLastfmNowPlaying(value: Boolean) {
+        lastfmNowPlaying.value = value
+        prefs.edit().putBoolean(KEY_LASTFM_NOW_PLAYING, value).apply()
+    }
+
+    fun setScrobbleMinDuration(value: Int) {
+        scrobbleMinDuration.value = value
+        prefs.edit().putInt(KEY_SCROBBLE_MIN_DURATION, value).apply()
+    }
+
+    fun setScrobbleDelayPercent(value: Float) {
+        scrobbleDelayPercent.value = value
+        prefs.edit().putFloat(KEY_SCROBBLE_DELAY_PERCENT, value).apply()
+    }
+
+    fun setScrobbleDelaySeconds(value: Int) {
+        scrobbleDelaySeconds.value = value
+        prefs.edit().putInt(KEY_SCROBBLE_DELAY_SECONDS, value).apply()
+    }
+
+    fun setListenBrainzEnabled(value: Boolean) {
+        listenBrainzEnabled.value = value
+        prefs.edit().putBoolean(KEY_LISTENBRAINZ_ENABLED, value).apply()
+    }
+
+    fun setListenBrainzToken(value: String) {
+        listenBrainzToken.value = value
+        prefs.edit().putString(KEY_LISTENBRAINZ_TOKEN, value).apply()
+    }
+
     const val DEFAULT_CACHE_LIMIT_BYTES = 512L * 1024 * 1024
     const val MAX_CACHE_LIMIT_BYTES = 10L * 1024 * 1024 * 1024
 
@@ -239,4 +333,18 @@ object AppSettings {
     private const val KEY_CACHE_LIMIT = "audio_cache_limit_bytes"
     private const val KEY_REDUCE_ANIMATION = "reduce_animation"
     private const val KEY_REDUCE_BLUR = "reduce_dynamic_blur"
+
+    private const val KEY_LASTFM_ENABLED = "lastfm_enabled"
+    private const val KEY_LASTFM_USERNAME = "lastfm_username"
+    private const val KEY_LASTFM_SESSION_KEY = "lastfm_session_key"
+    private const val KEY_LASTFM_API_KEY = "lastfm_api_key"
+    private const val KEY_LASTFM_SECRET = "lastfm_secret"
+    private const val KEY_LASTFM_ENDPOINT = "lastfm_endpoint"
+    private const val KEY_LASTFM_SCROBBLE_ENABLED = "lastfm_scrobble_enabled"
+    private const val KEY_LASTFM_NOW_PLAYING = "lastfm_now_playing"
+    private const val KEY_SCROBBLE_MIN_DURATION = "scrobble_min_duration"
+    private const val KEY_SCROBBLE_DELAY_PERCENT = "scrobble_delay_percent"
+    private const val KEY_SCROBBLE_DELAY_SECONDS = "scrobble_delay_seconds"
+    private const val KEY_LISTENBRAINZ_ENABLED = "listenbrainz_enabled"
+    private const val KEY_LISTENBRAINZ_TOKEN = "listenbrainz_token"
 }

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -85,8 +85,10 @@ class PlaybackService : MediaSessionService() {
 
     private var scrobbleManager: ScrobbleManager? = null
     private var listenBrainzSong: Song? = null
+
     private var listenBrainzStartMs: Long = 0L
 
+    private var listenBrainzDurationMs: Long? = null
     /**
      * The crossfade's tail player runs its own audio sink, so it needs its own
      * instance of the effect — [SpatialAudioProcessor] carries a delay line and
@@ -180,6 +182,18 @@ class PlaybackService : MediaSessionService() {
                 val song = exoPlayer.currentMediaItem?.toSong()
                 val durationMs = exoPlayer.duration.takeIf { it > 0 }
                 scrobbleManager?.onPlayerStateChanged(isPlaying, song, durationMs)
+
+                // ListenBrainz: "now playing" on play/resume too, not just on
+                // transition — a track started from idle or resumed from pause
+                // otherwise stays silent on the site.
+                if (isPlaying && song != null) {
+                    if (listenBrainzSong == null) {
+                        listenBrainzSong = song
+                        listenBrainzStartMs = System.currentTimeMillis()
+                        listenBrainzDurationMs = durationMs
+                    }
+                    submitListenBrainzPlayingNow(song, exoPlayer.currentPosition, durationMs)
+                }
             }
 
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -194,43 +208,30 @@ class PlaybackService : MediaSessionService() {
                 val durationMs = exoPlayer.duration.takeIf { it > 0 }
                 scrobbleManager?.onSongStart(newSong, durationMs)
 
-                // ListenBrainz: submit finished for old song, playing_now for new song
+                // ListenBrainz: submit finished for old song, playing_now for new song.
+                // The finished listen only counts when the track actually ended —
+                // an auto-advance, a repeat, or a crossfade at the very end. A
+                // manual skip (SEEK) means the song wasn't listened to, so it must
+                // not be scrobbled.
+                val crossfaded = crossfade?.consumeAutoAdvance() == true
+                val ended = crossfaded ||
+                    reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO ||
+                    reason == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT
                 val prevSong = listenBrainzSong
                 val prevStart = listenBrainzStartMs
-                if (prevSong != null) {
-                    val lbEnabled = AppSettings.listenBrainzEnabled.value
-                    val lbToken = AppSettings.listenBrainzToken.value
-                    if (lbEnabled && lbToken.isNotBlank()) {
-                        val endMs = System.currentTimeMillis()
-                        scope.launch {
-                            ListenBrainzManager.submitFinished(lbToken, prevSong, prevStart, endMs)
-                        }
-                    }
+                if (prevSong != null && ended) {
+                    submitListenBrainzFinished(prevSong, prevStart, listenBrainzDurationMs)
                 }
                 listenBrainzSong = newSong
                 listenBrainzStartMs = System.currentTimeMillis()
+                listenBrainzDurationMs = durationMs
                 if (newSong != null) {
-                    val lbEnabled = AppSettings.listenBrainzEnabled.value
-                    val lbToken = AppSettings.listenBrainzToken.value
-                    if (lbEnabled && lbToken.isNotBlank()) {
-                        scope.launch {
-                            ListenBrainzManager.submitPlayingNow(lbToken, newSong, 0L)
-                        }
-                    }
+                    submitListenBrainzPlayingNow(newSong, 0L, durationMs)
                 }
 
                 // "Sleep after this song": the queue moving on by itself is the
                 // moment the track the user meant has finished. REPEAT counts
                 // too, or the timer would never fire with repeat-one on.
-                //
-                // A crossfade arrives as a SEEK, because moving the queue on
-                // early is exactly how it starts the next track while the last
-                // one is still fading. Indistinguishable from a manual skip
-                // from here, so the crossfade says which of the two it was.
-                val crossfaded = crossfade?.consumeAutoAdvance() == true
-                val ended = crossfaded ||
-                    reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO ||
-                    reason == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT
                 if (ended && SleepTimer.afterTrack.value) {
                     exoPlayer.pause()
                     SleepTimer.cancel()
@@ -246,7 +247,19 @@ class PlaybackService : MediaSessionService() {
             // Nothing follows the last track, so there is no transition to
             // pause on — the queue simply runs out and the timer is spent.
             override fun onPlaybackStateChanged(state: Int) {
-                if (state == Player.STATE_ENDED) SleepTimer.cancel()
+                if (state == Player.STATE_ENDED) {
+                    SleepTimer.cancel()
+                    // The last track finished with nothing after it, so no
+                    // transition will ever close it out. Scrobble it now.
+                    val lastSong = listenBrainzSong
+                    if (lastSong != null) {
+                        val lastStart = listenBrainzStartMs
+                        val lastDuration = listenBrainzDurationMs
+                            ?: exoPlayer.duration.takeIf { it > 0 }
+                        submitListenBrainzFinished(lastSong, lastStart, lastDuration)
+                        listenBrainzSong = null
+                    }
+                }
             }
 
             /**
@@ -647,6 +660,31 @@ class PlaybackService : MediaSessionService() {
         val delaySeconds: Int,
     )
 
+    /**
+     * Submits a finished ListenBrainz listen, but only if the service is
+     * actually scrobbling — the settings are read at call time so the helper
+     * stays a no-op whenever ListenBrainz is switched off.
+     */
+    private fun submitListenBrainzFinished(song: Song, startMs: Long, durationMs: Long?) {
+        val lbEnabled = AppSettings.listenBrainzEnabled.value
+        val lbToken = AppSettings.listenBrainzToken.value
+        if (!lbEnabled || lbToken.isBlank()) return
+        val endMs = System.currentTimeMillis()
+        scope.launch {
+            ListenBrainzManager.submitFinished(lbToken, song, startMs, endMs, durationMs)
+        }
+    }
+
+    /** Sends a ListenBrainz "now playing" update for the current track. */
+    private fun submitListenBrainzPlayingNow(song: Song, positionMs: Long, durationMs: Long?) {
+        val lbEnabled = AppSettings.listenBrainzEnabled.value
+        val lbToken = AppSettings.listenBrainzToken.value
+        if (!lbEnabled || lbToken.isBlank()) return
+        scope.launch {
+            ListenBrainzManager.submitPlayingNow(lbToken, song, positionMs, durationMs)
+        }
+    }
+
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? =
         mediaSession
 
@@ -654,6 +692,25 @@ class PlaybackService : MediaSessionService() {
         // Last chance to record the resume point, while the player still exists.
         saveQueue()
         AudioCache.cancel()
+        // Also the last chance to close out the track that was playing — a
+        // swipe-away or stop never fires STATE_ENDED, so the session would
+        // otherwise end with an un-scrobbled song. This must not ride on the
+        // service scope: it is cancelled a few lines down, and the request
+        // should still reach ListenBrainz.
+        val lastSong = listenBrainzSong
+        if (lastSong != null) {
+            val lbEnabled = AppSettings.listenBrainzEnabled.value
+            val lbToken = AppSettings.listenBrainzToken.value
+            if (lbEnabled && lbToken.isNotBlank()) {
+                val lastStart = listenBrainzStartMs
+                val lastDuration = player?.duration?.takeIf { it > 0 }
+                CoroutineScope(Dispatchers.IO).launch {
+                    ListenBrainzManager.submitFinished(
+                        lbToken, lastSong, lastStart, System.currentTimeMillis(), lastDuration,
+                    )
+                }
+            }
+        }
         scrobbleManager?.destroy()
         scrobbleManager = null
         scope.cancel()

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -35,6 +35,10 @@ import com.music.bitchord.data.NerdStats
 import com.music.bitchord.data.innertube.PlaybackTracker
 import com.music.bitchord.data.innertube.PlayerClient
 import com.music.bitchord.data.innertube.StreamResolver
+import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.scrobbling.LastFM
+import com.music.bitchord.data.scrobbling.ListenBrainzManager
+import com.music.bitchord.data.scrobbling.ScrobbleManager
 import com.music.bitchord.data.settings.AppSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -46,6 +50,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.TimeoutCancellationException
 
 /** Past this point in a track, back restarts it instead of skipping to the previous one. */
 const val BACK_RESTARTS_AFTER_MS = 10_000L
@@ -71,6 +77,16 @@ class PlaybackService : MediaSessionService() {
     private var crossfade: CrossfadeController? = null
     private val spatialAudioProcessor = SpatialAudioProcessor()
 
+    /** Shared with the crossfade's tail player, so both read the same disk cache. */
+    private var mediaSourceFactory: DefaultMediaSourceFactory? = null
+
+    /** Last sampled position of the playing track, in seconds. */
+    private var lastPositionSeconds = 0L
+
+    private var scrobbleManager: ScrobbleManager? = null
+    private var listenBrainzSong: Song? = null
+    private var listenBrainzStartMs: Long = 0L
+
     /**
      * The crossfade's tail player runs its own audio sink, so it needs its own
      * instance of the effect — [SpatialAudioProcessor] carries a delay line and
@@ -78,12 +94,6 @@ class PlaybackService : MediaSessionService() {
      */
     private val ghostSpatialAudioProcessor = SpatialAudioProcessor()
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
-
-    /** Shared with the crossfade's tail player, so both read the same disk cache. */
-    private var mediaSourceFactory: DefaultMediaSourceFactory? = null
-
-    /** Last sampled position of the playing track, in seconds. */
-    private var lastPositionSeconds = 0L
 
     override fun onCreate() {
         super.onCreate()
@@ -109,7 +119,13 @@ class PlaybackService : MediaSessionService() {
         ) { dataSpec ->
             val videoId = dataSpec.uri.getQueryParameter("v")
                 ?: return@Factory dataSpec
-            val streamUrl = runBlocking { StreamResolver.resolve(videoId) }
+            val streamUrl = try {
+                runBlocking {
+                    withTimeout(RESOLVE_TIMEOUT_MS) { StreamResolver.resolve(videoId) }
+                }
+            } catch (e: TimeoutCancellationException) {
+                throw java.io.IOException("Stream resolution timed out for $videoId", e)
+            }
             dataSpec.buildUpon()
                 .setUri(Uri.parse(streamUrl))
                 // googlevideo names the client that minted the URL inside the
@@ -145,6 +161,7 @@ class PlaybackService : MediaSessionService() {
         AppSettings.audioSessionId.value = exoPlayer.audioSessionId
         applySettings(exoPlayer)
         observeSettings()
+        observeScrobbling()
         watchSleepTimer()
         // Before the listener below is attached, so loading the queue doesn't
         // read as a track change and set the read-ahead going.
@@ -159,6 +176,10 @@ class PlaybackService : MediaSessionService() {
                 // the last thing that happens before the process goes idle.
                 if (isPlaying) prefetchAround(exoPlayer) else AudioCache.cancel()
                 saveQueue()
+
+                val song = exoPlayer.currentMediaItem?.toSong()
+                val durationMs = exoPlayer.duration.takeIf { it > 0 }
+                scrobbleManager?.onPlayerStateChanged(isPlaying, song, durationMs)
             }
 
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -166,6 +187,38 @@ class PlaybackService : MediaSessionService() {
                 // the outgoing track is closed out on the last sampled value.
                 PlaybackTracker.onTrackChanged(lastPositionSeconds)
                 lastPositionSeconds = 0
+
+                // Scrobbling: stop old song, start new song
+                scrobbleManager?.onSongStop()
+                val newSong = mediaItem?.toSong()
+                val durationMs = exoPlayer.duration.takeIf { it > 0 }
+                scrobbleManager?.onSongStart(newSong, durationMs)
+
+                // ListenBrainz: submit finished for old song, playing_now for new song
+                val prevSong = listenBrainzSong
+                val prevStart = listenBrainzStartMs
+                if (prevSong != null) {
+                    val lbEnabled = AppSettings.listenBrainzEnabled.value
+                    val lbToken = AppSettings.listenBrainzToken.value
+                    if (lbEnabled && lbToken.isNotBlank()) {
+                        val endMs = System.currentTimeMillis()
+                        scope.launch {
+                            ListenBrainzManager.submitFinished(lbToken, prevSong, prevStart, endMs)
+                        }
+                    }
+                }
+                listenBrainzSong = newSong
+                listenBrainzStartMs = System.currentTimeMillis()
+                if (newSong != null) {
+                    val lbEnabled = AppSettings.listenBrainzEnabled.value
+                    val lbToken = AppSettings.listenBrainzToken.value
+                    if (lbEnabled && lbToken.isNotBlank()) {
+                        scope.launch {
+                            ListenBrainzManager.submitPlayingNow(lbToken, newSong, 0L)
+                        }
+                    }
+                }
+
                 // "Sleep after this song": the queue moving on by itself is the
                 // moment the track the user meant has finished. REPEAT counts
                 // too, or the timer would never fire with repeat-one on.
@@ -526,6 +579,74 @@ class PlaybackService : MediaSessionService() {
         }
     }
 
+    private fun observeScrobbling() {
+        // Rebuild the ScrobbleManager whenever scrobbling settings change.
+        scope.launch {
+            combine(
+                AppSettings.lastfmEnabled,
+                AppSettings.lastfmScrobbleEnabled,
+                AppSettings.lastfmNowPlaying,
+                AppSettings.lastfmSessionKey,
+                AppSettings.lastfmApiKey,
+                AppSettings.lastfmSecret,
+                AppSettings.lastfmEndpoint,
+                AppSettings.scrobbleMinDuration,
+                AppSettings.scrobbleDelayPercent,
+                AppSettings.scrobbleDelaySeconds,
+            ) { values ->
+                ScrobblingSnapshot(
+                    lastfmEnabled = values[0] as Boolean,
+                    scrobbleEnabled = values[1] as Boolean,
+                    nowPlaying = values[2] as Boolean,
+                    sessionKey = values[3] as String,
+                    apiKey = values[4] as String,
+                    secret = values[5] as String,
+                    endpoint = values[6] as String,
+                    minDuration = values[7] as Int,
+                    delayPercent = values[8] as Float,
+                    delaySeconds = values[9] as Int,
+                )
+            }.collectLatest { snapshot ->
+                scrobbleManager?.destroy()
+                scrobbleManager = null
+
+                if (snapshot.lastfmEnabled && snapshot.sessionKey.isNotBlank()) {
+                    // Configure LastFM client
+                    val endpoint = snapshot.endpoint.ifBlank { LastFM.DEFAULT_API_ENDPOINT }
+                    val apiKey = snapshot.apiKey.ifBlank { LastFM.FALLBACK_COMPAT_API_KEY }
+                    val secret = snapshot.secret.ifBlank { LastFM.FALLBACK_COMPAT_SECRET }
+                    LastFM.configure(
+                        endpoint = endpoint,
+                        apiKey = apiKey,
+                        secret = secret,
+                        sessionKey = snapshot.sessionKey,
+                    )
+                    scrobbleManager = ScrobbleManager(
+                        scope = scope,
+                        minSongDuration = snapshot.minDuration,
+                        scrobbleDelayPercent = snapshot.delayPercent,
+                        scrobbleDelaySeconds = snapshot.delaySeconds,
+                    ).apply {
+                        useNowPlaying = snapshot.nowPlaying
+                    }
+                }
+            }
+        }
+    }
+
+    private data class ScrobblingSnapshot(
+        val lastfmEnabled: Boolean,
+        val scrobbleEnabled: Boolean,
+        val nowPlaying: Boolean,
+        val sessionKey: String,
+        val apiKey: String,
+        val secret: String,
+        val endpoint: String,
+        val minDuration: Int,
+        val delayPercent: Float,
+        val delaySeconds: Int,
+    )
+
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? =
         mediaSession
 
@@ -533,6 +654,8 @@ class PlaybackService : MediaSessionService() {
         // Last chance to record the resume point, while the player still exists.
         saveQueue()
         AudioCache.cancel()
+        scrobbleManager?.destroy()
+        scrobbleManager = null
         scope.cancel()
         crossfade?.release()
         crossfade = null
@@ -624,5 +747,12 @@ class PlaybackService : MediaSessionService() {
 
         /** More room after a stall than at the start — see the load control. */
         const val RESUME_PLAYBACK_MS = 2_000
+
+        /**
+         * Outer cap on stream resolution. Individual client calls and probes
+         * have their own timeouts, but iterating all six plus the NewPipe
+         * fallback can accumulate far beyond what a listener should wait.
+         */
+        const val RESOLVE_TIMEOUT_MS = 45_000L
     }
 }

--- a/app/src/main/java/com/music/bitchord/ui/components/FloatingBottomBar.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/FloatingBottomBar.kt
@@ -8,8 +8,10 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,13 +20,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,7 +41,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.music.bitchord.data.settings.AppSettings
@@ -42,16 +57,6 @@ data class BottomTab(
     val icon: ImageVector,
 )
 
-/**
- * Floating translucent pill navigation, Telegram-flavoured:
- * thick-stroke icons and a springy (slightly overshooting) scale +
- * tinted-capsule selection animation.
- *
- * No blur of its own: the bottom fade blur it floats on is at full strength by
- * the time it reaches this far down, so the pill only needs the tint half of
- * that recipe. The alphas below are the ones [HazeMaterials.thin] applies, so
- * the body still matches the mini player sitting above it.
- */
 @Composable
 fun FloatingBottomBar(
     tabs: List<BottomTab>,
@@ -59,39 +64,126 @@ fun FloatingBottomBar(
     onTabSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Fully rounded ends, whatever the bar's height works out to.
     val pillShape = RoundedCornerShape(percent = 50)
     val container = MaterialTheme.colorScheme.surface
     val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
-    // With the frosted floor beneath it gone, the pill needs a solid fill of
-    // its own instead of a tint meant to sit on top of that blur.
     val glass = if (reduceDynamicBlur) {
         container
     } else {
         container.copy(alpha = if (container.luminance() >= 0.5f) 0.6f else 0.65f)
     }
-    Row(
+
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+    val haptics = LocalHapticFeedback.current
+    val density = LocalDensity.current
+    val currentSelectedIndex by rememberUpdatedState(selectedIndex)
+
+    var rowSize by remember { mutableStateOf(IntSize.Zero) }
+    val gapPx = with(density) { 6.dp.toPx() }
+    val n = tabs.size
+
+    // With weight(1f) + spacedBy(gap):
+    //   tabWidth = (rowWidth - gap*(n-1)) / n
+    //   tab i left edge = i * (tabWidth + gap) = i * (rowWidth + gap) / n
+    val tabWidthPx = if (rowSize.width > 0 && n > 0) {
+        (rowSize.width - gapPx * (n - 1)) / n
+    } else 0f
+    val tabStepPx = if (rowSize.width > 0 && n > 0) {
+        (rowSize.width + gapPx) / n
+    } else 0f
+
+    val pillTargetPx = if (tabStepPx > 0f) {
+        selectedIndex * tabStepPx - dragOffset
+    } else 0f
+
+    val animatedPillOffset by animateFloatAsState(
+        targetValue = pillTargetPx,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "pillOffset",
+    )
+
+    val tabStepDp = with(density) { tabStepPx.toDp() }
+    var lastHapticTab by remember { mutableIntStateOf(selectedIndex) }
+
+    LaunchedEffect(selectedIndex) { dragOffset = 0f }
+
+    Box(
         modifier = modifier
             .navigationBarsPadding()
             .padding(horizontal = PAGE_GUTTER)
-            // Sits close to the gesture bar, Apple-style.
             .padding(bottom = 2.dp)
             .fillMaxWidth()
             .clip(pillShape)
             .background(glass)
             .border(0.5.dp, Color.White.copy(alpha = 0.10f), pillShape)
             .padding(horizontal = 8.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalAlignment = Alignment.CenterVertically,
     ) {
-        // Equal weights: the gaps stay even however wide the screen is.
-        tabs.forEachIndexed { index, tab ->
-            BottomBarItem(
-                tab = tab,
-                selected = index == selectedIndex,
-                onClick = { onTabSelected(index) },
-                modifier = Modifier.weight(1f),
+        if (tabWidthPx > 0f) {
+            Box(
+                modifier = Modifier
+                    .width(with(density) { tabWidthPx.toDp() })
+                    .height(with(density) { rowSize.height.toDp() })
+                    .graphicsLayer { translationX = animatedPillOffset }
+                    .clip(pillShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)),
             )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .onSizeChanged { rowSize = it }
+                .pointerInput(Unit) {
+                    var totalDrag = 0f
+                    detectHorizontalDragGestures(
+                        onDragStart = { totalDrag = 0f },
+                        onDragCancel = { dragOffset = 0f },
+                        onDragEnd = {
+                            val threshold = tabStepPx * 0.35f
+                            when {
+                                totalDrag > threshold && currentSelectedIndex < tabs.lastIndex ->
+                                    onTabSelected(currentSelectedIndex + 1)
+                                totalDrag < -threshold && currentSelectedIndex > 0 ->
+                                    onTabSelected(currentSelectedIndex - 1)
+                            }
+                            dragOffset = 0f
+                        },
+                        onHorizontalDrag = { _, delta ->
+                            totalDrag += delta
+                            val rawPx = when {
+                                totalDrag > 0 && currentSelectedIndex == tabs.lastIndex ->
+                                    totalDrag * 0.25f
+                                totalDrag < 0 && currentSelectedIndex == 0 ->
+                                    totalDrag * 0.25f
+                                else -> totalDrag
+                            }
+                            dragOffset = with(density) { rawPx.toDp().value }
+
+                            val approxTab =
+                                (currentSelectedIndex - dragOffset / tabStepDp.value)
+                                    .coerceIn(0f, tabs.lastIndex.toFloat())
+                                    .toInt()
+                            if (approxTab != lastHapticTab) {
+                                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                lastHapticTab = approxTab
+                            }
+                        },
+                    )
+                },
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            tabs.forEachIndexed { index, tab ->
+                BottomBarItem(
+                    tab = tab,
+                    selected = index == selectedIndex,
+                    onClick = { onTabSelected(index) },
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
     }
 }
@@ -120,31 +212,22 @@ private fun BottomBarItem(
         animationSpec = tween(200),
         label = "tabTint",
     )
-    val capsuleAlpha by animateFloatAsState(
-        targetValue = if (selected) 0.14f else 0f,
-        animationSpec = tween(200),
-        label = "tabCapsule",
-    )
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
-            // Matches the bar's own ends rather than a softened rectangle.
             .clip(RoundedCornerShape(percent = 50))
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
                 onClick = onClick,
             )
-            .background(MaterialTheme.colorScheme.primary.copy(alpha = capsuleAlpha))
             .padding(vertical = 7.dp),
     ) {
         Icon(
             imageVector = tab.icon,
             contentDescription = tab.label,
             tint = tint,
-            // Scale the glyph, not the capsule — a growing capsule would
-            // crowd its neighbours now that the slots are fixed widths.
             modifier = Modifier
                 .size(25.dp)
                 .graphicsLayer {

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -5,6 +5,7 @@ import android.media.AudioManager
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
@@ -309,6 +310,8 @@ fun NowPlayingScreen(
     var queueOpen by remember { mutableStateOf(false) }
     var lyricsOpen by remember { mutableStateOf(false) }
     LaunchedEffect(song.videoId) { lyricsOpen = false }
+
+    BackHandler(enabled = lyricsOpen) { lyricsOpen = false }
 
     // Which line is playing right now: the last one whose stamp has passed.
     val activeLine = remember(lyrics, positionMs) {

--- a/app/src/main/java/com/music/bitchord/ui/screens/AccountAndScrobblingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/AccountAndScrobblingScreen.kt
@@ -1,0 +1,315 @@
+package com.music.bitchord.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Cloud
+import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.History
+import androidx.compose.material.icons.rounded.Tune
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.music.bitchord.data.model.Account
+import com.music.bitchord.data.scrobbling.LastFM
+import com.music.bitchord.data.settings.AppSettings
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountAndScrobblingScreen(
+    signedIn: Boolean,
+    account: Account?,
+    onSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+    contentPadding: PaddingValues,
+    modifier: Modifier = Modifier,
+) {
+    val lastfmEnabled by AppSettings.lastfmEnabled.collectAsStateWithLifecycle()
+    val lastfmUsername by AppSettings.lastfmUsername.collectAsStateWithLifecycle()
+    val lastfmSessionKey by AppSettings.lastfmSessionKey.collectAsStateWithLifecycle()
+    val lastfmScrobbleEnabled by AppSettings.lastfmScrobbleEnabled.collectAsStateWithLifecycle()
+    val lastfmNowPlayingEnabled by AppSettings.lastfmNowPlaying.collectAsStateWithLifecycle()
+    val scrobbleMinDuration by AppSettings.scrobbleMinDuration.collectAsStateWithLifecycle()
+    val scrobbleDelayPercent by AppSettings.scrobbleDelayPercent.collectAsStateWithLifecycle()
+    val scrobbleDelaySeconds by AppSettings.scrobbleDelaySeconds.collectAsStateWithLifecycle()
+    val listenBrainzEnabled by AppSettings.listenBrainzEnabled.collectAsStateWithLifecycle()
+    val listenBrainzToken by AppSettings.listenBrainzToken.collectAsStateWithLifecycle()
+
+    var showListenBrainzTokenDialog by remember { mutableStateOf(false) }
+    var showLastfmLoginDialog by remember { mutableStateOf(false) }
+    val scrobbleScope = rememberCoroutineScope()
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(contentPadding),
+    ) {
+        Text(
+            text = "Account & scrobbling",
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp, bottom = 14.dp),
+        )
+
+        AccountCard(signedIn = signedIn, account = account, onSignIn = onSignIn)
+
+        if (signedIn) {
+            SettingsGroup {
+                DestructiveRow(label = "Sign out", onClick = onSignOut)
+            }
+        }
+
+        SettingsGroup(
+            header = "Scrobbling",
+            footer = "Scrobble your listens to Last.fm and ListenBrainz.",
+        ) {
+            SettingsRow(
+                icon = Icons.Rounded.Cloud,
+                title = "ListenBrainz",
+                subtitle = if (listenBrainzEnabled && listenBrainzToken.isNotBlank()) "Connected" else "Enter a token to enable",
+                trailing = {
+                    Switch(
+                        checked = listenBrainzEnabled,
+                        onCheckedChange = AppSettings::setListenBrainzEnabled,
+                        colors = SwitchDefaults.colors(
+                            checkedTrackColor = MaterialTheme.colorScheme.primary,
+                            checkedBorderColor = MaterialTheme.colorScheme.primary,
+                        ),
+                    )
+                },
+                onClick = { showListenBrainzTokenDialog = true },
+            )
+            RowDivider()
+            SettingsRow(
+                icon = Icons.Rounded.History,
+                title = "Last.fm",
+                subtitle = if (lastfmSessionKey.isNotBlank()) "Signed in as $lastfmUsername" else "Tap to sign in",
+                trailing = {
+                    Switch(
+                        checked = lastfmEnabled,
+                        onCheckedChange = AppSettings::setLastfmEnabled,
+                        colors = SwitchDefaults.colors(
+                            checkedTrackColor = MaterialTheme.colorScheme.primary,
+                            checkedBorderColor = MaterialTheme.colorScheme.primary,
+                        ),
+                    )
+                },
+                onClick = {
+                    if (lastfmSessionKey.isNotBlank()) {
+                        AppSettings.setLastfmSessionKey("")
+                        AppSettings.setLastfmUsername("")
+                        AppSettings.setLastfmEnabled(false)
+                        AppSettings.setLastfmScrobbleEnabled(false)
+                        AppSettings.setLastfmNowPlaying(false)
+                    } else {
+                        showLastfmLoginDialog = true
+                    }
+                },
+            )
+            if (lastfmEnabled && lastfmSessionKey.isNotBlank()) {
+                RowDivider()
+                SettingsRow(
+                    icon = Icons.Rounded.GraphicEq,
+                    title = "Scrobble tracks",
+                    subtitle = "Log plays to your Last.fm timeline",
+                    trailing = {
+                        Switch(
+                            checked = lastfmScrobbleEnabled,
+                            onCheckedChange = AppSettings::setLastfmScrobbleEnabled,
+                            colors = SwitchDefaults.colors(
+                                checkedTrackColor = MaterialTheme.colorScheme.primary,
+                                checkedBorderColor = MaterialTheme.colorScheme.primary,
+                            ),
+                        )
+                    },
+                    onClick = { AppSettings.setLastfmScrobbleEnabled(!lastfmScrobbleEnabled) },
+                )
+                RowDivider()
+                SettingsRow(
+                    icon = Icons.Rounded.GraphicEq,
+                    title = "Now playing",
+                    subtitle = "Update Last.fm with what you're listening to",
+                    trailing = {
+                        Switch(
+                            checked = lastfmNowPlayingEnabled,
+                            onCheckedChange = AppSettings::setLastfmNowPlaying,
+                            colors = SwitchDefaults.colors(
+                                checkedTrackColor = MaterialTheme.colorScheme.primary,
+                                checkedBorderColor = MaterialTheme.colorScheme.primary,
+                            ),
+                        )
+                    },
+                    onClick = { AppSettings.setLastfmNowPlaying(!lastfmNowPlayingEnabled) },
+                )
+            }
+        }
+
+        if (lastfmEnabled && lastfmSessionKey.isNotBlank()) {
+            SettingsGroup(header = "Scrobble timing") {
+                SliderRow(
+                    icon = Icons.Rounded.Tune,
+                    title = "Min song duration",
+                    subtitle = "Songs shorter than this won't scrobble",
+                    value = "${scrobbleMinDuration}s",
+                    sliderValue = scrobbleMinDuration.toFloat(),
+                    onSliderValue = { AppSettings.setScrobbleMinDuration(it.roundToInt()) },
+                    valueRange = 15f..120f,
+                    steps = 20,
+                )
+                RowDivider()
+                SliderRow(
+                    icon = Icons.Rounded.Tune,
+                    title = "Scrobble delay",
+                    subtitle = "How far into a song before scrobbling",
+                    value = "${(scrobbleDelayPercent * 100).roundToInt()}%",
+                    sliderValue = scrobbleDelayPercent,
+                    onSliderValue = { AppSettings.setScrobbleDelayPercent(it) },
+                    valueRange = 0.1f..1.0f,
+                    steps = 8,
+                )
+                RowDivider()
+                SliderRow(
+                    icon = Icons.Rounded.Tune,
+                    title = "Max delay",
+                    subtitle = "Cap on scrobble delay in seconds",
+                    value = "${scrobbleDelaySeconds}s",
+                    sliderValue = scrobbleDelaySeconds.toFloat(),
+                    onSliderValue = { AppSettings.setScrobbleDelaySeconds(it.roundToInt()) },
+                    valueRange = 30f..300f,
+                    steps = 26,
+                )
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+
+    if (showListenBrainzTokenDialog) {
+        var tokenInput by remember { mutableStateOf(listenBrainzToken) }
+        AlertDialog(
+            onDismissRequest = { showListenBrainzTokenDialog = false },
+            title = { Text("ListenBrainz Token") },
+            text = {
+                OutlinedTextField(
+                    value = tokenInput,
+                    onValueChange = { tokenInput = it },
+                    label = { Text("API Token") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    AppSettings.setListenBrainzToken(tokenInput.trim())
+                    showListenBrainzTokenDialog = false
+                }) {
+                    Text("Save")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showListenBrainzTokenDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
+    if (showLastfmLoginDialog) {
+        var usernameInput by remember { mutableStateOf("") }
+        var passwordInput by remember { mutableStateOf("") }
+        var lastfmError by remember { mutableStateOf<String?>(null) }
+        var lastfmLoading by remember { mutableStateOf(false) }
+        AlertDialog(
+            onDismissRequest = { if (!lastfmLoading) showLastfmLoginDialog = false },
+            title = { Text("Last.fm Login") },
+            text = {
+                Column {
+                    if (lastfmError != null) {
+                        Text(
+                            text = lastfmError!!,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        )
+                    }
+                    OutlinedTextField(
+                        value = usernameInput,
+                        onValueChange = { usernameInput = it },
+                        label = { Text("Username") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = passwordInput,
+                        onValueChange = { passwordInput = it },
+                        label = { Text("Password") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        lastfmLoading = true
+                        lastfmError = null
+                        scrobbleScope.launch {
+                            try {
+                                LastFM.initialize(
+                                    apiKey = LastFM.FALLBACK_COMPAT_API_KEY,
+                                    secret = LastFM.FALLBACK_COMPAT_SECRET,
+                                )
+                                LastFM.getMobileSession(usernameInput.trim(), passwordInput)
+                                    .onSuccess { auth ->
+                                        AppSettings.setLastfmSessionKey(auth.session.key)
+                                        AppSettings.setLastfmUsername(auth.session.name)
+                                        AppSettings.setLastfmEnabled(true)
+                                        showLastfmLoginDialog = false
+                                    }
+                                    .onFailure { e ->
+                                        lastfmError = e.message ?: "Login failed"
+                                    }
+                            } catch (e: Exception) {
+                                lastfmError = e.message ?: "Login failed"
+                            } finally {
+                                lastfmLoading = false
+                            }
+                        }
+                    },
+                    enabled = !lastfmLoading && usernameInput.isNotBlank() && passwordInput.isNotBlank(),
+                ) {
+                    Text(if (lastfmLoading) "Signing in..." else "Sign in")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLastfmLoginDialog = false }, enabled = !lastfmLoading) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
@@ -30,8 +30,10 @@ import androidx.compose.material.icons.rounded.BlurOff
 import androidx.compose.material.icons.rounded.Brightness4
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.Cloud
 import androidx.compose.material.icons.rounded.DeleteSweep
 import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.MotionPhotosOff
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.SignalCellularAlt
@@ -41,20 +43,24 @@ import androidx.compose.material.icons.rounded.SurroundSound
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material.icons.rounded.Waves
 import androidx.compose.material.icons.rounded.Wifi
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -80,11 +86,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.SingletonImageLoader
 import coil3.compose.AsyncImage
 import com.music.bitchord.data.model.Account
+import com.music.bitchord.data.scrobbling.LastFM
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.AudioQuality
 import com.music.bitchord.data.settings.ThemeMode
 import com.music.bitchord.playback.AudioCache
 import com.music.bitchord.playback.DolbyAtmos
+import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 /**
@@ -101,6 +109,7 @@ fun SettingsScreen(
     account: Account?,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
+    onAccountScrobbling: () -> Unit,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
@@ -122,7 +131,22 @@ fun SettingsScreen(
     val sessionId by AppSettings.audioSessionId.collectAsStateWithLifecycle()
     val cacheLimitBytes by AppSettings.audioCacheLimitBytes.collectAsStateWithLifecycle()
 
+    // Scrobbling states
+    val lastfmEnabled by AppSettings.lastfmEnabled.collectAsStateWithLifecycle()
+    val lastfmUsername by AppSettings.lastfmUsername.collectAsStateWithLifecycle()
+    val lastfmSessionKey by AppSettings.lastfmSessionKey.collectAsStateWithLifecycle()
+    val lastfmScrobbleEnabled by AppSettings.lastfmScrobbleEnabled.collectAsStateWithLifecycle()
+    val lastfmNowPlayingEnabled by AppSettings.lastfmNowPlaying.collectAsStateWithLifecycle()
+    val scrobbleMinDuration by AppSettings.scrobbleMinDuration.collectAsStateWithLifecycle()
+    val scrobbleDelayPercent by AppSettings.scrobbleDelayPercent.collectAsStateWithLifecycle()
+    val scrobbleDelaySeconds by AppSettings.scrobbleDelaySeconds.collectAsStateWithLifecycle()
+    val listenBrainzEnabled by AppSettings.listenBrainzEnabled.collectAsStateWithLifecycle()
+    val listenBrainzToken by AppSettings.listenBrainzToken.collectAsStateWithLifecycle()
+
     var picking by remember { mutableStateOf<QualityTarget?>(null) }
+    var showListenBrainzTokenDialog by remember { mutableStateOf(false) }
+    var showLastfmLoginDialog by remember { mutableStateOf(false) }
+    val scrobbleScope = rememberCoroutineScope()
 
     // Coming back from the system Atmos panel is the one moment the answer is
     // most likely to have changed, and on devices whose Atmos switch isn't
@@ -151,7 +175,13 @@ fun SettingsScreen(
             modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp, bottom = 14.dp),
         )
 
-        AccountCard(signedIn = signedIn, account = account, onSignIn = onSignIn)
+        SettingsGroup {
+            SettingsRow(
+                icon = Icons.Rounded.Person,
+                title = "Account & scrobbling",
+                onClick = onAccountScrobbling,
+            )
+        }
 
         SettingsGroup(
             header = "Audio quality",
@@ -361,12 +391,6 @@ fun SettingsScreen(
             )
         }
 
-        if (signedIn) {
-            SettingsGroup {
-                DestructiveRow(label = "Sign out", onClick = onSignOut)
-            }
-        }
-
         Text(
             text = buildAnnotatedString {
                 append("BitChord $version  ")
@@ -414,6 +438,113 @@ fun SettingsScreen(
                 },
             )
         }
+    }
+
+    if (showListenBrainzTokenDialog) {
+        var tokenInput by remember { mutableStateOf(listenBrainzToken) }
+        AlertDialog(
+            onDismissRequest = { showListenBrainzTokenDialog = false },
+            title = { Text("ListenBrainz Token") },
+            text = {
+                OutlinedTextField(
+                    value = tokenInput,
+                    onValueChange = { tokenInput = it },
+                    label = { Text("API Token") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    AppSettings.setListenBrainzToken(tokenInput.trim())
+                    showListenBrainzTokenDialog = false
+                }) {
+                    Text("Save")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showListenBrainzTokenDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
+    if (showLastfmLoginDialog) {
+        var usernameInput by remember { mutableStateOf("") }
+        var passwordInput by remember { mutableStateOf("") }
+        var lastfmError by remember { mutableStateOf<String?>(null) }
+        var lastfmLoading by remember { mutableStateOf(false) }
+        AlertDialog(
+            onDismissRequest = { if (!lastfmLoading) showLastfmLoginDialog = false },
+            title = { Text("Last.fm Login") },
+            text = {
+                Column {
+                    if (lastfmError != null) {
+                        Text(
+                            text = lastfmError!!,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        )
+                    }
+                    OutlinedTextField(
+                        value = usernameInput,
+                        onValueChange = { usernameInput = it },
+                        label = { Text("Username") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = passwordInput,
+                        onValueChange = { passwordInput = it },
+                        label = { Text("Password") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        lastfmLoading = true
+                        lastfmError = null
+                        scrobbleScope.launch {
+                            try {
+                                // Use default keys for now
+                                LastFM.initialize(
+                                    apiKey = LastFM.FALLBACK_COMPAT_API_KEY,
+                                    secret = LastFM.FALLBACK_COMPAT_SECRET,
+                                )
+                                LastFM.getMobileSession(usernameInput.trim(), passwordInput)
+                                    .onSuccess { auth ->
+                                        AppSettings.setLastfmSessionKey(auth.session.key)
+                                        AppSettings.setLastfmUsername(auth.session.name)
+                                        AppSettings.setLastfmEnabled(true)
+                                        showLastfmLoginDialog = false
+                                    }
+                                    .onFailure { e ->
+                                        lastfmError = e.message ?: "Login failed"
+                                    }
+                            } catch (e: Exception) {
+                                lastfmError = e.message ?: "Login failed"
+                            } finally {
+                                lastfmLoading = false
+                            }
+                        }
+                    },
+                    enabled = !lastfmLoading && usernameInput.isNotBlank() && passwordInput.isNotBlank(),
+                ) {
+                    Text(if (lastfmLoading) "Signing in..." else "Sign in")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLastfmLoginDialog = false }, enabled = !lastfmLoading) {
+                    Text("Cancel")
+                }
+            },
+        )
     }
 }
 
@@ -470,7 +601,7 @@ private fun formatCacheSize(mb: Int): String {
 
 /** Who you're signed in as, straight from YouTube Music's account menu. */
 @Composable
-private fun AccountCard(
+internal fun AccountCard(
     signedIn: Boolean,
     account: Account?,
     onSignIn: () -> Unit,
@@ -609,21 +740,21 @@ private fun QualitySheet(
 
 // ---- Building blocks --------------------------------------------------------
 
-private val GroupShape = RoundedCornerShape(14.dp)
-private val GROUP_INSET = 16.dp
-private val ROW_INSET = 16.dp
-private val ICON_SIZE = 22.dp
-private val ICON_GAP = 14.dp
+internal val GroupShape = RoundedCornerShape(14.dp)
+internal val GROUP_INSET = 16.dp
+internal val ROW_INSET = 16.dp
+internal val ICON_SIZE = 22.dp
+internal val ICON_GAP = 14.dp
 
 /** Where a row's text starts — dividers are inset to match, as on iOS. */
-private val TEXT_INSET = ROW_INSET + ICON_SIZE + ICON_GAP
+internal val TEXT_INSET = ROW_INSET + ICON_SIZE + ICON_GAP
 
 /**
  * One inset card of rows, with an uppercase header above and an optional
  * plain-language [footer] below. Rows are separated by [RowDivider].
  */
 @Composable
-private fun SettingsGroup(
+internal fun SettingsGroup(
     header: String? = null,
     footer: String? = null,
     content: @Composable () -> Unit,
@@ -667,7 +798,7 @@ private fun SettingsGroup(
 }
 
 @Composable
-private fun RowDivider() {
+internal fun RowDivider() {
     HorizontalDivider(
         modifier = Modifier.padding(start = TEXT_INSET),
         thickness = 0.5.dp,
@@ -680,7 +811,7 @@ private fun RowDivider() {
  * [trailing] (a switch, say) or the current [value] followed by a chevron.
  */
 @Composable
-private fun SettingsRow(
+internal fun SettingsRow(
     icon: ImageVector,
     title: String,
     subtitle: String? = null,
@@ -749,7 +880,7 @@ private fun SettingsRow(
 
 /** Marks the connection whose ceiling is actually in force right now. */
 @Composable
-private fun Badge(text: String) {
+internal fun Badge(text: String) {
     Text(
         text = text.uppercase(),
         style = MaterialTheme.typography.labelSmall,
@@ -762,7 +893,7 @@ private fun Badge(text: String) {
 }
 
 @Composable
-private fun Chevron() {
+internal fun Chevron() {
     Icon(
         Icons.Rounded.ChevronRight,
         contentDescription = null,
@@ -774,7 +905,7 @@ private fun Chevron() {
 /** A continuous setting: label and current value on one line, track beneath. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SliderRow(
+internal fun SliderRow(
     icon: ImageVector,
     title: String,
     value: String,
@@ -842,7 +973,7 @@ private fun SliderRow(
 
 /** Sign out: centered, accent-coloured, no glyph — the shape of a real one. */
 @Composable
-private fun DestructiveRow(label: String, onClick: () -> Unit) {
+internal fun DestructiveRow(label: String, onClick: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
Changes made to the app for better usage and some UX improvements.
If anything is needed to present, I am up for doing so and sending screenshots or videos

### Scrobbling
- **1fdd38a** — Add scrobbling support (Last.fm + ListenBrainz). New
  `ScrobbleManager` + `LastFM` / `ListenBrainzManager` clients with
  token auth and API submission, wired into `PlaybackService` with
  settings under `AppSettings`.
- **0600858** — Extract Account & Scrobbling into its own settings
  sub-page instead of crowding the main settings sheet.
- **9b02aa0** — Fix ListenBrainz dropping finished tracks from Recent
  listens: `duration_ms` is now omitted when unknown (the server rejects
  zero), and the ended-track path reports through the exoplayer duration.
  Manual skips no longer scrobble the abandoned track.

### Playback fixes
- **dd518f8** — Update YouTube client versions and add the ANDROID_MUSIC
  client to fix stream playback (403s caused by po_token enforcement).
- **f95c369** — Fix the stream probe hitting HTTP 403: it now requests the
  same multi-megabyte range the real fetch uses, so grudged URLs are
  refused at resolve time instead of mid-playback.

### Player UX
- **9019fa2** — Make the bottom bar pill draggable with a smooth spring
  animation.
- **1b2d0d3** — Update the settings icon to a cogwheel.
- **f7c73d9** — Let the back gesture close the lyrics panel before
  dismissing the player sheet.