### PR TITLE
Fix paged YouTube Music result feeds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,20 +17,26 @@ jobs:
         distribution: 'temurin'
         cache: gradle
 
-    - name: Setup local.properties from Secrets
+    - name: Setup Secrets (Keystore & local.properties)
       run: |
         echo "MODULE_INDEX_URL=${{ secrets.MODULE_INDEX_URL }}" > local.properties
         echo "LASTFM_API_KEY=${{ secrets.LASTFM_API_KEY }}" >> local.properties
         echo "LASTFM_SECRET=${{ secrets.LASTFM_SECRET }}" >> local.properties
+        
+        echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > bitchord-release.jks
+        echo "storeFile=bitchord-release.jks" > keystore.properties
+        echo "storePassword=${{ secrets.KEYSTORE_PASSWORD }}" >> keystore.properties
+        echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> keystore.properties
+        echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> keystore.properties
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build Prod Release APK
+    - name: Build Signed Prod Release APK
       run: ./gradlew assembleProdRelease
 
     - name: Upload APK Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: bitchord-prod-release-unsigned
-        path: app/build/outputs/apk/prod/release/app-prod-release-unsigned.apk
+        name: bitchord-prod-release-signed
+        path: app/build/outputs/apk/prod/release/app-prod-release.apk

--- a/app/src/dev/AndroidManifest.xml
+++ b/app/src/dev/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:label="BitChord Dev"
+        tools:replace="android:label" />
+</manifest>

--- a/app/src/main/java/com/music/bitchord/data/YtMusicRepository.kt
+++ b/app/src/main/java/com/music/bitchord/data/YtMusicRepository.kt
@@ -152,10 +152,36 @@ object YtMusicRepository {
         }
     }
 
+    /**
+     * Search results across every page YouTube exposes for the chosen filter.
+     *
+     * The first response normally carries only about two dozen rows plus a
+     * continuation token. Returning it as the whole answer made filters such as
+     * Playlists stop around 20–25 rows even when the account had much more to
+     * show. Follow the same bounded paging contract as browse feeds: dedupe by
+     * the row's real identity, stop at [MAX_PAGES], and keep what was already
+     * collected if a later page fails.
+     */
     suspend fun search(query: String, filter: SearchFilter): Result<List<SearchResult>> =
         call("search:${filter.name}") {
-            InnertubeParser.parseSearch(Innertube.search(query, filter.params))
+            val out = LinkedHashMap<String, SearchResult>()
+            var page = InnertubeParser.parseSearchPage(Innertube.search(query, filter.params))
+            var count = 1
+            while (true) {
+                page.rows.forEach { row -> out.putIfAbsent(row.identityKey(), row) }
+                val token = page.continuation ?: break
+                if (count++ >= MAX_PAGES) break
+                page = runCatching {
+                    InnertubeParser.parseSearchPage(Innertube.searchContinuation(token))
+                }.getOrNull() ?: break
+            }
+            out.values.toList()
         }
+
+    private fun SearchResult.identityKey(): String = when (this) {
+        is SearchResult.Track -> "v:${song.videoId}"
+        is SearchResult.Browse -> "b:${item.browseId}"
+    }
 
     /**
      * What YouTube Music would suggest completing [input] to, for the search
@@ -231,10 +257,7 @@ object YtMusicRepository {
             val shelves = LIBRARY_FEEDS
                 .map { (title, browseId) ->
                     async {
-                        val items = runCatching {
-                            InnertubeParser.parseLibraryItems(Innertube.browse(browseId))
-                        }.getOrDefault(emptyList())
-                        HomeShelf(title, items)
+                        HomeShelf(title, runCatching { libraryItemsPaged(browseId) }.getOrDefault(emptyList()))
                     }
                 }
                 .awaitAll()
@@ -414,6 +437,32 @@ object YtMusicRepository {
         return out.values.toList()
     }
 
+    /**
+     * Every saved library card behind a feed browse id, following continuations.
+     *
+     * The library shelves are capped by YouTube's first page just like search:
+     * playlists, albums and artists often stop at about twenty-five rows unless
+     * their feed continuation is followed. These are background library loads,
+     * so collecting the full bounded set before publishing is preferable to a
+     * shelf that looks complete and silently is not.
+     */
+    private suspend fun libraryItemsPaged(browseId: String): List<ShelfItem> {
+        val out = LinkedHashMap<String, ShelfItem>()
+        var response = Innertube.browse(browseId)
+        var page = 1
+        while (true) {
+            val parsed = InnertubeParser.parseLibraryItemPage(response)
+            parsed.items.forEach { item ->
+                val key = item.browseId ?: item.videoId ?: "${item.title}\n${item.subtitle}"
+                out.putIfAbsent(key, item)
+            }
+            val token = parsed.continuation ?: break
+            if (page++ >= MAX_PAGES) break
+            response = runCatching { Innertube.browseContinuation(token) }.getOrNull() ?: break
+        }
+        return out.values.toList()
+    }
+
     const val MAX_PAGES = 10
 
     /**
@@ -480,12 +529,12 @@ object YtMusicRepository {
         call("library:$playlistId") { Innertube.ratePlaylist(playlistId, saved) }
 
     /**
-     * The playlists a track can be added to. Not paged: an account with more
-     * than one page of playlists is rare, and the picker is a list to scroll
-     * rather than a feed to follow.
+     * The playlists a track can be added to. Paged because accounts with long
+     * playlist collections otherwise lose everything past YouTube's first
+     * library-feed response.
      */
     suspend fun userPlaylists(): Result<List<UserPlaylist>> = call("playlists") {
-        InnertubeParser.parseUserPlaylists(Innertube.browse(LIBRARY_PLAYLISTS))
+        InnertubeParser.parseUserPlaylists(libraryItemsPaged(LIBRARY_PLAYLISTS))
     }
 
     /** Creates a playlist, optionally seeded with [videoIds]; returns its id. */

--- a/app/src/main/java/com/music/bitchord/data/innertube/Innertube.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/Innertube.kt
@@ -415,6 +415,14 @@ object Innertube {
             params?.let { put("params", it) }
         }
 
+    /** The next page of a filtered search result. */
+    suspend fun searchContinuation(token: String): JsonObject = postMusic(
+        endpoint = "search",
+        query = mapOf("ctoken" to token, "continuation" to token, "type" to "next"),
+    ) {
+        put("continuation", token)
+    }
+
     /**
      * The typeahead list YouTube Music's own search box shows for a
      * half-typed query — query strings, not results.

--- a/app/src/main/java/com/music/bitchord/data/innertube/InnertubeParser.kt
+++ b/app/src/main/java/com/music/bitchord/data/innertube/InnertubeParser.kt
@@ -33,12 +33,17 @@ object InnertubeParser {
     fun parseSearchSongs(response: JsonObject): List<Song> =
         parseSearch(response).filterIsInstance<SearchResult.Track>().map { it.song }
 
+    /** One page of search rows, plus the token for the next page if YouTube offers one. */
+    data class SearchPage(val rows: List<SearchResult>, val continuation: String?)
+
     /**
      * Search results are heterogeneous: songs carry a videoId, while albums,
      * artists and playlists carry a browseId plus a page type. Both arrive as
      * `musicResponsiveListItemRenderer`, so each row is classified on the way out.
      */
-    fun parseSearch(response: JsonObject): List<SearchResult> {
+    fun parseSearch(response: JsonObject): List<SearchResult> = parseSearchPage(response).rows
+
+    fun parseSearchPage(response: JsonObject): SearchPage {
         // The "All" tab spreads results across several shelf types (card shelf
         // for the top result, then one shelf per category), and the shapes
         // differ per filter. Walking for the row renderer itself is far more
@@ -46,7 +51,7 @@ object InnertubeParser {
         val rows = collectRenderers(response, "musicResponsiveListItemRenderer")
 
         val seen = HashSet<String>()
-        return rows.mapNotNull { renderer ->
+        val parsed = rows.mapNotNull { renderer ->
             // Browse rows are tested first: an album row also carries a
             // "play album" videoId in its overlay, so checking for a track
             // first would misread every album as a single song.
@@ -62,6 +67,7 @@ object InnertubeParser {
                 if (seen.add("v:${song.videoId}")) SearchResult.Track(song) else null
             }
         }
+        return SearchPage(parsed, continuationToken(response))
     }
 
     /**
@@ -379,25 +385,38 @@ object InnertubeParser {
         val scope: JsonElement = root.o("continuationContents")
             ?: root.o("contents").o("twoColumnBrowseResultsRenderer").o("secondaryContents")
             ?: return null
-        val looksLikePlaylist = collectRenderers(scope, "musicPlaylistShelfRenderer").isNotEmpty() ||
-            scope.o("musicPlaylistShelfContinuation") != null ||
-            collectRenderers(scope, "musicShelfRenderer").any { it.o("title").runs() == "Suggestions" }
-        if (!looksLikePlaylist) return null
+        val playlistScope = scope.o("musicPlaylistShelfContinuation")
+            ?: collectRenderers(scope, "musicPlaylistShelfRenderer").firstOrNull()
+        val suggestionShelves = collectRenderers(scope, "musicShelfRenderer")
+            .filter { it.o("title").runs() == "Suggestions" }
+        if (playlistScope == null && suggestionShelves.isEmpty()) return null
 
         val pageCredit = pageCredit(root)
-        val (songs, suggested) = collectRenderers(scope, "musicResponsiveListItemRenderer")
+        val songs = playlistScope?.let { playlist ->
+            collectRenderers(playlist, "musicResponsiveListItemRenderer")
+                .mapNotNull { parseResponsiveListItem(it, pageCredit) }
+                .distinctBy { it.videoId }
+        }.orEmpty()
+        val knownSongs = songs.mapTo(HashSet()) { it.videoId }
+        val suggested = suggestionShelves
+            .flatMap { collectRenderers(it, "musicResponsiveListItemRenderer") }
             .mapNotNull { parseResponsiveListItem(it, pageCredit) }
+            .filterNot { it.videoId in knownSongs }
             .distinctBy { it.videoId }
-            .partition { it.setVideoId != null }
         // The "Suggestions" shelf's own continuation reloads it with a fresh
         // batch rather than paging it (see its "Refresh" button, wired to a
-        // `reloadContinuationData` token) — only the real `nextContinuationData`
-        // / `continuationItemRenderer` found in scope means more to fetch.
-        val token = collectRenderers(scope, "continuationItemRenderer").firstOrNull()
-            .o("continuationEndpoint").o("continuationCommand").s("token")
-            ?: collectRenderers(scope, "nextContinuationData").firstOrNull().s("continuation")
+        // `reloadContinuationData` token). Only the playlist shelf's own
+        // continuation means more real tracks.
+        val token = playlistScope?.let { playlist ->
+            collectRenderers(playlist, "continuationItemRenderer").firstOrNull()
+                .o("continuationEndpoint").o("continuationCommand").s("token")
+                ?: collectRenderers(playlist, "nextContinuationData").firstOrNull().s("continuation")
+        }
         return PlaylistShelfPage(songs, suggested, token)
     }
+
+    /** One page of saved library cards, plus the token for the next page. */
+    data class LibraryItemPage(val items: List<ShelfItem>, val continuation: String?)
 
     /**
      * The cards on a library feed — saved playlists, albums, artists, podcasts.
@@ -406,7 +425,9 @@ object InnertubeParser {
      * view, and serve `musicTwoRowItemRenderer` cards for one and
      * `musicResponsiveListItemRenderer` rows for the other, so both are read.
      */
-    fun parseLibraryItems(root: JsonElement): List<ShelfItem> {
+    fun parseLibraryItems(root: JsonElement): List<ShelfItem> = parseLibraryItemPage(root).items
+
+    fun parseLibraryItemPage(root: JsonElement): LibraryItemPage {
         val out = LinkedHashMap<String, ShelfItem>()
         collectRenderers(root, "musicTwoRowItemRenderer").forEach { renderer ->
             val item = parseTwoRowItem(renderer) ?: return@forEach
@@ -419,7 +440,7 @@ object InnertubeParser {
                 ShelfItem(item.title, item.subtitle, item.thumbnailUrl, null, item.browseId),
             )
         }
-        return out.values.toList()
+        return LibraryItemPage(out.values.toList(), continuationToken(root))
     }
 
     /**
@@ -917,7 +938,10 @@ object InnertubeParser {
      * playlist out of being renamed or deleted.
      */
     fun parseUserPlaylists(root: JsonElement): List<UserPlaylist> =
-        parseLibraryItems(root).mapNotNull { item ->
+        parseUserPlaylists(parseLibraryItems(root))
+
+    fun parseUserPlaylists(items: List<ShelfItem>): List<UserPlaylist> =
+        items.mapNotNull { item ->
             val browseId = item.browseId ?: return@mapNotNull null
             if (!browseId.startsWith("VL")) return@mapNotNull null
             if (NOT_EDITABLE.any { browseId.startsWith("VL$it") }) return@mapNotNull null

--- a/app/src/test/java/com/music/bitchord/SearchPagingTest.kt
+++ b/app/src/test/java/com/music/bitchord/SearchPagingTest.kt
@@ -1,0 +1,208 @@
+package com.music.bitchord
+
+import com.music.bitchord.data.innertube.InnertubeParser
+import com.music.bitchord.data.model.BrowseType
+import com.music.bitchord.data.model.SearchResult
+import com.music.bitchord.data.model.ShelfItem
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchPagingTest {
+
+    @Test
+    fun `search page keeps rows and next continuation`() {
+        val json = """
+        {
+          "contents": {
+            "sectionListRenderer": {
+              "contents": [
+                {
+                  "musicShelfRenderer": {
+                    "contents": [
+                      {
+                        "musicResponsiveListItemRenderer": {
+                          "navigationEndpoint": {
+                            "browseEndpoint": {
+                              "browseId": "VLPL123",
+                              "browseEndpointContextSupportedConfigs": {
+                                "browseEndpointContextMusicConfig": {
+                                  "pageType": "MUSIC_PAGE_TYPE_PLAYLIST"
+                                }
+                              }
+                            }
+                          },
+                          "flexColumns": [
+                            {
+                              "musicResponsiveListItemFlexColumnRenderer": {
+                                "text": { "runs": [{ "text": "One hundred songs" }] }
+                              }
+                            },
+                            {
+                              "musicResponsiveListItemFlexColumnRenderer": {
+                                "text": { "runs": [{ "text": "Playlist" }] }
+                              }
+                            }
+                          ],
+                          "thumbnail": {
+                            "musicThumbnailRenderer": {
+                              "thumbnail": { "thumbnails": [{ "url": "https://example.test/art.jpg" }] }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "continuationItemRenderer": {
+                    "continuationEndpoint": {
+                      "continuationCommand": { "token": "SEARCH_MORE" }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+        """.trimIndent()
+
+        val page = InnertubeParser.parseSearchPage(Json.parseToJsonElement(json).jsonObject)
+
+        assertEquals("SEARCH_MORE", page.continuation)
+        assertEquals(1, page.rows.size)
+        val item = (page.rows.single() as SearchResult.Browse).item
+        assertEquals("VLPL123", item.browseId)
+        assertEquals("One hundred songs", item.title)
+        assertEquals(BrowseType.PLAYLIST, item.type)
+    }
+
+    @Test
+    fun `search page deduplicates repeated rows before pagination`() {
+        val row = """
+        {
+          "musicResponsiveListItemRenderer": {
+            "navigationEndpoint": {
+              "browseEndpoint": {
+                "browseId": "VLPL123",
+                "browseEndpointContextSupportedConfigs": {
+                  "browseEndpointContextMusicConfig": {
+                    "pageType": "MUSIC_PAGE_TYPE_PLAYLIST"
+                  }
+                }
+              }
+            },
+            "flexColumns": [
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": { "runs": [{ "text": "Repeated playlist" }] }
+                }
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val json = """
+        {
+          "contents": [ $row, $row ],
+          "continuations": [
+            { "nextContinuationData": { "continuation": "NEXT_PAGE" } }
+          ]
+        }
+        """.trimIndent()
+
+        val page = InnertubeParser.parseSearchPage(Json.parseToJsonElement(json).jsonObject)
+
+        assertEquals("NEXT_PAGE", page.continuation)
+        assertEquals(1, page.rows.size)
+        assertTrue(page.rows.single() is SearchResult.Browse)
+    }
+
+    @Test
+    fun `playlist continuation rows are real tracks even without set video ids`() {
+        val json = """
+        {
+          "continuationContents": {
+            "musicPlaylistShelfContinuation": {
+              "contents": [
+                {
+                  "musicResponsiveListItemRenderer": {
+                    "playlistItemData": { "videoId": "song-2" },
+                    "flexColumns": [
+                      {
+                        "musicResponsiveListItemFlexColumnRenderer": {
+                          "text": { "runs": [{ "text": "Second page song" }] }
+                        }
+                      },
+                      {
+                        "musicResponsiveListItemFlexColumnRenderer": {
+                          "text": { "runs": [{ "text": "Artist" }, { "text": " • " }, { "text": "3:21" }] }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "continuations": [
+                { "nextContinuationData": { "continuation": "PLAYLIST_MORE" } }
+              ]
+            }
+          }
+        }
+        """.trimIndent()
+
+        val page = InnertubeParser.parsePlaylistShelf(Json.parseToJsonElement(json).jsonObject)
+
+        requireNotNull(page)
+        assertEquals(listOf("song-2"), page.songs.map { it.videoId })
+        assertEquals(emptyList<String>(), page.suggested.map { it.videoId })
+        assertEquals("PLAYLIST_MORE", page.continuation)
+    }
+
+    @Test
+    fun `library item page keeps saved cards and next continuation`() {
+        val json = """
+        {
+          "contents": [
+            {
+              "musicTwoRowItemRenderer": {
+                "title": { "runs": [{ "text": "Road songs" }] },
+                "subtitle": { "runs": [{ "text": "Playlist" }] },
+                "navigationEndpoint": { "browseEndpoint": { "browseId": "VLPLROAD" } },
+                "thumbnailRenderer": {
+                  "musicThumbnailRenderer": {
+                    "thumbnail": { "thumbnails": [{ "url": "https://example.test/road.jpg" }] }
+                  }
+                }
+              }
+            }
+          ],
+          "continuations": [
+            { "nextContinuationData": { "continuation": "LIBRARY_MORE" } }
+          ]
+        }
+        """.trimIndent()
+
+        val page = InnertubeParser.parseLibraryItemPage(Json.parseToJsonElement(json).jsonObject)
+
+        assertEquals("LIBRARY_MORE", page.continuation)
+        assertEquals(1, page.items.size)
+        assertEquals("VLPLROAD", page.items.single().browseId)
+        assertEquals("Road songs", page.items.single().title)
+    }
+
+    @Test
+    fun `user playlists filter still excludes non editable auto playlists after paging`() {
+        val playlists = InnertubeParser.parseUserPlaylists(
+            listOf(
+                ShelfItem("Road songs", "Playlist", null, null, "VLPLROAD"),
+                ShelfItem("Liked Music", "Auto playlist", null, null, "VLLM"),
+                ShelfItem("Album", "Album", null, null, "MPREb_album"),
+            ),
+        )
+
+        assertEquals(listOf("PLROAD"), playlists.map { it.playlistId })
+    }
+}


### PR DESCRIPTION
## Summary
- Follow YouTube Music search continuations so filtered search results no longer stop at the first page.
- Follow saved-library feed continuations for playlists, albums, artists, subscriptions, podcasts, and the add-to-playlist picker.
- Keep playlist continuation parsing scoped to the actual playlist shelf while preserving Suggested rows separately.
- Add regression coverage for search continuation tokens, playlist continuation rows, and paged library cards.

## Test Plan
- `./gradlew testDevDebugUnitTest --tests com.music.bitchord.SearchPagingTest --no-daemon`
- `./gradlew assembleDevRelease --no-daemon`

## Notes
- Verified manually in a local dev build against an account with more than one page of playlists.
