### PR TITLE
feat: align Media3 notification controls with player state

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,13 +180,13 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     // ---- Media playback: Media3 / ExoPlayer ----
-    implementation("androidx.media3:media3-exoplayer:1.5.1")
-    implementation("androidx.media3:media3-session:1.5.1")
-    implementation("androidx.media3:media3-common:1.5.1")
-    implementation("androidx.media3:media3-datasource-okhttp:1.5.1")
+    implementation("androidx.media3:media3-exoplayer:1.11.0")
+    implementation("androidx.media3:media3-session:1.11.0")
+    implementation("androidx.media3:media3-common:1.11.0")
+    implementation("androidx.media3:media3-datasource-okhttp:1.11.0")
     // Audio is progressive, but Apple serves its motion artwork as HLS — this
     // is what lets the animated sleeve play it. See CanvasArtworkPlayer.
-    implementation("androidx.media3:media3-exoplayer-hls:1.5.1")
+    implementation("androidx.media3:media3-exoplayer-hls:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.9.0")
 
     // ---- Images: Coil 3 + Palette (dominant colors for the mesh gradient) ----

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -79,27 +79,23 @@ import com.music.bitchord.data.NerdStats
 import com.music.bitchord.data.TrackLog
 import com.music.bitchord.data.model.BrowseType
 import com.music.bitchord.data.model.LikeStatus
-import com.music.bitchord.data.model.SearchFilter
-import com.music.bitchord.data.model.SearchResult
 import com.music.bitchord.data.model.Song
 import com.music.bitchord.data.model.UiState
 import com.music.bitchord.data.model.UserPlaylist
 import com.music.bitchord.data.scrobbling.LastFM
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.ThemeMode
-import com.music.bitchord.data.sources.SourceRegistry
-import com.music.bitchord.data.sources.TrackMatcher
 import com.music.bitchord.ui.screens.AccountAndScrobblingScreen
 import com.music.bitchord.ui.screens.DiscordDialog
 import com.music.bitchord.ui.screens.DiscordDialogHost
 import com.music.bitchord.ui.screens.DiscordScreen
 import com.music.bitchord.ui.screens.SettingsScreen
-import com.music.bitchord.playback.QueueBuilder
 import com.music.bitchord.playback.QueueShuffle
 import com.music.bitchord.playback.autoplaySectionStart
 import com.music.bitchord.playback.dropAutoplayTracks
 import com.music.bitchord.playback.playSongs
 import com.music.bitchord.playback.toMediaItem
+import com.music.bitchord.playback.toggleAutoplay
 import com.music.bitchord.download.DownloadStore
 import com.music.bitchord.download.Downloads
 import com.music.bitchord.ui.components.PlaylistActionsSheet
@@ -133,9 +129,6 @@ import com.music.bitchord.ui.theme.rememberArtworkPalette
 import com.music.bitchord.ui.theme.SystemBarIcons
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -274,41 +267,6 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
     val player = rememberPlayerState(controller)
     val shuffleEnabled by QueueShuffle.enabled.collectAsStateWithLifecycle()
 
-    // AutoPlay: once the queue reaches its last track, extend it with YouTube
-    // Music's radio mix for that song so playback carries on by itself.
-    //
-    // Repeat-all is left out of the trigger: its whole point is to loop the
-    // queue as it stands, which AutoPlay extending it forever would defeat —
-    // the queue would never actually reach the end repeat-all is meant to
-    // wrap from. See onCycleRepeat, which drops whatever AutoPlay has already
-    // added the moment repeat-all is turned on.
-    var autoplaySeed by remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(autoplay, player.queueIndex, player.queue.size, player.song?.videoId, player.repeatMode) {
-        val song = player.song
-        val current = song?.videoId
-        if (!autoplay || song == null || current == null) return@LaunchedEffect
-        if (player.repeatMode == Player.REPEAT_MODE_ALL) return@LaunchedEffect
-        if (player.queueIndex < player.queue.lastIndex) return@LaunchedEffect
-        if (autoplaySeed == current) return@LaunchedEffect
-        autoplaySeed = current
-        // Radio is YouTube's, and only YouTube's — a module track's id means
-        // nothing to it. See [youtubeSeedFor].
-        val seed = youtubeSeedFor(song) ?: return@LaunchedEffect
-        YtMusicRepository.radio(seed).onSuccess { related ->
-            val extra = QueueBuilder.extend(player.queue, related, RADIO_BATCH)
-            if (extra.isNotEmpty()) {
-                // Swapped for the catalogue audio track before it ever
-                // reaches the queue — see YtMusicRepository.resolveAudio.
-                val resolved = coroutineScope {
-                    extra.map { async { YtMusicRepository.resolveAudio(it) } }.awaitAll()
-                }
-                controller?.addMediaItems(
-                    resolved.map { it.copy(fromAutoplay = true).toMediaItem() },
-                )
-            }
-        }
-    }
-
     // Lyrics follow whatever is playing; duration lands a beat after the track.
     // Keyed on the lyric settings too, so turning a source on or off applies to
     // the track already playing rather than only the next one.
@@ -392,17 +350,6 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
 
     val scope = rememberCoroutineScope()
 
-    /**
-     * A video-tagged [Song] is swapped for its catalogue audio release
-     * before the queue, the notification or YouTube's own history ever see
-     * it — see [YtMusicRepository.resolveAudio]. Plain songs pass through
-     * this untouched and unawaited (`isVideo` is false, so the suspend call
-     * returns immediately), so this costs nothing on the common path.
-     */
-    suspend fun List<Song>.resolvedForQueue(): List<Song> = coroutineScope {
-        map { async { YtMusicRepository.resolveAudio(it) } }.awaitAll()
-    }
-
     val play: (List<Song>, Int) -> Unit = { songs, index ->
         scope.launch {
             val starting = YtMusicRepository.resolveAudio(songs[index])
@@ -439,31 +386,10 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
      * where the surrounding list *is* the thing the user asked for.
      */
     val playRadio: (Song) -> Unit = { song ->
-        // Claim the AutoPlay seed up front: a one-track queue is already at its
-        // end, so that effect would otherwise fetch the same radio in parallel.
-        autoplaySeed = song.videoId
         scope.launch {
             val resolved = YtMusicRepository.resolveAudio(song)
-            autoplaySeed = resolved.videoId
             controller?.playSongs(listOf(resolved), 0)
             showNowPlaying = true
-            // Radio is YouTube's, and only YouTube's — see [youtubeSeedFor].
-            val seed = youtubeSeedFor(resolved) ?: return@launch
-            YtMusicRepository.radio(seed).onSuccess { related ->
-                // The user may have moved on while the mix was loading.
-                if (controller?.currentMediaItem?.mediaId != resolved.videoId) return@onSuccess
-                val extra = QueueBuilder.extend(listOf(resolved), related, RADIO_BATCH)
-                if (extra.isNotEmpty()) {
-                    // The station's own mix, which the queue files under
-                    // AutoPlay just like the tracks it appends later — only the
-                    // seed was actually asked for.
-                    controller?.addMediaItems(
-                        extra.resolvedForQueue().map {
-                            it.copy(fromAutoplay = true).toMediaItem()
-                        },
-                    )
-                }
-            }
         }
     }
     val addToQueue: (Song) -> Unit = { song ->
@@ -1113,25 +1039,16 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                             // tracks are the opposite of that — an endless supply
                             // of new ones — so they come back out first. Native
                             // REPEAT_MODE_ALL then wraps a plain queue exactly as
-                            // it should, and the LaunchedEffect above leaves it be
-                            // for as long as repeat-all stays on.
+                            // it should, and the service's AutoPlay loader leaves
+                            // it be for as long as repeat-all stays on.
                             if (next == Player.REPEAT_MODE_ALL) it.dropAutoplayTracks()
                             it.repeatMode = next
                         }
                     },
                     onToggleAutoplay = {
-                        val on = !autoplay
-                        AppSettings.setAutoplay(on)
-                        if (on) {
-                            // Let the effect above seed a mix for the track
-                            // playing now, instead of passing over it as one it
-                            // has already extended.
-                            autoplaySeed = null
-                        } else {
-                            // Switching it off takes the mix back out of the
-                            // queue — what's left is what was actually asked for.
-                            controller?.dropAutoplayTracks()
-                        }
+                        // PlaybackService owns the setting and queue extension so
+                        // this path and the notification use exactly one loader.
+                        controller?.toggleAutoplay()
                     },
                     onJumpTo = { controller?.seekToDefaultPosition(it) },
                     onRemoveFromQueue = { controller?.removeMediaItem(it) },
@@ -1498,9 +1415,6 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
 private fun tween(durationMillis: Int) =
     androidx.compose.animation.core.tween<Float>(durationMillis)
 
-/** How many tracks a station pulls in at a time. */
-private const val RADIO_BATCH = 20
-
 /**
  * How far short of the end a seek is allowed to land.
  *
@@ -1510,36 +1424,6 @@ private const val RADIO_BATCH = 20
  * from the end plays the outro instead.
  */
 private const val SEEK_END_GUARD_MS = 1_000L
-
-/**
- * A YouTube video id to seed a radio station from, for a track that may not
- * have one of its own.
- *
- * Radio, related tracks and the home feed are YouTube's alone — see
- * [SourceKind.YOUTUBE][com.music.bitchord.data.sources.SourceKind.YOUTUBE].
- * A track played from module *search* carries a
- * [SourceRegistry.trackKey] as its media id, which means nothing to
- * Innertube: handing one to [YtMusicRepository.radio] gets an empty mix
- * back, which is why AutoPlay quietly stopped extending the queue after a
- * module search result. Looking the recording up on YouTube by name gives
- * the station something it can actually seed from, and the mix that comes
- * back is YouTube's — those tracks then take the ordinary YouTube path and
- * get substituted individually if a module happens to hold them.
- *
- * Null when the track isn't on YouTube at all, which is a real answer: no
- * station rather than a station for the wrong song.
- */
-private suspend fun youtubeSeedFor(song: Song): String? {
-    if (SourceRegistry.parseTrackKey(song.videoId) == null) return song.videoId
-    val target = TrackMatcher.targetOf(song)
-    val query = TrackMatcher.queries(target).firstOrNull() ?: return null
-    return YtMusicRepository.search(query, SearchFilter.SONGS)
-        .getOrNull()
-        ?.filterIsInstance<SearchResult.Track>()
-        ?.map { it.song }
-        ?.let { TrackMatcher.best(it, target) }
-        ?.videoId
-}
 
 /**
  * How far a detail page scrolls before its title moves up into the bar.

--- a/app/src/main/java/com/music/bitchord/data/LikeState.kt
+++ b/app/src/main/java/com/music/bitchord/data/LikeState.kt
@@ -1,0 +1,34 @@
+package com.music.bitchord.data
+
+import com.music.bitchord.data.model.LikeStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Ratings changed during this app session, shared by the UI and playback service.
+ *
+ * The library remains the source for ratings that were already known at load time;
+ * these overrides win over it so a notification tap and a player-screen tap paint
+ * the same result immediately.
+ */
+object LikeState {
+    private val _overrides = MutableStateFlow<Map<String, LikeStatus>>(emptyMap())
+    val overrides: StateFlow<Map<String, LikeStatus>> = _overrides.asStateFlow()
+
+    fun set(videoId: String, status: LikeStatus) {
+        _overrides.value += (videoId to status)
+    }
+
+    /** Seeds only ratings not already changed explicitly during this session. */
+    fun seedLiked(videoIds: Set<String>) {
+        if (videoIds.isEmpty()) return
+        val next = _overrides.value.toMutableMap()
+        videoIds.forEach { next.putIfAbsent(it, LikeStatus.LIKE) }
+        if (next != _overrides.value) _overrides.value = next
+    }
+
+    fun clear() {
+        _overrides.value = emptyMap()
+    }
+}

--- a/app/src/main/java/com/music/bitchord/data/YtMusicRepository.kt
+++ b/app/src/main/java/com/music/bitchord/data/YtMusicRepository.kt
@@ -218,6 +218,7 @@ object YtMusicRepository {
 
             val likedSongs = liked.await()
             val likedIds = likedSongs.mapTo(HashSet()) { it.videoId }
+            LikeState.seedLiked(likedIds)
             LibraryPage(
                 likedSongs = likedSongs,
                 // Thumbs-up'd tracks are also in the library feed; only what

--- a/app/src/main/java/com/music/bitchord/playback/Autoplay.kt
+++ b/app/src/main/java/com/music/bitchord/playback/Autoplay.kt
@@ -1,0 +1,57 @@
+package com.music.bitchord.playback
+
+import com.music.bitchord.data.YtMusicRepository
+import com.music.bitchord.data.model.SearchFilter
+import com.music.bitchord.data.model.SearchResult
+import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.sources.SourceRegistry
+import com.music.bitchord.data.sources.TrackMatcher
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+/** Number of radio tracks appended by the single AutoPlay loader. */
+private const val AUTOPLAY_BATCH = 20
+
+/**
+ * Finds the YouTube id that should seed AutoPlay for a song. Module tracks do not
+ * carry YouTube ids, so they are matched on YouTube before the radio request.
+ */
+suspend fun youtubeSeedFor(song: Song): String? {
+    if (SourceRegistry.parseTrackKey(song.videoId) == null) return song.videoId
+    val target = TrackMatcher.targetOf(song)
+    val query = TrackMatcher.queries(target).firstOrNull() ?: return null
+    return YtMusicRepository.search(query, SearchFilter.SONGS)
+        .getOrNull()
+        ?.filterIsInstance<SearchResult.Track>()
+        ?.map { it.song }
+        ?.let { TrackMatcher.best(it, target) }
+        ?.videoId
+}
+
+/**
+ * Loads, de-duplicates and resolves one AutoPlay batch. The playback service is
+ * the only caller for the AutoPlay toggle; the player UI's explicit radio start
+ * uses this same helper for its initial station batch.
+ */
+suspend fun loadAutoplayTracks(
+    existing: List<Song>,
+    seedSong: Song,
+): Result<List<Song>> {
+    val seed = youtubeSeedFor(seedSong) ?: return Result.success(emptyList())
+    val related = YtMusicRepository.radio(seed).getOrElse { return Result.failure(it) }
+    val extra = QueueBuilder.extend(existing, related, AUTOPLAY_BATCH)
+    if (extra.isEmpty()) return Result.success(emptyList())
+
+    val resolved = try {
+        coroutineScope {
+            extra.map { async { YtMusicRepository.resolveAudio(it) } }.awaitAll()
+        }
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (failure: Throwable) {
+        return Result.failure(failure)
+    }
+    return Result.success(resolved.map { it.copy(fromAutoplay = true) })
+}

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import android.os.SystemClock
 import android.util.Log
 import androidx.media3.common.AudioAttributes
@@ -28,18 +29,27 @@ import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionError
+import androidx.media3.session.SessionResult
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
 import com.music.bitchord.MainActivity
 import com.music.bitchord.R
 import com.music.bitchord.data.Http
+import com.music.bitchord.data.LikeState
 import com.music.bitchord.data.NerdStats
 import com.music.bitchord.data.TrackLog
+import com.music.bitchord.data.YtMusicRepository
 import com.music.bitchord.data.discord.DiscordRPC
 import com.music.bitchord.data.innertube.PlaybackTracker
 import com.music.bitchord.data.innertube.PlayerClient
 import com.music.bitchord.data.innertube.StreamResolver
+import com.music.bitchord.data.model.LikeStatus
 import com.music.bitchord.data.model.Song
 import com.music.bitchord.data.scrobbling.LastFM
 import com.music.bitchord.data.scrobbling.ListenBrainzManager
@@ -73,6 +83,12 @@ import kotlinx.coroutines.TimeoutCancellationException
 
 /** Past this point in a track, back restarts it instead of skipping to the previous one. */
 const val BACK_RESTARTS_AFTER_MS = 10_000L
+
+/** Session command used by both the player UI and the media notification. */
+const val ACTION_TOGGLE_AUTOPLAY = "com.music.bitchord.action.TOGGLE_AUTOPLAY"
+
+/** Session command used by the media notification's Shuffle button. */
+const val ACTION_TOGGLE_SHUFFLE = "com.music.bitchord.action.TOGGLE_SHUFFLE"
 
 /**
  * Background playback via Media3. A [MediaSessionService] gives us the media
@@ -169,6 +185,55 @@ class PlaybackService : MediaSessionService() {
     private var discordPresenceUp = false
 
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+    /** Commands exposed as the secondary buttons on the media notification. */
+    private val favoriteCommand = SessionCommand(ACTION_TOGGLE_FAVORITE, Bundle.EMPTY)
+    private val autoplayCommand = SessionCommand(ACTION_TOGGLE_AUTOPLAY, Bundle.EMPTY)
+    private val shuffleCommand = SessionCommand(ACTION_TOGGLE_SHUFFLE, Bundle.EMPTY)
+
+    private var favoriteActionJob: Job? = null
+    private var autoplayLoadJob: Job? = null
+    private var autoplaySeed: String? = null
+
+    private val sessionCallback = object : MediaSession.Callback {
+        override fun onConnect(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+        ): MediaSession.ConnectionResult {
+            // The media notification controller is a normal Media3 controller. Its custom
+            // buttons are omitted unless their commands are explicitly available.
+            val commands = MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS
+                .buildUpon()
+                .add(favoriteCommand)
+                .add(autoplayCommand)
+                .add(shuffleCommand)
+                .build()
+            return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+                .setAvailableSessionCommands(commands)
+                .build()
+        }
+
+        override fun onCustomCommand(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            customCommand: SessionCommand,
+            args: Bundle,
+        ): ListenableFuture<SessionResult> {
+            when (customCommand.customAction) {
+                ACTION_TOGGLE_AUTOPLAY -> toggleAutoplayFromNotification()
+                ACTION_TOGGLE_SHUFFLE -> toggleShuffleFromNotification()
+                ACTION_TOGGLE_FAVORITE -> session.player.currentMediaItem?.mediaId?.let {
+                    toggleFavoriteFromNotification(it)
+                }
+                else -> return Futures.immediateFuture(
+                    SessionResult(SessionError.ERROR_NOT_SUPPORTED),
+                )
+            }
+            // The actual YouTube rating is asynchronous. The command itself has been accepted;
+            // the notification is refreshed when the network write completes.
+            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+        }
+    }
 
     /**
      * Everything the service books against the player it is currently on.
@@ -284,6 +349,11 @@ class PlaybackService : MediaSessionService() {
                     reason == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT,
                 reason = reason,
             )
+            autoplayLoadJob?.cancel()
+            autoplayLoadJob = null
+            autoplaySeed = null
+            loadAutoplayForCurrentTrack()
+            mediaSession?.setCustomLayout(notificationButtons())
         }
 
         /**
@@ -322,6 +392,12 @@ class PlaybackService : MediaSessionService() {
             }
         }
 
+        override fun onRepeatModeChanged(repeatMode: Int) {
+            // Turning repeat-all back off can leave the current item at the end
+            // of the queue, which is the same trigger as a normal transition.
+            loadAutoplayForCurrentTrack()
+        }
+
         /**
          * AutoPlay appends to the queue after the transition that ran it
          * dry, so the track to read ahead for often only exists once the
@@ -332,6 +408,9 @@ class PlaybackService : MediaSessionService() {
             // session is currently pointed at.
             val exoPlayer = player ?: return
             if (exoPlayer.isPlaying) prefetchAround(exoPlayer)
+            if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED) {
+                mediaSession?.setCustomLayout(notificationButtons())
+            }
         }
     }
 
@@ -459,6 +538,21 @@ class PlaybackService : MediaSessionService() {
                 .build()
                 .apply { setSmallIcon(R.drawable.ic_notification_logo) },
         )
+
+        // The player screen toggles QueueShuffle directly on its MediaController.
+        // Observe the shared state here so the notification's Shuffle icon and
+        // label follow that toggle immediately as well.
+        scope.launch {
+            QueueShuffle.enabled
+                .collectLatest {
+                    mediaSession?.setCustomLayout(notificationButtons())
+                }
+        }
+        scope.launch {
+            LikeState.overrides.collectLatest {
+                mediaSession?.setCustomLayout(notificationButtons())
+            }
+        }
 
         // No user agent on the factory: the right one depends on which client
         // minted the URL, so it is set per request below. Setting it here as
@@ -634,6 +728,7 @@ class PlaybackService : MediaSessionService() {
         // History pings fire once a track is actually audible — both when
         // playback starts and when the queue moves on while already playing.
         exoPlayer.addListener(playbackListener)
+        loadAutoplayForCurrentTrack()
 
         // Only the analytics listener reports the format the audio renderer was
         // configured with. Treated as a trigger rather than a source: the
@@ -674,7 +769,135 @@ class PlaybackService : MediaSessionService() {
         mediaSession = MediaSession.Builder(this, SessionPlayer(exoPlayer, controller))
             .setId(SESSION_ID)
             .setSessionActivity(sessionActivity())
+            .setCallback(sessionCallback)
             .build()
+        mediaSession?.setCustomLayout(notificationButtons())
+    }
+
+    /** The one custom layout advertised to all Media3 control surfaces. */
+    private fun notificationButtons(): List<CommandButton> {
+        val autoplay = CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+            .setSessionCommand(autoplayCommand)
+            .setIconResId(R.drawable.ic_autoplay)
+            .setDisplayName("AutoPlay")
+            .build()
+        val favorite = CommandButton.Builder(
+            if (LikeState.overrides.value[player?.currentMediaItem?.mediaId] == LikeStatus.LIKE) {
+                CommandButton.ICON_HEART_FILLED
+            } else {
+                CommandButton.ICON_HEART_UNFILLED
+            },
+        )
+            .setSessionCommand(favoriteCommand)
+            .setDisplayName("Favorite")
+            .build()
+        val shuffleEnabled = QueueShuffle.enabled.value
+        val shuffle = CommandButton.Builder(
+            if (shuffleEnabled) {
+                CommandButton.ICON_SHUFFLE_ON
+            } else {
+                CommandButton.ICON_SHUFFLE_OFF
+            },
+        )
+            .setSessionCommand(shuffleCommand)
+            .setDisplayName(if (shuffleEnabled) "Shuffle off" else "Shuffle on")
+            .build()
+        return listOf(favorite, autoplay, shuffle)
+    }
+
+    private fun toggleShuffleFromNotification() {
+        player?.let(QueueShuffle::toggle)
+        mediaSession?.setCustomLayout(notificationButtons())
+    }
+
+    private fun toggleAutoplayFromNotification() {
+        val enabled = !AppSettings.autoplay.value
+        AppSettings.setAutoplay(enabled)
+        if (enabled) {
+            autoplayLoadJob?.cancel()
+            autoplayLoadJob = null
+            autoplaySeed = null
+            loadAutoplayForCurrentTrack()
+        } else {
+            autoplayLoadJob?.cancel()
+            autoplayLoadJob = null
+            autoplaySeed = null
+            dropAutoplayTracksFromQueue()
+        }
+        mediaSession?.setCustomLayout(notificationButtons())
+    }
+
+    /** Starts the same radio extension used by the player when AutoPlay is enabled. */
+    private fun loadAutoplayForCurrentTrack() {
+        val exoPlayer = player ?: return
+        if (!AppSettings.autoplay.value ||
+            exoPlayer.repeatMode == Player.REPEAT_MODE_ALL ||
+            exoPlayer.hasNextMediaItem()
+        ) {
+            return
+        }
+        val current = exoPlayer.currentMediaItem?.toSong() ?: return
+        if (autoplaySeed == current.videoId) return
+        autoplaySeed = current.videoId
+        autoplayLoadJob = scope.launch {
+            val existing = (0 until exoPlayer.mediaItemCount)
+                .map { exoPlayer.getMediaItemAt(it).toSong() }
+            loadAutoplayTracks(existing, current)
+                .onSuccess { resolved ->
+                    val activePlayer = player ?: return@onSuccess
+                    if (!AppSettings.autoplay.value ||
+                        activePlayer.currentMediaItem?.mediaId != current.videoId ||
+                        activePlayer.hasNextMediaItem()
+                    ) {
+                        return@onSuccess
+                    }
+                    val stillPlaying = player ?: return@onSuccess
+                    if (!AppSettings.autoplay.value ||
+                        stillPlaying.currentMediaItem?.mediaId != current.videoId ||
+                        stillPlaying.hasNextMediaItem()
+                    ) {
+                        return@onSuccess
+                    }
+                    stillPlaying.addMediaItems(
+                        resolved.map { it.toMediaItem() },
+                    )
+                }
+                .onFailure {
+                    TrackLog.w("BitChord", "notification autoplay failed: ${it.message}", about = current.videoId)
+                }
+        }
+    }
+
+    private fun dropAutoplayTracksFromQueue() {
+        val exoPlayer = player ?: return
+        for (index in exoPlayer.mediaItemCount - 1 downTo exoPlayer.currentMediaItemIndex + 1) {
+            if (exoPlayer.getMediaItemAt(index).fromAutoplay) {
+                exoPlayer.removeMediaItem(index)
+            }
+        }
+    }
+
+    private fun toggleFavoriteFromNotification(videoId: String) {
+        favoriteActionJob?.cancel()
+        val previous = LikeState.overrides.value[videoId] ?: LikeStatus.INDIFFERENT
+        val target = if (previous == LikeStatus.LIKE) {
+            LikeStatus.INDIFFERENT
+        } else {
+            LikeStatus.LIKE
+        }
+
+        // Match the player UI: update both surfaces immediately, then reconcile
+        // the optimistic state with YouTube in the background.
+        LikeState.set(videoId, target)
+        mediaSession?.setCustomLayout(notificationButtons())
+        favoriteActionJob = scope.launch {
+            YtMusicRepository.rate(videoId, target)
+                .onFailure {
+                    LikeState.set(videoId, previous)
+                    mediaSession?.setCustomLayout(notificationButtons())
+                    TrackLog.w("BitChord", "notification favorite failed: ${it.message}", about = videoId)
+                }
+        }
     }
 
     /**
@@ -2633,6 +2856,7 @@ class PlaybackService : MediaSessionService() {
 
         const val CHANNEL_ID = "bitchord_playback"
         const val SESSION_ID = "BitChordPlayback"
+        const val ACTION_TOGGLE_FAVORITE = "com.music.bitchord.action.TOGGLE_FAVORITE"
 
         /** How often played-seconds are sampled off the player. */
         const val PROGRESS_SAMPLE_MS = 5_000L

--- a/app/src/main/java/com/music/bitchord/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlayerConnection.kt
@@ -2,6 +2,7 @@ package com.music.bitchord.playback
 
 import android.content.ComponentName
 import android.net.Uri
+import android.os.Bundle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -17,6 +18,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
+import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionToken
 import com.music.bitchord.data.model.NOTIFICATION_ART_PX
 import com.music.bitchord.data.model.Song
@@ -66,6 +68,14 @@ fun rememberMediaController(): MediaController? {
         }
     }
     return controller
+}
+
+/** Routes the player-screen AutoPlay button through the playback service. */
+fun MediaController.toggleAutoplay() {
+    sendCustomCommand(
+        SessionCommand(ACTION_TOGGLE_AUTOPLAY, Bundle.EMPTY),
+        Bundle.EMPTY,
+    )
 }
 
 /** Mirrors the controller into Compose state, polling position while playing. */

--- a/app/src/main/java/com/music/bitchord/ui/MainViewModel.kt
+++ b/app/src/main/java/com/music/bitchord/ui/MainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.music.bitchord.auth.AuthStore
 import com.music.bitchord.data.AppUpdateChecker
 import com.music.bitchord.data.LocalMediaRepository
+import com.music.bitchord.data.LikeState
 import com.music.bitchord.data.YtMusicRepository
 import com.music.bitchord.data.lyrics.LyricLine
 import com.music.bitchord.data.lyrics.LyricsRepository
@@ -245,11 +246,9 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
      * them ([likeStatuses]) means a tap shows immediately without the library
      * having to be re-fetched, and a later refresh can't undo it.
      */
-    private val _likeOverrides = MutableStateFlow<Map<String, LikeStatus>>(emptyMap())
-
     /** Every rating known for this account: the library's, then this session's. */
     val likeStatuses: StateFlow<Map<String, LikeStatus>> =
-        combine(_library, _likeOverrides) { library, overrides ->
+        combine(_library, LikeState.overrides) { library, overrides ->
             val liked = (library as? UiState.Success)?.data?.likedSongs
                 ?.associate { it.videoId to LikeStatus.LIKE }
                 .orEmpty()
@@ -271,7 +270,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
         if (!requireSignIn()) return
         val previous = likeStatusOf(videoId)
         if (previous == status) return
-        _likeOverrides.value += (videoId to status)
+        LikeState.set(videoId, status)
         viewModelScope.launch {
             YtMusicRepository.rate(videoId, status).fold(
                 onSuccess = {
@@ -285,7 +284,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
                     if (unliked) forgetFromLibrary(videoId)
                 },
                 onFailure = {
-                    _likeOverrides.value += (videoId to previous)
+                    LikeState.set(videoId, previous)
                 },
             )
         }
@@ -438,9 +437,9 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
             _songMenu.value = menu
             val stated = menu.likeStatus
             if (stated != null && stated != LikeStatus.INDIFFERENT &&
-                videoId !in _likeOverrides.value
+                videoId !in LikeState.overrides.value
             ) {
-                _likeOverrides.value += (videoId to stated)
+                LikeState.set(videoId, stated)
             }
         }
     }
@@ -1313,7 +1312,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
         _library.value = UiState.Loading
         // Ratings and playlists belong to the account that just left; keeping
         // them would show the next signed-in user someone else's hearts.
-        _likeOverrides.value = emptyMap()
+        LikeState.clear()
         _playlists.value = emptyList()
         _songMenu.value = null
         loadHome()

--- a/app/src/main/res/drawable/ic_autoplay.xml
+++ b/app/src/main/res/drawable/ic_autoplay.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- AutoPlay's infinity mark, kept as an opaque white notification glyph. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,12c-1.8,-2.8 -3.2,-4 -5,-4C4.8,8 3,9.8 3,12s1.8,4 4,4c1.8,0 3.2,-1.2 5,-4 1.8,2.8 3.2,4 5,4 2.2,0 4,-1.8 4,-4s-1.8,-4 -4,-4c-1.8,0 -3.2,1.2 -5,4zM7,14c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2c1,0 1.9,0.7 3.1,2C8.9,13.3 8,14 7,14zM17,14c-1,0 -1.9,-0.7 -3.1,-2 1.2,-1.3 2.1,-2 3.1,-2 1.1,0 2,0.9 2,2s-0.9,2 -2,2z" />
+</vector>


### PR DESCRIPTION
- Add Like/Autoplay/Shuffle/Loop to notification controls
- Bump `androidx.media3` dependencies to 1.11.0.
- Move Autoplay logic into the playback service to support notification controls and consistent state.
- Introduce `LikeState` object to synchronize track ratings between the UI and background service.
- Add Autoplay icon for notification commands.

| Before | After |
| --------- | ------ |
| <img width="917" height="422" alt="image" src="https://github.com/user-attachments/assets/20e244e4-5a89-48c3-8e35-c2d5f23d9c1a" />| <img width="943" height="433" alt="image" src="https://github.com/user-attachments/assets/b9a7d2e2-d329-429b-8d3f-a5e1738455a7" /> |

P.S.: bumping  `androidx.media3` was required as using `1.5.1` required too much complexity over managing the buttons of notification UI on MIUI/HOS and OneUI