### PR TITLE
feat: brand channel support — choose which channel to listen as

### DIFF
--- a/app/src/main/java/com/music/bitchord/BitChordApplication.kt
+++ b/app/src/main/java/com/music/bitchord/BitChordApplication.kt
@@ -42,6 +42,10 @@ class BitChordApplication : Application(), SingletonImageLoader.Factory {
         // the listener, from one that was never registered at all. Fire and
         // forget — every caller works without it, just less precisely.
         if (authStore.cookie != null) {
+            // After the cookie, never before: setting the cookie clears any
+            // channel the last session was acting as, so restoring the choice
+            // first would restore it into the value about to be wiped.
+            Innertube.selectChannel(authStore.channelPageId, authStore.channelDataSyncId)
             CoroutineScope(Dispatchers.IO).launch { Innertube.ensureSessionScope() }
         }
         AppSettings.init(this)

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -88,6 +88,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.music.bitchord.auth.DiscordLoginScreen
+import com.music.bitchord.auth.WebSessionMode
 import com.music.bitchord.auth.YtMusicLoginScreen
 import com.music.bitchord.data.AppUpdateChecker
 import com.music.bitchord.data.LocalMediaRepository
@@ -106,6 +107,7 @@ import com.music.bitchord.data.model.durationMillis
 import com.music.bitchord.data.scrobbling.LastFM
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.ThemeMode
+import com.music.bitchord.ui.components.AccountChannelDialog
 import com.music.bitchord.ui.screens.AccountAndScrobblingScreen
 import com.music.bitchord.ui.screens.DiscordDialog
 import com.music.bitchord.ui.screens.DiscordDialogHost
@@ -268,7 +270,11 @@ private fun BitChordApp(
             PlayerDeepLink.handled()
         }
     }
-    var showLogin by remember { mutableStateOf(false) }
+    /**
+     * What the in-app browser is open for, or null while it is closed —
+     * signing in, or picking a channel in YouTube Music's own Accounts list.
+     */
+    var webSession by remember { mutableStateOf<WebSessionMode?>(null) }
     var showSettings by remember { mutableStateOf(false) }
     // Replay: the page, the stories over it, and the share sheet over those.
     // Three states rather than one enum because they stack — the stories are
@@ -293,6 +299,7 @@ private fun BitChordApp(
     var libraryShowAll by remember { mutableStateOf<HomeShelf?>(null) }
     var showLyricsSources by remember { mutableStateOf(false) }
     var showAppLanguage by remember { mutableStateOf(false) }
+    var showChannelPicker by remember { mutableStateOf(false) }
     var showListenBrainzLogin by remember { mutableStateOf(false) }
     var showLastfmLogin by remember { mutableStateOf(false) }
     /**
@@ -385,6 +392,10 @@ private fun BitChordApp(
     val filter by viewModel.filter.collectAsStateWithLifecycle()
     val signedIn by viewModel.signedIn.collectAsStateWithLifecycle()
     val account by viewModel.account.collectAsStateWithLifecycle()
+    val channels by viewModel.channels.collectAsStateWithLifecycle()
+    val channelsLoading by viewModel.channelsLoading.collectAsStateWithLifecycle()
+    val selectedChannelKey by viewModel.selectedChannelKey.collectAsStateWithLifecycle()
+    val selectedChannelName by viewModel.selectedChannelName.collectAsStateWithLifecycle()
     val historyState by viewModel.history.collectAsStateWithLifecycle()
     val lyrics by viewModel.lyrics.collectAsStateWithLifecycle()
     val lyricsSource by viewModel.lyricsSource.collectAsStateWithLifecycle()
@@ -1435,10 +1446,18 @@ private fun BitChordApp(
                         AccountAndScrobblingScreen(
                             signedIn = signedIn,
                             account = account,
+                            channelName = selectedChannelName,
                             onSignIn = {
                                 showAccountScrobbling = false
                                 showSettings = false
-                                showLogin = true
+                                webSession = WebSessionMode.SIGN_IN
+                            },
+                            onSwitchChannel = {
+                                // Asked for on open rather than on sign-in: it
+                                // is a request per session that most listeners,
+                                // who have exactly one channel, never need.
+                                viewModel.loadChannels()
+                                showChannelPicker = true
                             },
                             onSignOut = { viewModel.signOut() },
                             onOpenListenBrainzLogin = { showListenBrainzLogin = true },
@@ -1461,7 +1480,7 @@ private fun BitChordApp(
                             account = account,
                             onSignIn = {
                                 showSettings = false
-                                showLogin = true
+                                webSession = WebSessionMode.SIGN_IN
                             },
                             onSignOut = { viewModel.signOut() },
                             onAccountScrobbling = { showAccountScrobbling = true },
@@ -1613,7 +1632,7 @@ private fun BitChordApp(
                             state = homeState,
                             listState = homeListState,
                             signedIn = signedIn,
-                            onSignIn = { showLogin = true },
+                            onSignIn = { webSession = WebSessionMode.SIGN_IN },
                             onItemClick = { item ->
                                 when {
                                     item.videoId != null -> playRadio(
@@ -1750,7 +1769,7 @@ private fun BitChordApp(
                             onShowAll = { shelf -> libraryShowAll = shelf },
                             replayCard = replayCards.firstOrNull(),
                             onOpenReplay = { showReplay = true },
-                            onSignIn = { showLogin = true },
+                            onSignIn = { webSession = WebSessionMode.SIGN_IN },
                             onRetry = viewModel::loadLibrary,
                             refreshing = MainViewModel.Feed.LIBRARY in refreshing,
                             onRefresh = { viewModel.refresh(MainViewModel.Feed.LIBRARY) },
@@ -2299,8 +2318,14 @@ private fun BitChordApp(
         }
 
         // ---- Google sign-in (full screen WebView) ----
-        if (showLogin) {
-            BackHandler { showLogin = false }
+        webSession?.let { mode ->
+            BackHandler { webSession = null }
+            // Raised by "Use this channel", read by the browser as "take the
+            // session from the page as it now stands". A counter rather than a
+            // flag so a second tap, after a failed first one, is still a new
+            // request rather than a value that was already true.
+            var captureRequest by remember(mode) { mutableIntStateOf(0) }
+            var captureFailed by remember(mode) { mutableStateOf(false) }
             Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
                 Column(Modifier.fillMaxSize()) {
                     Row(
@@ -2310,24 +2335,52 @@ private fun BitChordApp(
                             .padding(horizontal = 8.dp, vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        IconButton(onClick = { showLogin = false }) {
+                        IconButton(onClick = { webSession = null }) {
                             Icon(
                                 Icons.Rounded.Close,
                                 contentDescription = "Close",
                                 tint = MaterialTheme.colorScheme.onBackground,
                             )
                         }
-                        Text(
-                            "Sign in to YouTube Music",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onBackground,
-                        )
+                        Column(Modifier.weight(1f)) {
+                            Text(
+                                text = when (mode) {
+                                    WebSessionMode.SIGN_IN -> "Sign in to YouTube Music"
+                                    WebSessionMode.SWITCH_CHANNEL -> "Choose a channel"
+                                },
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onBackground,
+                            )
+                            if (mode == WebSessionMode.SWITCH_CHANNEL) {
+                                Text(
+                                    text = if (captureFailed) {
+                                        "No session on this page yet — open YouTube Music first"
+                                    } else {
+                                        "Switch with the avatar, then tap Use this channel"
+                                    },
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 2,
+                                )
+                            }
+                        }
+                        if (mode == WebSessionMode.SWITCH_CHANNEL) {
+                            TextButton(onClick = {
+                                captureFailed = false
+                                captureRequest++
+                            }) {
+                                Text("Use this channel")
+                            }
+                        }
                     }
                     YtMusicLoginScreen(
-                        onCookiesCaptured = { cookie ->
-                            viewModel.onSignedIn(cookie)
-                            showLogin = false
-                            selectedTab = 2
+                        mode = mode,
+                        captureRequest = captureRequest,
+                        onCaptureUnavailable = { captureFailed = true },
+                        onCaptured = { session ->
+                            viewModel.onWebSession(session, mode)
+                            webSession = null
+                            if (mode == WebSessionMode.SIGN_IN) selectedTab = 2
                         },
                     )
                 }
@@ -2374,6 +2427,22 @@ private fun BitChordApp(
             LyricsSourcesDialog(
                 hazeState = hazeState,
                 onDismiss = { showLyricsSources = false },
+            )
+        }
+
+        if (showChannelPicker) {
+            BackHandler { showChannelPicker = false }
+            AccountChannelDialog(
+                channels = channels,
+                loading = channelsLoading,
+                selectedKey = selectedChannelKey,
+                hazeState = hazeState,
+                onSelect = { viewModel.selectChannel(it) },
+                onChooseInYouTube = {
+                    showChannelPicker = false
+                    webSession = WebSessionMode.SWITCH_CHANNEL
+                },
+                onDismiss = { showChannelPicker = false },
             )
         }
 

--- a/app/src/main/java/com/music/bitchord/auth/AuthStore.kt
+++ b/app/src/main/java/com/music/bitchord/auth/AuthStore.kt
@@ -49,9 +49,78 @@ class AuthStore(context: Context) {
         set(value) = prefs.edit().putString(KEY_DISCORD_TOKEN, value).apply()
 
     /**
+     * The channel the listener chose to act as, if they chose one.
+     *
+     * Stored beside the cookie rather than in the plain settings because it is
+     * only meaningful with that cookie and must not outlive it: a `dataSyncId`
+     * from one login, replayed under another, is answered with 401 on every
+     * request. [signOut] and [onNewSession] both clear it for that reason.
+     *
+     * A null [channelPageId] with a [channelDataSyncId] set is a real state,
+     * not an absent one — it is the account's own channel, deliberately chosen
+     * over a brand channel the web player would otherwise default to.
+     */
+    val channelPageId: String? get() = prefs.getString(KEY_CHANNEL_PAGE_ID, null)
+    val channelDataSyncId: String? get() = prefs.getString(KEY_CHANNEL_DATASYNC_ID, null)
+
+    /** The chosen channel's display name, for the settings row. */
+    val channelName: String? get() = prefs.getString(KEY_CHANNEL_NAME, null)
+
+    /** Which Google account in the jar it belongs to; null means "as the shell says". */
+    val channelAuthUser: String? get() = prefs.getString(KEY_CHANNEL_AUTH_USER, null)
+
+    fun selectChannel(
+        pageId: String?,
+        dataSyncId: String?,
+        name: String?,
+        authUser: String? = null,
+    ) = prefs.edit()
+        .putString(KEY_CHANNEL_PAGE_ID, pageId)
+        .putString(KEY_CHANNEL_DATASYNC_ID, dataSyncId)
+        .putString(KEY_CHANNEL_NAME, name)
+        .putString(KEY_CHANNEL_AUTH_USER, authUser)
+        .apply()
+
+    /**
+     * The chosen channel's name, once something knows it.
+     *
+     * Separate from [selectChannel] because the two are learned at different
+     * times: a channel picked in the in-app browser is identified by ids the
+     * moment it is picked, and named only after the next account fetch comes
+     * back to say what it is called.
+     */
+    fun setChannelName(name: String?) =
+        prefs.edit().putString(KEY_CHANNEL_NAME, name).apply()
+
+    /** Back to whichever channel YouTube Music serves by default. */
+    fun clearChannel() = prefs.edit()
+        .remove(KEY_CHANNEL_PAGE_ID)
+        .remove(KEY_CHANNEL_DATASYNC_ID)
+        .remove(KEY_CHANNEL_NAME)
+        .remove(KEY_CHANNEL_AUTH_USER)
+        .apply()
+
+    /**
+     * A fresh login lands here. The cookie is new, so any channel chosen under
+     * the old one names an identity this session cannot act as.
+     */
+    fun onNewSession(cookie: String) {
+        this.cookie = cookie
+        clearChannel()
+    }
+
+    /**
      * Signs out of YouTube Music only — the Discord login is a separate account.
      */
-    fun signOut() = prefs.edit().remove(KEY_COOKIE).apply()
+    fun signOut() {
+        prefs.edit().remove(KEY_COOKIE).apply()
+        clearChannel()
+        // The in-app browser keeps its own copy of the Google login, and a
+        // sign-out that leaves it in place is not one: the next sign-in is
+        // waved straight through as the account just signed out of, with no
+        // opportunity to choose another. See [BrowserSession].
+        BrowserSession.clearGoogleCookies()
+    }
 
     companion object {
         /**
@@ -77,6 +146,10 @@ class AuthStore(context: Context) {
             setOf("SAPISID", "__Secure-3PAPISID", "__Secure-1PAPISID")
 
         private const val KEY_COOKIE = "cookie"
+        private const val KEY_CHANNEL_PAGE_ID = "channel_page_id"
+        private const val KEY_CHANNEL_DATASYNC_ID = "channel_datasync_id"
+        private const val KEY_CHANNEL_NAME = "channel_name"
+        private const val KEY_CHANNEL_AUTH_USER = "channel_auth_user"
         private const val KEY_DISCORD_TOKEN = "discord_token"
     }
 }

--- a/app/src/main/java/com/music/bitchord/auth/WebSession.kt
+++ b/app/src/main/java/com/music/bitchord/auth/WebSession.kt
@@ -1,0 +1,106 @@
+package com.music.bitchord.auth
+
+import android.webkit.CookieManager
+import com.music.bitchord.data.DebugLog as Log
+
+/** What the in-app browser is being opened for. */
+enum class WebSessionMode {
+    /** No usable session yet: sign in to Google. */
+    SIGN_IN,
+
+    /**
+     * Already signed in, but on the wrong channel. Opens YouTube Music itself
+     * so its own Accounts switcher can be used, and takes the session from
+     * whatever page the listener ends up on.
+     */
+    SWITCH_CHANNEL,
+}
+
+/**
+ * A session lifted out of the in-app browser: the cookie, plus who the page
+ * being looked at says it is.
+ *
+ * The identity fields come from the live page's `ytcfg` rather than from a
+ * later server-side fetch of the shell, and that is the entire point. Which
+ * channel YouTube Music serves by default is not a question this app gets to
+ * answer, but which channel the page in front of the listener is *currently*
+ * showing is not a question at all — it is written down in the page. Reading
+ * it there is what lets "switch to the channel I want, then save" work.
+ *
+ * All identity fields are nullable: a page that will not give them up leaves
+ * the app exactly where it was before, scraping the shell for its best guess.
+ */
+data class CapturedSession(
+    val cookie: String,
+    /** `DELEGATED_SESSION_ID` — set only while a brand channel is selected. */
+    val pageId: String?,
+    /** `DATASYNC_ID`, account half only. */
+    val dataSyncId: String?,
+    /** `SESSION_INDEX` — which Google account in the cookie jar. */
+    val authUser: String?,
+    val visitorData: String?,
+    val clientVersion: String?,
+    /** Whether the page reported itself signed in at all. */
+    val loggedIn: Boolean,
+)
+
+/**
+ * The WebView's own cookie jar, which is not the app's.
+ *
+ * These are separate stores and the difference is invisible until it bites:
+ * signing out of BitChord forgets the cookie the app makes requests with, and
+ * leaves the browser's copy untouched. The next sign-in then loads
+ * accounts.google.com, is recognised immediately, redirects straight through
+ * to music.youtube.com and hands back a cookie for the account that was just
+ * signed out of — a sign-in screen that cannot be used to sign in as anyone
+ * else, and shows barely a flicker while refusing to.
+ */
+object BrowserSession {
+
+    /**
+     * Forgets the Google login the in-app browser is holding.
+     *
+     * Google's cookies only, by name, rather than [CookieManager.removeAllCookies]:
+     * the same jar holds the Discord and Last.fm logins from their own in-app
+     * browsers, and signing out of YouTube Music is not a reason to sign out of
+     * those. There is no per-domain removal in the API, so each cookie is
+     * overwritten with an expired one of the same name.
+     */
+    fun clearGoogleCookies() {
+        // Best effort throughout. CookieManager needs a WebView provider, and
+        // on a device that is mid-update or has none there isn't one — which is
+        // a reason for the next sign-in to be less convenient, not a reason for
+        // signing out to crash.
+        val manager = runCatching { CookieManager.getInstance() }.getOrElse {
+            Log.w("BitChord", "no cookie manager to clear: ${it.message}")
+            return
+        }
+        var cleared = 0
+        GOOGLE_ORIGINS.forEach { origin ->
+            val jar = manager.getCookie(origin) ?: return@forEach
+            val host = origin.substringAfter("://")
+            jar.split(';').forEach { entry ->
+                val name = entry.substringBefore('=').trim()
+                if (name.isEmpty()) return@forEach
+                // Both the host-only and the domain-wide form: a cookie set on
+                // `.google.com` is not removed by expiring it on the host, and
+                // which of the two a given cookie used is not recorded here.
+                manager.setCookie(origin, "$name=; Max-Age=0; Path=/")
+                manager.setCookie(origin, "$name=; Max-Age=0; Path=/; Domain=$host")
+                manager.setCookie(origin, "$name=; Max-Age=0; Path=/; Domain=.$host")
+                cleared++
+            }
+        }
+        runCatching { manager.flush() }
+        Log.d("BitChord", "cleared $cleared browser cookies for Google")
+    }
+
+    private val GOOGLE_ORIGINS = listOf(
+        "https://music.youtube.com",
+        "https://www.youtube.com",
+        "https://youtube.com",
+        "https://accounts.google.com",
+        "https://www.google.com",
+        "https://google.com",
+    )
+}

--- a/app/src/main/java/com/music/bitchord/auth/YtMusicLoginScreen.kt
+++ b/app/src/main/java/com/music/bitchord/auth/YtMusicLoginScreen.kt
@@ -6,31 +6,79 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import com.music.bitchord.data.DebugLog as Log
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 
 private const val MUSIC_ORIGIN = "https://music.youtube.com"
 
+private const val LOGIN_URL =
+    "https://accounts.google.com/ServiceLogin" +
+        "?ltmpl=music&service=youtube&passive=true" +
+        "&continue=https%3A%2F%2Fmusic.youtube.com%2F"
+
+private const val TAG = "BitChord"
+
 /**
- * In-app Google sign-in for YouTube Music.
+ * In-app Google sign-in for YouTube Music, and the way to change which channel
+ * it listens as.
  *
- * Flow: load the standard Google web login with `continue=music.youtube.com`.
- * The user authenticates directly against accounts.google.com (2FA, passkeys
- * etc. all work — it's the real page). When Google redirects back to
- * music.youtube.com, the session cookies (SAPISID, __Secure-3PAPISID, ...)
- * land in the WebView's CookieManager; we lift the cookie header for the
- * music.youtube.com origin and hand it to [onCookiesCaptured] exactly once.
- * The credential itself never passes through app code.
+ * [WebSessionMode.SIGN_IN] loads the standard Google web login with
+ * `continue=music.youtube.com`. The user authenticates directly against
+ * accounts.google.com (2FA, passkeys etc. all work — it's the real page). When
+ * Google redirects back to music.youtube.com the session is taken automatically
+ * and the screen closes. The browser's Google cookies are cleared on the way in,
+ * or a listener who signed out would be waved straight back through as the
+ * account they were trying to leave — see [BrowserSession.clearGoogleCookies].
+ *
+ * [WebSessionMode.SWITCH_CHANNEL] keeps those cookies and opens YouTube Music
+ * itself, so the listener can use the avatar menu's own Accounts list — the one
+ * screen that authoritatively knows which channels exist and which is which.
+ * Nothing is taken automatically there: the session is read when they say so,
+ * by raising [captureRequest].
+ *
+ * Either way what is read is the page's own `ytcfg`, not a guess made later
+ * from a server-side fetch. The credential itself never passes through app code.
  */
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun YtMusicLoginScreen(
-    onCookiesCaptured: (cookieHeader: String) -> Unit,
+    mode: WebSessionMode,
+    onCaptured: (CapturedSession) -> Unit,
     modifier: Modifier = Modifier,
+    /**
+     * Raise to take the session from the page as it stands. Ignored at its
+     * initial value, so arriving on the screen doesn't capture anything.
+     */
+    captureRequest: Int = 0,
+    /** Told when a capture was asked for and there was no session to take. */
+    onCaptureUnavailable: () -> Unit = {},
 ) {
+    var webView by remember { mutableStateOf<WebView?>(null) }
+    val currentOnCaptured by rememberUpdatedState(onCaptured)
+    val currentOnUnavailable by rememberUpdatedState(onCaptureUnavailable)
+
+    LaunchedEffect(captureRequest) {
+        if (captureRequest == 0) return@LaunchedEffect
+        val view = webView
+        if (view == null || !captureFrom(view, currentOnCaptured)) currentOnUnavailable()
+    }
+
     AndroidView(
         modifier = modifier.fillMaxSize(),
         factory = { context ->
+            if (mode == WebSessionMode.SIGN_IN) BrowserSession.clearGoogleCookies()
             WebView(context).apply {
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
@@ -39,25 +87,97 @@ fun YtMusicLoginScreen(
                     private var captured = false
 
                     override fun onPageFinished(view: WebView?, url: String?) {
+                        // Only [WebSessionMode.SIGN_IN] finishes by itself. In
+                        // the switch flow the first music.youtube.com page is
+                        // where the listener starts, not where they are done —
+                        // grabbing the session there would save the channel
+                        // they came to change.
+                        if (mode != WebSessionMode.SIGN_IN) return
                         if (captured || url?.startsWith(MUSIC_ORIGIN) != true) return
-                        val cookies = CookieManager.getInstance().getCookie(MUSIC_ORIGIN)
-                        // Not a substring test. See [AuthStore.hasApiSid] — the
-                        // one this replaces accepted a jar with no signing
-                        // secret in it, and the sign-in then appeared to
-                        // succeed while every request stayed anonymous.
-                        if (cookies != null && AuthStore.hasApiSid(cookies)) {
-                            captured = true
-                            onCookiesCaptured(cookies)
-                        }
+                        if (view != null && captureFrom(view, currentOnCaptured)) captured = true
                     }
                 }
 
-                loadUrl(
-                    "https://accounts.google.com/ServiceLogin" +
-                        "?ltmpl=music&service=youtube&passive=true" +
-                        "&continue=https%3A%2F%2Fmusic.youtube.com%2F",
-                )
+                webView = this
+                loadUrl(if (mode == WebSessionMode.SIGN_IN) LOGIN_URL else "$MUSIC_ORIGIN/")
             }
         },
     )
 }
+
+/**
+ * Takes the session from [view], if it is holding one.
+ *
+ * @return whether there was one to take. False means the cookie jar has no
+ *   signing secret in it yet — the page is mid-login, or is not a YouTube page
+ *   at all — and the caller should leave the screen open rather than saving
+ *   something that cannot sign a request. See [AuthStore.hasApiSid].
+ */
+private fun captureFrom(view: WebView, onCaptured: (CapturedSession) -> Unit): Boolean {
+    val cookies = CookieManager.getInstance().getCookie(MUSIC_ORIGIN)
+    if (cookies == null || !AuthStore.hasApiSid(cookies)) return false
+    // Flushed here rather than left to the WebView's own schedule: the screen
+    // is usually closing in the next frame, and a cookie jar written after
+    // that is a jar the next sign-in reads instead of this one.
+    CookieManager.getInstance().flush()
+
+    view.evaluateJavascript(YTCFG_PROBE) { raw ->
+        val config = raw.parseConfig()
+        if (config == null) {
+            Log.w(TAG, "no ytcfg on the page; falling back to the shell for identity")
+        }
+        onCaptured(
+            CapturedSession(
+                cookie = cookies,
+                // `<accountSyncId>||<sessionSyncId>` — only the first half
+                // names the account; the second changes on its own schedule.
+                dataSyncId = config?.string("dataSyncId")?.substringBefore("||"),
+                pageId = config?.string("pageId"),
+                authUser = config?.string("authUser"),
+                visitorData = config?.string("visitorData"),
+                clientVersion = config?.string("clientVersion"),
+                loggedIn = config?.get("loggedIn").let { it is JsonPrimitive && it.content == "true" },
+            ),
+        )
+    }
+    return true
+}
+
+/**
+ * The identity of the page as the page itself has it.
+ *
+ * Returns an object rather than a string so the WebView serialises it — a
+ * probe that stringified its own result would come back double-encoded. A page
+ * without `ytcfg` (an error page, a redirect that hasn't landed) returns null,
+ * which is a fine answer and not an error.
+ */
+private const val YTCFG_PROBE = """
+(function () {
+  try {
+    if (!window.ytcfg || !window.ytcfg.get) return null;
+    var get = function (key) {
+      var value = window.ytcfg.get(key);
+      return (value === undefined || value === null || value === '') ? null : String(value);
+    };
+    return {
+      loggedIn: String(!!window.ytcfg.get('LOGGED_IN')),
+      pageId: get('DELEGATED_SESSION_ID'),
+      dataSyncId: get('DATASYNC_ID'),
+      authUser: get('SESSION_INDEX'),
+      visitorData: get('VISITOR_DATA'),
+      clientVersion: get('INNERTUBE_CLIENT_VERSION')
+    };
+  } catch (e) {
+    return null;
+  }
+})()
+"""
+
+private val json = Json { ignoreUnknownKeys = true }
+
+/** The probe's result, or null for anything that isn't the object it promises. */
+private fun String?.parseConfig(): JsonObject? =
+    this?.let { runCatching { json.parseToJsonElement(it).jsonObject }.getOrNull() }
+
+private fun JsonObject.string(key: String): String? =
+    (this[key] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }

--- a/app/src/main/java/com/music/bitchord/data/YtMusicRepository.kt
+++ b/app/src/main/java/com/music/bitchord/data/YtMusicRepository.kt
@@ -4,6 +4,7 @@ import com.music.bitchord.data.DebugLog as Log
 import com.music.bitchord.data.innertube.Innertube
 import com.music.bitchord.data.innertube.InnertubeParser
 import com.music.bitchord.data.model.Account
+import com.music.bitchord.data.model.AccountChannel
 import com.music.bitchord.data.model.ArtistPage
 import com.music.bitchord.data.model.HomeFeed
 import com.music.bitchord.data.model.HomeShelf
@@ -213,6 +214,26 @@ object YtMusicRepository {
     suspend fun account(): Result<Account> = call("account") {
         InnertubeParser.parseAccount(Innertube.accountMenu())
             ?: error("No account details")
+    }
+
+    /**
+     * The channels this login can act as — its own, plus any brand channels.
+     *
+     * Two endpoints are asked in turn because either can come back with an
+     * envelope holding no `accountItem` at all, and the two do not fail
+     * together: `accounts_list` is the first-party route and the switcher is
+     * what youtube.com's own avatar menu uses. An empty list from the first is
+     * not an answer, it is a shape this parser didn't recognise, so it is
+     * treated the same as a failure and the other route is tried.
+     */
+    suspend fun accountChannels(): Result<List<AccountChannel>> = call("channels") {
+        val viaInnertube = runCatching {
+            InnertubeParser.parseAccountChannels(Innertube.accountsList())
+        }.onFailure { Log.w(TAG, "accounts_list unavailable: ${it.message}") }
+            .getOrNull()
+            .orEmpty()
+        if (viaInnertube.isNotEmpty()) return@call viaInnertube
+        InnertubeParser.parseAccountChannels(Innertube.accountSwitcher())
     }
 
     /**

--- a/app/src/main/java/com/music/bitchord/data/innertube/Innertube.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/Innertube.kt
@@ -88,6 +88,10 @@ object Innertube {
                 scope = null
                 visitorData = null
                 visitorDataIsSessionBound = false
+                // The chosen channel belonged to the account that just left.
+                // A `dataSyncId` from one login sent under another's cookie is
+                // answered with 401 on every request, so it goes with it.
+                channelOverride = null
             }
             field = value
         }
@@ -206,6 +210,115 @@ object Innertube {
     private var scope: SessionScope? = null
 
     private val scopeLock = Mutex()
+
+    /** A channel the listener picked, standing in for the shell's default. */
+    class ChannelSelection(
+        val pageId: String?,
+        val dataSyncId: String?,
+        /**
+         * Which Google account in the cookie jar the channel belongs to. Null
+         * leaves the shell's own answer alone — a brand channel sits under the
+         * account that owns it, so this only differs when the listener switched
+         * to a channel of a *different* signed-in Google account.
+         */
+        val authUser: String? = null,
+    )
+
+    /**
+     * The channel to act as, when the listener has said which.
+     *
+     * [fetchSessionScope] can only report the one music.youtube.com serves by
+     * default, and for an account whose music lives on a brand channel that is
+     * the wrong one — the library, the likes and the history all belong to the
+     * other identity. Once a channel has been chosen it outranks the shell
+     * completely, including when what it chose is the account's own channel and
+     * the shell is the one offering a brand page.
+     */
+    @Volatile
+    private var channelOverride: ChannelSelection? = null
+
+    /**
+     * Act as this channel from now on; both null goes back to the shell's
+     * default. Takes effect on the next request — nothing is cached from it.
+     */
+    fun selectChannel(pageId: String?, dataSyncId: String?, authUser: String? = null) {
+        channelOverride = if (pageId == null && dataSyncId == null) {
+            null
+        } else {
+            ChannelSelection(pageId, dataSyncId, authUser)
+        }
+        Log.d(
+            TAG,
+            "acting as channel pageId=${pageId ?: "none"} authUser=${authUser ?: "as-is"} " +
+                "(override=${channelOverride != null})",
+        )
+    }
+
+    /**
+     * Takes the session scope from a page the listener was actually looking at,
+     * rather than working it out later from a fetch of our own.
+     *
+     * The shell fetch in [fetchSessionScope] can only ever report the channel
+     * music.youtube.com serves this app by default, and the whole reason the
+     * in-app browser exists is that the listener has just told it, by hand,
+     * that they want a different one. That answer is written into the page's
+     * own `ytcfg`, so it is read from there and adopted whole.
+     *
+     * Adopting also settles [ensureSessionScope] — a scope already in hand is
+     * not refetched — so the shell cannot quietly overwrite the choice with its
+     * default on the next request.
+     *
+     * A page that reported itself signed out is ignored apart from its client
+     * version: its `DATASYNC_ID` belongs to no account, and sending one Google
+     * cannot tie to the session is answered with 401 on every request.
+     */
+    fun adoptSessionScope(
+        pageId: String?,
+        dataSyncId: String?,
+        authUser: String?,
+        visitorData: String?,
+        clientVersion: String?,
+        loggedIn: Boolean,
+    ) {
+        val version = clientVersion ?: scope?.clientVersion
+        if (!loggedIn) {
+            Log.w(TAG, "captured page was signed out; not scoping requests to it")
+            scope = version?.let { SessionScope(null, null, "0", it) }
+            return
+        }
+        scope = SessionScope(
+            dataSyncId = dataSyncId?.takeIf { it.isNotBlank() },
+            pageId = pageId?.takeIf { it.isNotBlank() },
+            authUser = authUser?.takeIf { it.isNotBlank() } ?: "0",
+            clientVersion = version,
+        )
+        // The page's own visitor id, bound to this session — strictly better
+        // than the anonymous one [fetchVisitorData] mints. See [visitorData].
+        visitorData?.takeIf { it.isNotBlank() }?.let {
+            this.visitorData = it
+            visitorDataIsSessionBound = true
+        }
+        Log.d(TAG, "adopted page scope: pageId=${pageId ?: "none"} authUser=${authUser ?: "0"}")
+    }
+
+    /** The brand channel to send, chosen one first. */
+    private fun pageIdFor(session: SessionScope?): String? =
+        (channelOverride ?: return session?.pageId).pageId
+
+    /**
+     * The account to send as `onBehalfOfUser`, chosen one first.
+     *
+     * No falling back to the shell's value once a channel has been chosen: the
+     * shell's id names the default identity, and pairing it with another
+     * channel's [pageId] describes an account/page combination that doesn't
+     * exist.
+     */
+    private fun dataSyncIdFor(session: SessionScope?): String? =
+        (channelOverride ?: return session?.dataSyncId).dataSyncId
+
+    /** Which account in the cookie jar, chosen channel's first. */
+    private fun authUserFor(session: SessionScope?): String =
+        channelOverride?.authUser ?: session?.authUser ?: "0"
 
     /**
      * The WEB_REMIX version to claim, live if the shell has been read.
@@ -398,6 +511,51 @@ object Innertube {
 
     /** Signed-in profile: display name, email/handle and avatar. */
     suspend fun accountMenu(): JsonObject = postMusic("account/account_menu") {}
+
+    /**
+     * Every channel this session can act as, as Innertube's account switcher
+     * lists them: the account's own channel first, then its brand channels.
+     *
+     * Each entry carries the two things a request needs to be made *as* that
+     * channel — a `pageIdToken` and a `datasyncIdToken` — which is the whole
+     * reason to ask rather than to reason about it. See [selectChannel].
+     */
+    suspend fun accountsList(): JsonObject = postMusic("account/accounts_list") {}
+
+    /**
+     * The same list from youtube.com's own switcher, as a second route.
+     *
+     * Worth having both. `accounts_list` is the tidier call but it is not
+     * uniformly answered for every client identity, and a listener whose music
+     * is on a brand channel is stuck with the wrong library until *something*
+     * enumerates their channels. This endpoint is what the youtube.com avatar
+     * menu itself calls, and it answers a plain signed GET.
+     *
+     * The body is JSON behind Google's XSSI guard — a `)]}'` line that exists
+     * to make the response invalid JavaScript — so it is trimmed before parsing
+     * rather than being handed to the JSON reader as-is.
+     */
+    suspend fun accountSwitcher(): JsonObject {
+        requireSession()
+        val session = scope
+        val text = withRetry {
+            client.get("$YOUTUBE_ORIGIN/getAccountSwitcherEndpoint") {
+                header("User-Agent", WEB_USER_AGENT)
+                header("Accept-Language", "en-US,en;q=0.9")
+                header("X-Origin", YOUTUBE_ORIGIN)
+                header("Referer", "$YOUTUBE_ORIGIN/")
+                cookie?.let { c ->
+                    header("Cookie", c)
+                    header("X-Goog-AuthUser", authUserFor(session))
+                    sapisidFrom(c)?.let {
+                        header("Authorization", sapisidHash(it, YOUTUBE_ORIGIN))
+                    }
+                }
+            }.bodyAsText()
+        }
+        val body = text.substringAfter(")]}'", text).trim()
+        return json.parseToJsonElement(body).jsonObject
+    }
 
     /**
      * The watch queue that YouTube Music would play after [videoId] — the
@@ -699,8 +857,8 @@ object Innertube {
         visitorData?.let { header("X-Goog-Visitor-Id", it) }
         cookie?.let { c ->
             header("Cookie", c)
-            header("X-Goog-AuthUser", scope?.authUser ?: "0")
-            scope?.pageId?.let { header("X-Goog-PageId", it) }
+            header("X-Goog-AuthUser", authUserFor(scope))
+            pageIdFor(scope)?.let { header("X-Goog-PageId", it) }
             sapisidFrom(c)?.let { header("Authorization", sapisidHash(it)) }
         }
     }
@@ -943,8 +1101,8 @@ object Innertube {
                     // Which account in the jar, and which brand channel of it.
                     // Both were fixed at "the first one" before — see
                     // [SessionScope].
-                    header("X-Goog-AuthUser", session?.authUser ?: "0")
-                    session?.pageId?.let { header("X-Goog-PageId", it) }
+                    header("X-Goog-AuthUser", authUserFor(session))
+                    pageIdFor(session)?.let { header("X-Goog-PageId", it) }
                     sapisidFrom(c)?.let { header("Authorization", sapisidHash(it)) }
                 }
                 setBody(
@@ -964,7 +1122,7 @@ object Innertube {
                                 // `onBehalfOfUser` it cannot tie to the cookie
                                 // with 401, so a guess here would take the
                                 // whole app down rather than just history.
-                                session?.dataSyncId?.let { put("onBehalfOfUser", it) }
+                                dataSyncIdFor(session)?.let { put("onBehalfOfUser", it) }
                             }
                             putJsonObject("request") { put("useSsl", true) }
                         }
@@ -1040,8 +1198,8 @@ object Innertube {
             if (authenticated) {
                 cookie?.let { c ->
                     header("Cookie", c)
-                    header("X-Goog-AuthUser", scope?.authUser ?: "0")
-                    scope?.pageId?.let { header("X-Goog-PageId", it) }
+                    header("X-Goog-AuthUser", authUserFor(scope))
+                    pageIdFor(scope)?.let { header("X-Goog-PageId", it) }
                     // Hashed against the host this request is actually going
                     // to, not against music.youtube.com unconditionally. Google
                     // recomputes the digest over the origin it sees and rejects

--- a/app/src/main/java/com/music/bitchord/data/innertube/InnertubeParser.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/InnertubeParser.kt
@@ -1,6 +1,7 @@
 package com.music.bitchord.data.innertube
 
 import com.music.bitchord.data.model.Account
+import com.music.bitchord.data.model.AccountChannel
 import com.music.bitchord.data.model.ArtistPage
 import com.music.bitchord.data.model.BrowseItem
 import com.music.bitchord.data.model.BrowseType
@@ -689,6 +690,49 @@ object InnertubeParser {
         )
     }
 
+    /**
+     * The channels a switcher response offers, in the order YouTube lists them.
+     *
+     * Read by scanning for `accountItem` rather than by walking a fixed path:
+     * the two endpoints that produce this list ([Innertube.accountsList] and
+     * [Innertube.accountSwitcher]) wrap the same item renderer in different
+     * envelopes, and the wrapper is not the part worth agreeing on.
+     *
+     * The two tokens are likewise found by name anywhere inside the item. They
+     * arrive as a list of single-key objects under `supportedTokens`, in no
+     * promised order and alongside tokens meant for other purposes, so a
+     * positional read of that list would be a guess about a structure Google
+     * never said was ordered.
+     *
+     * An entry with neither token is dropped. There would be nothing to send
+     * for it, and offering a channel that silently keeps the current one is
+     * worse than not listing it.
+     */
+    fun parseAccountChannels(root: JsonElement): List<AccountChannel> =
+        collectRenderers(root, "accountItem").mapNotNull { item ->
+            val name = item.o("accountName").runs()
+                .ifBlank { item.o("accountName").s("simpleText").orEmpty() }
+            if (name.isBlank()) return@mapNotNull null
+            val pageId = item.findString("pageId")
+            // `<accountSyncId>||<sessionSyncId>`; only the first half names the
+            // account, exactly as in the shell's own DATASYNC_ID.
+            val dataSyncId = item.findString("datasyncIdToken")
+                ?.substringBefore("||")
+                ?.takeIf { it.isNotBlank() }
+            if (pageId == null && dataSyncId == null) return@mapNotNull null
+            AccountChannel(
+                name = name,
+                subtitle = item.o("channelHandle").runs()
+                    .ifBlank { item.o("channelHandle").s("simpleText").orEmpty() }
+                    .ifBlank { item.o("accountByline").runs() }
+                    .ifBlank { item.o("accountByline").s("simpleText").orEmpty() },
+                thumbnailUrl = item.o("accountPhoto").a("thumbnails").best(),
+                pageId = pageId,
+                dataSyncId = dataSyncId,
+                activeOnWeb = (item["isSelected"] as? JsonPrimitive)?.content == "true",
+            )
+        }.distinctBy { it.key }
+
     /** Tracks of a watch queue (`next` response) — the AutoPlay radio mix. */
     fun parseWatchQueue(root: JsonElement): List<Song> {
         val out = LinkedHashMap<String, Song>()
@@ -1035,6 +1079,19 @@ private fun JsonElement?.a(key: String): JsonArray? =
 
 private fun JsonElement?.s(key: String): String? =
     ((this as? JsonObject)?.get(key) as? JsonPrimitive)?.contentOrNull
+
+/**
+ * The first string under [key] anywhere in the subtree, by name rather than by
+ * path — for a value whose position is not promised. See [InnertubeParser.parseAccountChannels].
+ */
+private fun JsonElement?.findString(key: String): String? = when (this) {
+    is JsonObject -> {
+        (this[key] as? JsonPrimitive)?.contentOrNull
+            ?: values.firstNotNullOfOrNull { it.findString(key) }
+    }
+    is JsonArray -> firstNotNullOfOrNull { it.findString(key) }
+    else -> null
+}
 
 private fun JsonElement?.runs(): String =
     this.a("runs")?.joinToString("") { it.s("text").orEmpty() }.orEmpty()

--- a/app/src/main/java/com/music/bitchord/data/model/Models.kt
+++ b/app/src/main/java/com/music/bitchord/data/model/Models.kt
@@ -161,6 +161,36 @@ data class Account(
     val thumbnailUrl: String?,
 )
 
+/**
+ * One identity the signed-in session can act as: the Google account's own
+ * channel, plus any brand channel it owns.
+ *
+ * A brand channel is a separate YouTube identity attached to the same login,
+ * and YouTube Music treats it as a separate listener — its own library, likes,
+ * history and recommendations. Nothing in the cookie says which one is meant,
+ * so a client that never asks gets whichever one the web player happens to
+ * default to, which is why a listener whose music lives on a brand channel
+ * signs in and is shown a stranger's account.
+ *
+ * @param pageId `X-Goog-PageId`. Null for the account's own channel, which is
+ *   not a delegated page and must not be given one.
+ * @param dataSyncId `context.user.onBehalfOfUser`, taken from the switcher's
+ *   `datasyncIdToken` — never guessed, since Google answers one it cannot tie
+ *   to the session with 401.
+ */
+data class AccountChannel(
+    val name: String,
+    val subtitle: String,
+    val thumbnailUrl: String?,
+    val pageId: String?,
+    val dataSyncId: String?,
+    /** Whether YouTube's own switcher marks this as the session's active one. */
+    val activeOnWeb: Boolean,
+) {
+    /** Identity of the selection, stable across refetches of the list. */
+    val key: String get() = pageId ?: dataSyncId ?: name
+}
+
 data class HomeShelf(
     val title: String,
     val items: List<ShelfItem>,

--- a/app/src/main/java/com/music/bitchord/ui/MainViewModel.kt
+++ b/app/src/main/java/com/music/bitchord/ui/MainViewModel.kt
@@ -16,7 +16,10 @@ import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.innertube.Innertube
 import com.music.bitchord.data.innertube.PlaybackTracker
 import com.music.bitchord.data.innertube.StreamResolver
+import com.music.bitchord.auth.CapturedSession
+import com.music.bitchord.auth.WebSessionMode
 import com.music.bitchord.data.model.Account
+import com.music.bitchord.data.model.AccountChannel
 import com.music.bitchord.data.model.BrowseType
 import com.music.bitchord.data.model.DetailPage
 import com.music.bitchord.data.model.HomeShelf
@@ -252,6 +255,29 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _account = MutableStateFlow<Account?>(null)
     val account: StateFlow<Account?> = _account.asStateFlow()
+
+    /**
+     * The channels this login can act as. Empty until the picker asks for
+     * them — it is one more request per sign-in and nothing else on the
+     * settings page needs the answer.
+     */
+    private val _channels = MutableStateFlow<List<AccountChannel>>(emptyList())
+    val channels: StateFlow<List<AccountChannel>> = _channels.asStateFlow()
+
+    private val _channelsLoading = MutableStateFlow(false)
+    val channelsLoading: StateFlow<Boolean> = _channelsLoading.asStateFlow()
+
+    /**
+     * The chosen channel's [AccountChannel.key], or null while the app is
+     * acting as whichever channel YouTube Music serves by default.
+     */
+    private val _selectedChannelKey = MutableStateFlow(
+        authStore.channelPageId ?: authStore.channelDataSyncId,
+    )
+    val selectedChannelKey: StateFlow<String?> = _selectedChannelKey.asStateFlow()
+
+    private val _selectedChannelName = MutableStateFlow(authStore.channelName)
+    val selectedChannelName: StateFlow<String?> = _selectedChannelName.asStateFlow()
 
     private val _history = MutableStateFlow<UiState<List<Song>>>(UiState.Loading)
     val history: StateFlow<UiState<List<Song>>> = _history.asStateFlow()
@@ -930,7 +956,16 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
     private fun loadAccount() {
         viewModelScope.launch {
-            _account.value = YtMusicRepository.account().getOrNull()
+            val account = YtMusicRepository.account().getOrNull()
+            _account.value = account
+            // A channel picked in the in-app browser arrives as ids and nothing
+            // else — the page's `ytcfg` never says what the channel is called.
+            // The account menu, asked *as* that channel, answers with its name,
+            // which is what the settings row needs to show.
+            if (account != null && _selectedChannelKey.value != null) {
+                _selectedChannelName.value = account.name
+                authStore.setChannelName(account.name)
+            }
         }
     }
 
@@ -1738,21 +1773,131 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
         return true
     }
 
-    fun onSignedIn(cookie: String) {
-        authStore.cookie = cookie
-        Innertube.cookie = cookie
-        // Every "this track can't be played" the resolver recorded while there
-        // was no session was recorded under different rules. An age-gated track
-        // is the whole point of signing in, and it is the one verdict a session
-        // overturns — so a listener who signs in to play a track must not spend
-        // the next ten minutes being told it still cannot be played.
+    /**
+     * Loads the channel list, unless it is already in hand.
+     *
+     * @param force refetch even if it is — after a switch, since the list
+     *   itself reports which channel is active.
+     */
+    fun loadChannels(force: Boolean = false) {
+        if (!_signedIn.value) return
+        if (_channelsLoading.value) return
+        if (!force && _channels.value.isNotEmpty()) return
+        viewModelScope.launch {
+            _channelsLoading.value = true
+            YtMusicRepository.accountChannels()
+                .onSuccess { _channels.value = it }
+            _channelsLoading.value = false
+        }
+    }
+
+    /**
+     * Acts as [channel] from here on.
+     *
+     * Everything already on screen belongs to the channel being left — its
+     * library, its hearts, its playlists — so the switch clears them and
+     * refetches rather than letting the new identity's pages arrive one at a
+     * time on top of the old one's.
+     */
+    fun selectChannel(channel: AccountChannel) {
+        if (channel.key == _selectedChannelKey.value) return
+        authStore.selectChannel(channel.pageId, channel.dataSyncId, channel.name)
+        Innertube.selectChannel(channel.pageId, channel.dataSyncId)
+        _selectedChannelKey.value = channel.key
+        _selectedChannelName.value = channel.name
+        clearListenerState()
+        reloadForAccount()
+        loadChannels(force = true)
+    }
+
+    /**
+     * A session lifted out of the in-app browser — a fresh sign-in, or the same
+     * login now pointed at a different channel.
+     *
+     * One path for both because they differ in exactly one thing: whether the
+     * cookie is new. What follows — adopt the identity the captured page
+     * reported, remember it, and refetch everything that belongs to a listener
+     * — is the same work either way.
+     */
+    fun onWebSession(session: CapturedSession, mode: WebSessionMode) {
+        val fresh = mode == WebSessionMode.SIGN_IN || session.cookie != authStore.cookie
+        if (fresh) {
+            // Clears any channel chosen under the previous login, which named
+            // an identity this cookie cannot act as.
+            authStore.onNewSession(session.cookie)
+            _channels.value = emptyList()
+        } else {
+            authStore.cookie = session.cookie
+        }
+        // Assigned before the scope is adopted, never after: setting a cookie
+        // that differs from the last one clears the scope and the channel with
+        // it, which would throw away the identity just captured.
+        Innertube.cookie = session.cookie
+        Innertube.adoptSessionScope(
+            pageId = session.pageId,
+            dataSyncId = session.dataSyncId,
+            authUser = session.authUser,
+            visitorData = session.visitorData,
+            clientVersion = session.clientVersion,
+            loggedIn = session.loggedIn,
+        )
+
+        if (session.loggedIn && (session.pageId != null || session.dataSyncId != null)) {
+            // Persisted so the choice survives a restart: the shell fetched on
+            // the next launch reports the default channel, and without this the
+            // app would quietly drift back to it.
+            authStore.selectChannel(
+                pageId = session.pageId,
+                dataSyncId = session.dataSyncId,
+                // Named by the account fetch below, which is the only thing
+                // that knows what the channel is called.
+                name = if (fresh) null else authStore.channelName,
+                authUser = session.authUser,
+            )
+            Innertube.selectChannel(session.pageId, session.dataSyncId, session.authUser)
+            _selectedChannelKey.value = session.pageId ?: session.dataSyncId
+            if (fresh) _selectedChannelName.value = null
+        }
+
+        // Every "this track can't be played" the resolver recorded under the
+        // previous session was reached under different rules. An age-gated
+        // track is the whole point of signing in, and it is the one verdict a
+        // session overturns — so a listener who signs in to play a track must
+        // not spend the next ten minutes being told it still cannot be played.
         StreamResolver.onSessionChanged()
+        val wasSignedIn = _signedIn.value
         _signedIn.value = true
-        // Before the reloads below, and the reason they are inside a coroutine
-        // now: which of the cookie's accounts was just signed into decides what
-        // "the library" and "the history" even refer to. Loading them first and
-        // scoping second shows the listener the wrong account's music and then
-        // silently disagrees with itself.
+        if (fresh || wasSignedIn) clearListenerState()
+        reloadForAccount()
+    }
+
+    /**
+     * Drops everything on screen that belongs to the identity being left.
+     *
+     * The hearts, the playlists and the library are all answers to "who is
+     * asking", so keeping them across a switch shows the new channel the old
+     * one's music until each page happens to be refetched.
+     */
+    private fun clearListenerState() {
+        LikeState.clear()
+        _playlists.value = emptyList()
+        _playlistOwned.value = emptyMap()
+        ownershipInFlight.clear()
+        _songMenu.value = null
+        _library.value = UiState.Loading
+        _history.value = UiState.Loading
+    }
+
+    /**
+     * Everything that is "the signed-in listener's", refetched.
+     *
+     * The scope comes first, and inside one coroutine rather than beside them:
+     * which channel the session acts as decides what "the library" and "the
+     * history" even refer to, so loading them first and scoping second shows
+     * the listener the wrong account's music and then silently disagrees with
+     * itself.
+     */
+    private fun reloadForAccount() {
         viewModelScope.launch {
             Innertube.ensureSessionScope()
             loadHome()
@@ -1771,6 +1916,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
         StreamResolver.onSessionChanged()
         _signedIn.value = false
         _account.value = null
+        Innertube.selectChannel(null, null)
+        _channels.value = emptyList()
+        _selectedChannelKey.value = null
+        _selectedChannelName.value = null
         _library.value = UiState.Loading
         // Ratings and playlists belong to the account that just left; keeping
         // them would show the next signed-in user someone else's hearts.

--- a/app/src/main/java/com/music/bitchord/ui/components/AccountChannelDialog.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/AccountChannelDialog.kt
@@ -1,0 +1,256 @@
+package com.music.bitchord.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.music.bitchord.data.model.AccountChannel
+import com.music.bitchord.data.settings.AppSettings
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
+
+/**
+ * Which channel to listen as — the Google account's own, or one of its brand
+ * channels.
+ *
+ * Same frosted alert as [AppLanguageDialog], and single-select for the same
+ * reason: there is one active identity, so a tap applies it and closes rather
+ * than waiting on a Done.
+ *
+ * The selected row is the app's own choice, not YouTube's. A channel YouTube's
+ * switcher reports as active is labelled as such but never ticked, because the
+ * tick answers "which one is this app acting as", and before a choice is made
+ * that is decided by the shell rather than by the listener.
+ */
+@OptIn(ExperimentalHazeMaterialsApi::class)
+@Composable
+fun AccountChannelDialog(
+    channels: List<AccountChannel>,
+    loading: Boolean,
+    selectedKey: String?,
+    hazeState: HazeState,
+    onSelect: (AccountChannel) -> Unit,
+    onChooseInYouTube: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
+    val shape = RoundedCornerShape(ALERT_CORNER)
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(SCRIM_COLOR)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = onDismiss,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .width(ALERT_WIDTH)
+                .clip(shape)
+                .then(
+                    if (reduceDynamicBlur) {
+                        Modifier.background(MaterialTheme.colorScheme.surface)
+                    } else {
+                        Modifier.hazeEffect(
+                            state = hazeState,
+                            style = HazeMaterials.regular(MaterialTheme.colorScheme.surface),
+                        )
+                    },
+                )
+                // Swallows the tap before it reaches the scrim behind, so
+                // touching the card itself never dismisses it.
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = {},
+                ),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 19.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = "Listen as",
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.W600,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = when {
+                        loading && channels.isEmpty() -> "Looking up your channels…"
+                        channels.isEmpty() ->
+                            "Couldn't list this account's channels. You can still pick " +
+                                "one in YouTube Music itself."
+                        else ->
+                            "Your library, likes and history come from the channel " +
+                                "you pick here."
+                    },
+                    modifier = Modifier.padding(top = 4.dp),
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontSize = 13.sp,
+                        lineHeight = 17.sp,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+                if (loading && channels.isEmpty()) {
+                    Spacer(Modifier.padding(top = 12.dp))
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(22.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+
+            channels.forEach { channel ->
+                AlertRule()
+                ChannelRow(
+                    channel = channel,
+                    selected = channel.key == selectedKey,
+                    onClick = {
+                        onSelect(channel)
+                        onDismiss()
+                    },
+                )
+            }
+
+            AlertRule()
+            // The route that cannot be wrong about what exists. YouTube's own
+            // Accounts list is the authority on which channels this login has,
+            // and picking there means the session is read from a page already
+            // showing the chosen channel rather than assembled from ids.
+            AlertAction(
+                label = "Choose in YouTube Music",
+                emphasised = channels.isEmpty(),
+                onClick = onChooseInYouTube,
+            )
+            AlertRule()
+            AlertAction(label = "Close", emphasised = false, onClick = onDismiss)
+        }
+    }
+}
+
+@Composable
+private fun ChannelRow(channel: AccountChannel, selected: Boolean, onClick: () -> Unit) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = ACTION_HEIGHT)
+            .background(
+                if (pressed) MaterialTheme.colorScheme.onSurface.copy(alpha = 0.09f) else Color.Transparent,
+            )
+            .clickable(
+                indication = null,
+                interactionSource = interactionSource,
+                onClick = onClick,
+            )
+            .padding(horizontal = 16.dp, vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (channel.thumbnailUrl != null) {
+            AsyncImage(
+                model = channel.thumbnailUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .thumbnailBorder(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Rounded.Person,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(17.dp),
+                )
+            }
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = channel.name,
+                style = MaterialTheme.typography.bodyLarge.copy(fontSize = 15.sp),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            // The handle when there is one; otherwise what kind of channel it
+            // is, which is the part a listener with two of them is choosing by.
+            val subtitle = channel.subtitle.ifBlank {
+                if (channel.pageId != null) "Brand channel" else "Your channel"
+            }
+            Text(
+                text = if (channel.activeOnWeb) "$subtitle · default" else subtitle,
+                style = MaterialTheme.typography.bodyMedium.copy(fontSize = 12.sp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (selected) {
+            Spacer(Modifier.width(8.dp))
+            Icon(
+                imageVector = Icons.Rounded.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(19.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/music/bitchord/ui/screens/AccountAndScrobblingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/AccountAndScrobblingScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Cloud
 import androidx.compose.material.icons.rounded.GraphicEq
 import androidx.compose.material.icons.rounded.History
+import androidx.compose.material.icons.rounded.SwitchAccount
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
@@ -33,7 +34,9 @@ import kotlin.math.roundToInt
 fun AccountAndScrobblingScreen(
     signedIn: Boolean,
     account: Account?,
+    channelName: String?,
     onSignIn: () -> Unit,
+    onSwitchChannel: () -> Unit,
     onSignOut: () -> Unit,
     onOpenListenBrainzLogin: () -> Unit,
     onOpenLastfmLogin: () -> Unit,
@@ -71,6 +74,19 @@ fun AccountAndScrobblingScreen(
         AccountCard(signedIn = signedIn, account = account, onSignIn = onSignIn)
 
         if (signedIn) {
+            SettingsGroup(
+                footer = "A Google account can own brand channels, and each one is a " +
+                    "separate YouTube Music listener with its own library, likes and " +
+                    "history. Pick the one your music is on.",
+            ) {
+                SettingsRow(
+                    icon = Icons.Rounded.SwitchAccount,
+                    title = "Listen as",
+                    subtitle = channelName ?: "YouTube Music's default channel",
+                    onClick = onSwitchChannel,
+                )
+            }
+
             SettingsGroup {
                 DestructiveRow(label = "Sign out", onClick = onSignOut)
             }

--- a/app/src/test/java/com/music/bitchord/AccountChannelTest.kt
+++ b/app/src/test/java/com/music/bitchord/AccountChannelTest.kt
@@ -1,0 +1,127 @@
+package com.music.bitchord
+
+import com.music.bitchord.data.innertube.InnertubeParser
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Reading the channels a login can act as out of an account-switcher response.
+ *
+ * Pinned because the two things each row must yield — the `pageId` header and
+ * the `datasyncIdToken` body value — arrive as single-key objects in a list
+ * Google never promised an order for, alongside tokens meant for other
+ * purposes. A positional read of that list works right up until Google adds a
+ * token, and then it silently switches the listener to a channel that isn't
+ * the one they tapped.
+ *
+ * The fixtures are trimmed copies of the shape both `account/accounts_list`
+ * and `getAccountSwitcherEndpoint` return: the same `accountItem` renderer in
+ * different envelopes, which is why the parser scans for the item rather than
+ * walking a path to it.
+ */
+class AccountChannelTest {
+
+    private fun parse(json: String) =
+        InnertubeParser.parseAccountChannels(Json.parseToJsonElement(json))
+
+    @Test
+    fun `personal channel and brand channel are both read`() {
+        val channels = parse(SWITCHER)
+
+        assertEquals(2, channels.size)
+
+        val personal = channels[0]
+        assertEquals("Ada Lovelace", personal.name)
+        assertEquals("@ada", personal.subtitle)
+        // Not a delegated page, and must not be given one — a `X-Goog-PageId`
+        // on the account's own channel is a different request entirely.
+        assertNull(personal.pageId)
+        assertEquals("SYNC_PERSONAL", personal.dataSyncId)
+        assertTrue(personal.activeOnWeb)
+
+        val brand = channels[1]
+        assertEquals("Analytical Engine Radio", brand.name)
+        assertEquals("113355", brand.pageId)
+        assertEquals("SYNC_BRAND", brand.dataSyncId)
+        assertEquals(false, brand.activeOnWeb)
+    }
+
+    @Test
+    fun `token order is not assumed`() {
+        // Same brand channel, tokens listed the other way round and with an
+        // unrelated one in front of both.
+        val channels = parse(SHUFFLED_TOKENS)
+        assertEquals(1, channels.size)
+        assertEquals("113355", channels[0].pageId)
+        assertEquals("SYNC_BRAND", channels[0].dataSyncId)
+    }
+
+    @Test
+    fun `only the account half of the datasync id is kept`() {
+        // `<accountSyncId>||<sessionSyncId>` — the second half changes on its
+        // own schedule and names the session, not the account.
+        assertEquals("SYNC_BRAND", parse(SHUFFLED_TOKENS)[0].dataSyncId)
+    }
+
+    @Test
+    fun `an entry with nothing to send is dropped`() {
+        // Offering a channel that would quietly leave the current one selected
+        // is worse than not listing it.
+        assertTrue(parse(NO_TOKENS).isEmpty())
+    }
+
+    @Test
+    fun `an unrecognised envelope yields nothing rather than throwing`() {
+        assertTrue(parse("""{"responseContext":{},"contents":{}}""").isEmpty())
+    }
+
+    private companion object {
+        const val SWITCHER = """
+        {"data":{"actions":[{"getMultiPageMenuAction":{"menu":{"multiPageMenuRenderer":{
+          "sections":[{"accountSectionListRenderer":{"contents":[{"accountItemSectionRenderer":{
+            "contents":[
+              {"accountItem":{
+                "accountName":{"simpleText":"Ada Lovelace"},
+                "accountPhoto":{"thumbnails":[{"url":"https://x/s40","width":40}]},
+                "isSelected":true,
+                "channelHandle":{"simpleText":"@ada"},
+                "serviceEndpoint":{"selectActiveIdentityEndpoint":{"supportedTokens":[
+                  {"accountSigninToken":{"signinUrl":"https://accounts.google.com/x"}},
+                  {"datasyncIdToken":{"datasyncIdToken":"SYNC_PERSONAL||SESSION_A"}}
+                ]}}
+              }},
+              {"accountItem":{
+                "accountName":{"runs":[{"text":"Analytical Engine Radio"}]},
+                "accountPhoto":{"thumbnails":[{"url":"https://y/s40","width":40}]},
+                "isSelected":false,
+                "accountByline":{"simpleText":"Brand account"},
+                "serviceEndpoint":{"selectActiveIdentityEndpoint":{"supportedTokens":[
+                  {"pageIdToken":{"pageId":"113355"}},
+                  {"datasyncIdToken":{"datasyncIdToken":"SYNC_BRAND||SESSION_B"}}
+                ]}}
+              }}
+            ]}}]}}]}}}}]}}
+        """
+
+        const val SHUFFLED_TOKENS = """
+        {"contents":[{"accountItem":{
+          "accountName":{"simpleText":"Analytical Engine Radio"},
+          "serviceEndpoint":{"selectActiveIdentityEndpoint":{"supportedTokens":[
+            {"offlineCacheKeyToken":{"clientCacheKey":"CACHE"}},
+            {"datasyncIdToken":{"datasyncIdToken":"SYNC_BRAND||SESSION_B"}},
+            {"pageIdToken":{"pageId":"113355"}}
+          ]}}
+        }}]}
+        """
+
+        const val NO_TOKENS = """
+        {"contents":[{"accountItem":{
+          "accountName":{"simpleText":"Ada Lovelace"},
+          "serviceEndpoint":{"signalServiceEndpoint":{"signal":"CLIENT_SIGNAL"}}
+        }}]}
+        """
+    }
+}


### PR DESCRIPTION
A Google account can own brand channels, and YouTube Music treats each one as a separate listener — its own library, likes, history and recommendations. BitChord had no way to say which one it meant: the session scope is scraped from music.youtube.com's shell at sign-in, so it always acts as whichever channel the web player serves by default. If your music lives on a brand channel (the account YouTube Music pushes you onto when you have one), signing in shows a stranger's library and writes history to the wrong identity.

The request plumbing already existed — `X-Goog-PageId` and `context.user.onBehalfOfUser`, from when history was fixed. What was missing was any way to choose what fills it.

## Two ways to pick a channel

**Settings → Account & integrations → "Listen as"** lists the channels the login can act as, from `account/accounts_list`, falling back to youtube.com's own `getAccountSwitcherEndpoint`. Either envelope can come back in a shape the parser doesn't recognise and the two don't fail together, so an empty list from one is treated as a failure rather than an answer.

**"Choose in YouTube Music"** opens the in-app browser on music.youtube.com so the avatar menu's own Accounts list can be used, and reads the session out of the page's `ytcfg` when you tap **Use this channel**. That page already knows which channel it's showing, so nothing is guessed and nothing is fetched again afterwards to be told the default. Nothing is captured automatically in that mode — arriving on music.youtube.com is where you start, not where you're done.

The choice is persisted next to the cookie, restored at launch, and cleared on sign-out or a new login: a `dataSyncId` from one session replayed under another is answered with 401 on every request. It applies to browse, library, playlist writes and the stats pings that write history, so a play lands on the channel that made it.

## Signing out now actually signs out

The WebView keeps its own cookie jar, separate from the one requests are signed with, and sign-out only forgot the app's copy. The next sign-in was recognised at accounts.google.com, redirected straight through and handed back the same account — a sign-in screen that couldn't be used to sign in as anyone else, and showed barely a flicker while refusing to. Sign-out and the sign-in flow now expire the browser's Google cookies, by name and by domain, so the Discord and Last.fm logins in the same jar are left alone.

## Testing

`AccountChannelTest` covers parsing the switcher response — the two tokens each row must yield arrive in a `supportedTokens` list whose order Google has never promised, so a positional read works right up until a token is added and then silently switches you to a channel you didn't tap. Fixtures cover both envelopes, reordered tokens, entries with no usable token, and an unrecognised response.

Verified on device against an account with several brand channels: switching moves the library, likes and history to the chosen channel, and the choice survives a restart.
