### PR TITLE
feat: add lyrics blur toggle

### DIFF
--- a/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
@@ -193,6 +193,9 @@ object AppSettings {
     /** Drops haze blur (status bar, mini player, bottom fade, lyrics focus) for a solid-fill look. */
     val reduceDynamicBlur = MutableStateFlow(false)
 
+    /** Blurs unfocused lyric lines, keeping the active line sharp. */
+    val lyricsBlur = MutableStateFlow(true)
+
     /**
      * Plays a looping video behind the cover art on the player when one is
      * published for the track — Spotify's Canvas, Apple's motion artwork.
@@ -459,6 +462,7 @@ object AppSettings {
         dontRepeatSuggestions.value = prefs.getBoolean(KEY_DONT_REPEAT_SUGGESTIONS, false)
         convertVideoToAudio.value = prefs.getBoolean(KEY_CONVERT_VIDEO_TO_AUDIO, true)
         reduceDynamicBlur.value = prefs.getBoolean(KEY_REDUCE_BLUR, false)
+        lyricsBlur.value = prefs.getBoolean(KEY_LYRICS_BLUR, true)
         animatedCanvas.value = prefs.getBoolean(KEY_ANIMATED_CANVAS, true)
         canvasOverCellular.value = prefs.getBoolean(KEY_CANVAS_OVER_CELLULAR, false)
         fullBleedArtwork.value = prefs.getBoolean(KEY_FULL_BLEED_ARTWORK, true)
@@ -690,6 +694,11 @@ object AppSettings {
     fun setReduceDynamicBlur(value: Boolean) {
         reduceDynamicBlur.value = value
         prefs.edit().putBoolean(KEY_REDUCE_BLUR, value).apply()
+    }
+
+    fun setLyricsBlur(value: Boolean) {
+        lyricsBlur.value = value
+        prefs.edit().putBoolean(KEY_LYRICS_BLUR, value).apply()
     }
 
     fun setSyncedLyrics(value: Boolean) {
@@ -1065,6 +1074,7 @@ object AppSettings {
     private const val KEY_DONT_REPEAT_SUGGESTIONS = "dont_repeat_suggestions"
     private const val KEY_CONVERT_VIDEO_TO_AUDIO = "convert_video_to_audio"
     private const val KEY_REDUCE_BLUR = "reduce_dynamic_blur"
+    private const val KEY_LYRICS_BLUR = "lyrics_blur"
     private const val KEY_ANIMATED_CANVAS = "animated_canvas"
     private const val KEY_CANVAS_OVER_CELLULAR = "canvas_over_cellular"
     private const val KEY_FULL_BLEED_ARTWORK = "full_bleed_artwork"

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -2530,6 +2530,7 @@ private fun LyricsPanel(
     val keepScroll = remember(listState) { keepScrollInList(listState) }
     var browsing by remember { mutableStateOf(false) }
     val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
+    val lyricsBlur by AppSettings.lyricsBlur.collectAsStateWithLifecycle()
     val reduceAnimation by AppSettings.reduceAnimation.collectAsStateWithLifecycle()
 
     // The bloom is a blurred copy of the line, so it is off wherever blur is:
@@ -2539,7 +2540,7 @@ private fun LyricsPanel(
     // switch for exactly this kind of flourish, and reduce dynamic blur
     // because adding a blur under a setting that says it drops them would be
     // the app disagreeing with itself.
-    val glowing = !reduceAnimation && !reduceDynamicBlur &&
+    val glowing = !reduceAnimation && !reduceDynamicBlur && lyricsBlur &&
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
 
     // Only a finger on the list counts as browsing — watching
@@ -2645,6 +2646,13 @@ private fun LyricsPanel(
             val offset = if (activeLine < 0) 0 else index - activeLine
             val distance = abs(offset)
             val isActive = index == activeLine || index == alsoActive
+            val blur by animateDpAsState(
+                targetValue = when {
+                    reduceDynamicBlur || !lyricsBlur || browsing || isActive -> 0.dp
+                    else -> (distance * 1.6f).coerceAtMost(7f).dp
+                },
+                label = "lyricBlur",
+            )
             // Lines already sung stay close to legible — they're what the eye
             // just read and glances back to. Lines still to come fade faster
             // and further, so the panel reads as an arrival rather than a wall
@@ -2668,6 +2676,7 @@ private fun LyricsPanel(
                     contentDescription = "Instrumental",
                     tint = Color.White.copy(alpha = lineAlpha),
                     modifier = Modifier
+                        .blur(blur, BlurredEdgeTreatment.Unbounded)
                         .clip(RoundedCornerShape(10.dp))
                         .clickable { onSeekToLine(line.timeMs) }
                         // Matches the inset every sung line carries, so the
@@ -2703,6 +2712,7 @@ private fun LyricsPanel(
                         transformOrigin = TransformOrigin(0f, 0.5f)
                         alpha = lineAlpha
                     }
+                    .blur(blur, BlurredEdgeTreatment.Unbounded)
                     .clip(RoundedCornerShape(10.dp))
                     .clickable { onSeekToLine(line.timeMs) }
                 // Lead and answering vocal are one row: they are one line of

--- a/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
@@ -578,7 +578,7 @@ fun SettingsScreen(
             SettingsRow(
                 icon = Icons.Rounded.BlurOn,
                 title = "Blur unfocused lyrics",
-                subtitle = "Highlights the line being sung",
+                subtitle = "Keeps the spotlight on the current line",
                     trailing = {
                         Switch(
                             checked = lyricsBlur,

--- a/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.rounded.Animation
 import androidx.compose.material.icons.rounded.BarChart
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.BlurOff
+import androidx.compose.material.icons.rounded.BlurOn
 import androidx.compose.material.icons.rounded.Brightness4
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ChevronRight
@@ -160,6 +161,7 @@ fun SettingsScreen(
     val nerdStats by AppSettings.showNerdStats.collectAsStateWithLifecycle()
     val reduceAnimation by AppSettings.reduceAnimation.collectAsStateWithLifecycle()
     val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
+    val lyricsBlur by AppSettings.lyricsBlur.collectAsStateWithLifecycle()
     val animatedCanvas by AppSettings.animatedCanvas.collectAsStateWithLifecycle()
     val canvasOverCellular by AppSettings.canvasOverCellular.collectAsStateWithLifecycle()
     val fullBleedArtwork by AppSettings.fullBleedArtwork.collectAsStateWithLifecycle()
@@ -572,6 +574,23 @@ fun SettingsScreen(
             // sources are third-party services being reached on the user's
             // connection — which is the part worth being able to narrow.
             if (syncedLyrics) {
+                RowDivider()
+            SettingsRow(
+                icon = Icons.Rounded.BlurOn,
+                title = "Blur unfocused lyrics",
+                subtitle = "Highlights the line being sung",
+                    trailing = {
+                        Switch(
+                            checked = lyricsBlur,
+                            onCheckedChange = AppSettings::setLyricsBlur,
+                            colors = SwitchDefaults.colors(
+                                checkedTrackColor = MaterialTheme.colorScheme.primary,
+                                checkedBorderColor = MaterialTheme.colorScheme.primary,
+                            ),
+                        )
+                    },
+                    onClick = { AppSettings.setLyricsBlur(!lyricsBlur) },
+                )
                 RowDivider()
                 SettingsRow(
                     icon = Icons.Rounded.Language,


### PR DESCRIPTION
Bring back the unfocused lyrics blur from v1.4 as a dedicated setting. Blur now respects both the global Reduce dynamic blur and the new per-feature toggle, with a switch in Settings under Synced lyrics.