### PR TITLE
feat: restore Last.fm and ListenBrainz scrobbling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ cd BitChord
 
 A debug build needs no extra setup. For a signed release build, create a keystore and a `keystore.properties` (see [`keystore.properties.example`](keystore.properties.example)):
 
+Last.fm login additionally needs `LASTFM_API_KEY` and `LASTFM_SECRET` in
+`local.properties` or the environment. These credentials are optional and are
+never committed; ListenBrainz only requires the user's token in the app.
+
 ```bash
 keytool -genkey -v -keystore bitchord-release.jks \
     -keyalg RSA -keysize 2048 -validity 10000 -alias bitchord

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,16 @@ val localProps = Properties().apply {
     if (file.exists()) file.inputStream().use { load(it) }
 }
 val moduleIndexUrl: String = localProps.getProperty("MODULE_INDEX_URL", "")
+val lastfmApiKey: String = (
+    localProps.getProperty("LASTFM_API_KEY")
+        ?: System.getenv("LASTFM_API_KEY")
+        ?: ""
+    ).trim()
+val lastfmSecret: String = (
+    localProps.getProperty("LASTFM_SECRET")
+        ?: System.getenv("LASTFM_SECRET")
+        ?: ""
+    ).trim()
 
 android {
     namespace = "com.music.bitchord"
@@ -47,6 +57,10 @@ android {
 
         // Lossless/HQ module index URL — empty string if not configured.
         buildConfigField("String", "MODULE_INDEX_URL", "\"${moduleIndexUrl}\"")
+
+        // Last.fm credentials are supplied locally and never committed.
+        buildConfigField("String", "LASTFM_API_KEY", "\"${lastfmApiKey.replace("\\", "\\\\").replace("\"", "\\\"")}\"")
+        buildConfigField("String", "LASTFM_SECRET", "\"${lastfmSecret.replace("\\", "\\\\").replace("\"", "\\\"")}\"")
 
         // Automix's DSP analyzer (native/analyzer). 64-bit only: minSdk 26
         // already postdates the 64-bit requirement, so a 32-bit slice would

--- a/app/src/main/java/com/music/bitchord/BitChordApplication.kt
+++ b/app/src/main/java/com/music/bitchord/BitChordApplication.kt
@@ -93,8 +93,9 @@ class BitChordApplication : Application(), SingletonImageLoader.Factory {
         val sessionKey = AppSettings.lastfmSessionKey.value
         if (sessionKey.isBlank()) return
         val endpoint = AppSettings.lastfmEndpoint.value.ifBlank { LastFM.DEFAULT_API_ENDPOINT }
-        val apiKey = AppSettings.lastfmApiKey.value.ifBlank { LastFM.FALLBACK_COMPAT_API_KEY }
-        val secret = AppSettings.lastfmSecret.value.ifBlank { LastFM.FALLBACK_COMPAT_SECRET }
+        val apiKey = AppSettings.lastfmApiKey.value.trim()
+        val secret = AppSettings.lastfmSecret.value.trim()
+        if (apiKey.isBlank() || secret.isBlank()) return
         LastFM.configure(
             endpoint = endpoint,
             apiKey = apiKey,

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -1373,8 +1373,8 @@ private fun BitChordApp(darkTheme: Boolean, viewModel: MainViewModel = viewModel
                     scope.launch {
                         try {
                             LastFM.initialize(
-                                apiKey = LastFM.FALLBACK_COMPAT_API_KEY,
-                                secret = LastFM.FALLBACK_COMPAT_SECRET,
+                                apiKey = AppSettings.lastfmApiKey.value,
+                                secret = AppSettings.lastfmSecret.value,
                             )
                             LastFM.getMobileSession(usernameInput.trim(), passwordInput)
                                 .onSuccess { auth ->

--- a/app/src/main/java/com/music/bitchord/data/scrobbling/LastFM.kt
+++ b/app/src/main/java/com/music/bitchord/data/scrobbling/LastFM.kt
@@ -20,8 +20,6 @@ import java.security.MessageDigest
 object LastFM {
     const val DEFAULT_API_ENDPOINT = "https://ws.audioscrobbler.com/2.0/"
     const val LIBREFM_API_ENDPOINT = "https://libre.fm/2.0/"
-    const val FALLBACK_COMPAT_API_KEY = "bitchord"
-    const val FALLBACK_COMPAT_SECRET = "bitchord"
 
     @Serializable
     data class Session(val name: String, val key: String, val subscriber: Int)
@@ -196,6 +194,9 @@ object LastFM {
         apiKey: String,
         secret: String,
     ) {
+        require(apiKey.isNotBlank() && secret.isNotBlank()) {
+            "Last.fm API credentials are not configured for this build"
+        }
         configure(
             endpoint = runtimeConfig.endpoint,
             apiKey = apiKey,

--- a/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import com.music.bitchord.BuildConfig
 import com.music.bitchord.auth.AuthStore
 import com.music.bitchord.data.lyrics.LyricsSource
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -158,24 +159,8 @@ object AppSettings {
 
     // ── Scrobbling ──────────────────────────────────────────────────────
 
-    /**
-     * Whether the scrobbling integrations are offered at all.
-     *
-     * Off for now: Last.fm and ListenBrainz are shelved until a later version,
-     * and this is the one switch that shelves them — the settings rows dim
-     * and the submit paths in
-     * [PlaybackService][com.music.bitchord.playback.PlaybackService] go quiet.
-     * Without the second half of that, a device that had Last.fm connected
-     * before would keep scrobbling behind a screen saying the feature is gone.
-     *
-     * Nothing here clears the stored keys or toggles, so an account that was
-     * connected comes back exactly as it was.
-     *
-     * A plain `val` rather than a `const val` on purpose: a const would be
-     * folded away and every gate below would compile to a "condition is always
-     * false" warning.
-     */
-    val scrobblingAvailable = false
+    /** One release gate shared by the settings UI and the playback service. */
+    val scrobblingAvailable = true
 
     val lastfmEnabled = MutableStateFlow(false)
     val lastfmUsername = MutableStateFlow("")
@@ -305,11 +290,11 @@ object AppSettings {
         lastfmEnabled.value = prefs.getBoolean(KEY_LASTFM_ENABLED, false)
         lastfmUsername.value = prefs.getString(KEY_LASTFM_USERNAME, "").orEmpty()
         lastfmSessionKey.value = prefs.getString(KEY_LASTFM_SESSION_KEY, "").orEmpty()
-        lastfmApiKey.value = prefs.getString(KEY_LASTFM_API_KEY, "").orEmpty()
-        lastfmSecret.value = prefs.getString(KEY_LASTFM_SECRET, "").orEmpty()
+        lastfmApiKey.value = prefs.getString(KEY_LASTFM_API_KEY, "").orEmpty().ifBlank { BuildConfig.LASTFM_API_KEY }
+        lastfmSecret.value = prefs.getString(KEY_LASTFM_SECRET, "").orEmpty().ifBlank { BuildConfig.LASTFM_SECRET }
         lastfmEndpoint.value = prefs.getString(KEY_LASTFM_ENDPOINT, "").orEmpty()
         lastfmScrobbleEnabled.value = prefs.getBoolean(KEY_LASTFM_SCROBBLE_ENABLED, false)
-        lastfmNowPlaying.value = prefs.getBoolean(KEY_LASTFM_NOW_PLAYING, false)
+        lastfmNowPlaying.value = prefs.getBoolean(KEY_LASTFM_NOW_PLAYING, false) && lastfmScrobbleEnabled.value
         scrobbleMinDuration.value = prefs.getInt(KEY_SCROBBLE_MIN_DURATION, 30)
         scrobbleDelayPercent.value = prefs.getFloat(KEY_SCROBBLE_DELAY_PERCENT, 0.5f)
         scrobbleDelaySeconds.value = prefs.getInt(KEY_SCROBBLE_DELAY_SECONDS, 180)
@@ -556,10 +541,15 @@ object AppSettings {
 
     fun setLastfmScrobbleEnabled(value: Boolean) {
         lastfmScrobbleEnabled.value = value
-        prefs.edit().putBoolean(KEY_LASTFM_SCROBBLE_ENABLED, value).apply()
+        if (!value) lastfmNowPlaying.value = false
+        prefs.edit()
+            .putBoolean(KEY_LASTFM_SCROBBLE_ENABLED, value)
+            .putBoolean(KEY_LASTFM_NOW_PLAYING, if (value) lastfmNowPlaying.value else false)
+            .apply()
     }
 
     fun setLastfmNowPlaying(value: Boolean) {
+        if (!lastfmScrobbleEnabled.value && value) return
         lastfmNowPlaying.value = value
         prefs.edit().putBoolean(KEY_LASTFM_NOW_PLAYING, value).apply()
     }

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -286,9 +286,11 @@ class PlaybackService : MediaSessionService() {
             // transition — a track started from idle or resumed from pause
             // otherwise stays silent on the site.
             if (isPlaying && song != null) {
-                if (listenBrainzSong == null) {
+                if (listenBrainzSong?.videoId != song.videoId || listenBrainzStartMs == 0L) {
                     listenBrainzSong = song
                     listenBrainzStartMs = System.currentTimeMillis()
+                    listenBrainzDurationMs = durationMs
+                } else if (listenBrainzDurationMs == null) {
                     listenBrainzDurationMs = durationMs
                 }
                 submitListenBrainzPlayingNow(song, exoPlayer.currentPosition, durationMs)
@@ -403,13 +405,15 @@ class PlaybackService : MediaSessionService() {
                 // The last track finished with nothing after it, so no
                 // transition will ever close it out. Scrobble it now.
                 val lastSong = listenBrainzSong
-                if (lastSong != null) {
+                if (lastSong != null && listenBrainzStartMs > 0L) {
                     val lastStart = listenBrainzStartMs
                     val lastDuration = listenBrainzDurationMs
                         ?: exoPlayer.duration.takeIf { it > 0 }
                     submitListenBrainzFinished(lastSong, lastStart, lastDuration)
-                    listenBrainzSong = null
                 }
+                listenBrainzSong = null
+                listenBrainzStartMs = 0L
+                listenBrainzDurationMs = null
             }
         }
 
@@ -1099,7 +1103,9 @@ class PlaybackService : MediaSessionService() {
         scrobbleManager?.onSongStop()
         val newSong = mediaItem?.toSong()
         val durationMs = exoPlayer.duration.takeIf { it > 0 }
-        scrobbleManager?.onSongStart(newSong, durationMs)
+        if (exoPlayer.isPlaying) {
+            scrobbleManager?.onSongStart(newSong, durationMs)
+        }
 
         // ListenBrainz: submit finished for old song, playing_now for new song.
         // The finished listen only counts when the track actually ended —
@@ -1109,13 +1115,13 @@ class PlaybackService : MediaSessionService() {
         val ended = previousEnded
         val prevSong = listenBrainzSong
         val prevStart = listenBrainzStartMs
-        if (prevSong != null && ended) {
+        if (prevSong != null && ended && prevStart > 0L) {
             submitListenBrainzFinished(prevSong, prevStart, listenBrainzDurationMs)
         }
         listenBrainzSong = newSong
-        listenBrainzStartMs = System.currentTimeMillis()
+        listenBrainzStartMs = if (exoPlayer.isPlaying) System.currentTimeMillis() else 0L
         listenBrainzDurationMs = durationMs
-        if (newSong != null) {
+        if (newSong != null && exoPlayer.isPlaying) {
             submitListenBrainzPlayingNow(newSong, 0L, durationMs)
         }
 
@@ -2513,7 +2519,8 @@ class PlaybackService : MediaSessionService() {
     }
 
     private fun observeScrobbling() {
-        // Rebuild the ScrobbleManager whenever scrobbling settings change.
+        // Keep the manager alive while its timing settings change, so updating
+        // a preference does not cancel the current track's scrobble timer.
         scope.launch {
             // Explicit <Any, _>: these flows have mixed element types, and letting
             // the reified vararg combine() infer T lands on an intersection type.
@@ -2542,30 +2549,40 @@ class PlaybackService : MediaSessionService() {
                     delaySeconds = values[9] as Int,
                 )
             }.collectLatest { snapshot ->
-                scrobbleManager?.destroy()
-                scrobbleManager = null
-
-                if (AppSettings.scrobblingAvailable &&
+                val shouldEnable = AppSettings.scrobblingAvailable &&
                     snapshot.lastfmEnabled &&
-                    snapshot.sessionKey.isNotBlank()
-                ) {
-                    // Configure LastFM client
-                    val endpoint = snapshot.endpoint.ifBlank { LastFM.DEFAULT_API_ENDPOINT }
-                    val apiKey = snapshot.apiKey.ifBlank { LastFM.FALLBACK_COMPAT_API_KEY }
-                    val secret = snapshot.secret.ifBlank { LastFM.FALLBACK_COMPAT_SECRET }
-                    LastFM.configure(
-                        endpoint = endpoint,
-                        apiKey = apiKey,
-                        secret = secret,
-                        sessionKey = snapshot.sessionKey,
-                    )
-                    scrobbleManager = ScrobbleManager(
-                        scope = scope,
-                        minSongDuration = snapshot.minDuration,
-                        scrobbleDelayPercent = snapshot.delayPercent,
-                        scrobbleDelaySeconds = snapshot.delaySeconds,
-                    ).apply {
-                        useNowPlaying = snapshot.nowPlaying
+                    snapshot.scrobbleEnabled &&
+                    snapshot.sessionKey.isNotBlank() &&
+                    snapshot.apiKey.isNotBlank() &&
+                    snapshot.secret.isNotBlank()
+
+                if (!shouldEnable) {
+                    scrobbleManager?.destroy()
+                    scrobbleManager = null
+                    return@collectLatest
+                }
+
+                LastFM.configure(
+                    endpoint = snapshot.endpoint.ifBlank { LastFM.DEFAULT_API_ENDPOINT },
+                    apiKey = snapshot.apiKey,
+                    secret = snapshot.secret,
+                    sessionKey = snapshot.sessionKey,
+                )
+                val manager = scrobbleManager ?: ScrobbleManager(scope).also {
+                    scrobbleManager = it
+                }
+                manager.minSongDuration = snapshot.minDuration
+                manager.scrobbleDelayPercent = snapshot.delayPercent
+                manager.scrobbleDelaySeconds = snapshot.delaySeconds
+                manager.useNowPlaying = snapshot.nowPlaying
+
+                player?.let { exoPlayer ->
+                    if (exoPlayer.isPlaying) {
+                        manager.onPlayerStateChanged(
+                            isPlaying = true,
+                            song = exoPlayer.currentMediaItem?.toSong(),
+                            durationMs = exoPlayer.duration.takeIf { it > 0 },
+                        )
                     }
                 }
             }
@@ -2815,7 +2832,7 @@ class PlaybackService : MediaSessionService() {
         // service scope: it is cancelled a few lines down, and the request
         // should still reach ListenBrainz.
         val lastSong = listenBrainzSong
-        if (lastSong != null) {
+        if (lastSong != null && listenBrainzStartMs > 0L) {
             val lbEnabled =
                 AppSettings.scrobblingAvailable && AppSettings.listenBrainzEnabled.value
             val lbToken = AppSettings.listenBrainzToken.value

--- a/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
@@ -735,10 +735,10 @@ fun SettingsScreen(
                         lastfmError = null
                         scrobbleScope.launch {
                             try {
-                                // Use default keys for now
+                                // Use the credentials supplied for this build.
                                 LastFM.initialize(
-                                    apiKey = LastFM.FALLBACK_COMPAT_API_KEY,
-                                    secret = LastFM.FALLBACK_COMPAT_SECRET,
+                                    apiKey = AppSettings.lastfmApiKey.value,
+                                    secret = AppSettings.lastfmSecret.value,
                                 )
                                 LastFM.getMobileSession(usernameInput.trim(), passwordInput)
                                     .onSuccess { auth ->


### PR DESCRIPTION
- fixes #9 

NOTE: Last.fm login needs `LASTFM_API_KEY` and `LASTFM_SECRET` in
`local.properties` or the environment, kindly make sure to create one for BitChord (here: https://www.last.fm/api/account/create) first and define there during build time before release.