### PR TITLE
feat: persist Shuffle/Mix and Repeat/Loop states across app restarts

### DIFF
--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -1239,7 +1239,7 @@ private fun BitChordApp(
             signedIn = signedIn,
             likeStatus = likeStatuses[song.videoId] ?: LikeStatus.INDIFFERENT,
             onToggleLike = { viewModel.toggleLike(song.videoId) },
-            onToggleShuffle = { controller?.let(QueueShuffle::toggle) },
+            onToggleShuffle = { controller?.let { it2 -> QueueShuffle.toggle(it2); AppSettings.setShuffleEnabled(QueueShuffle.enabled.value) } },
             onCycleRepeat = {
                 controller?.let {
                     val next = when (it.repeatMode) {
@@ -1247,6 +1247,8 @@ private fun BitChordApp(
                         Player.REPEAT_MODE_ALL -> Player.REPEAT_MODE_ONE
                         else -> Player.REPEAT_MODE_OFF
                     }
+                    // Persist the new repeat mode so it survives app restarts.
+                    AppSettings.setRepeatMode(next)
                     // Nothing else to do here: PlaybackService watches the
                     // repeat mode itself and takes AutoPlay's tracks out of
                     // the queue for the duration of repeat-all — and, unlike

--- a/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import androidx.media3.common.Player
 import com.music.bitchord.BuildConfig
 import com.music.bitchord.auth.AuthStore
 import com.music.bitchord.data.lyrics.LyricsSource
@@ -177,6 +178,12 @@ object AppSettings {
 
     /** Keep playing similar music once the queue runs out. */
     val autoplay = MutableStateFlow(true)
+
+    /** Whether the queue is held in shuffled order (Mix button). */
+    val shuffleEnabled = MutableStateFlow(false)
+
+    /** Repeat mode for the player — Off, All, or One. */
+    val repeatMode = MutableStateFlow(Player.REPEAT_MODE_OFF)
 
     /** Put the playing track's codec, bitrate and sample rate on the player. */
     val showNerdStats = MutableStateFlow(false)
@@ -485,6 +492,8 @@ object AppSettings {
             ThemeMode.valueOf(prefs.getString(KEY_THEME, null) ?: "DARK")
         }.getOrDefault(ThemeMode.DARK)
         autoplay.value = prefs.getBoolean(KEY_AUTOPLAY, true)
+        shuffleEnabled.value = prefs.getBoolean(KEY_SHUFFLE_ENABLED, false)
+        repeatMode.value = prefs.getInt(KEY_REPEAT_MODE, Player.REPEAT_MODE_OFF)
         showNerdStats.value = prefs.getBoolean(KEY_NERD_STATS, false)
         reduceAnimation.value = prefs.getBoolean(KEY_REDUCE_ANIMATION, false)
         highPerformanceMode.value = prefs.getBoolean(KEY_HIGH_PERFORMANCE_MODE, false)
@@ -649,6 +658,16 @@ object AppSettings {
     fun setAutoplay(value: Boolean) {
         autoplay.value = value
         prefs.edit().putBoolean(KEY_AUTOPLAY, value).apply()
+    }
+
+    fun setShuffleEnabled(value: Boolean) {
+        shuffleEnabled.value = value
+        prefs.edit().putBoolean(KEY_SHUFFLE_ENABLED, value).apply()
+    }
+
+    fun setRepeatMode(value: Int) {
+        repeatMode.value = value
+        prefs.edit().putInt(KEY_REPEAT_MODE, value).apply()
     }
 
     fun setAudioQualityWifi(value: AudioQuality) {
@@ -1182,6 +1201,8 @@ object AppSettings {
     private const val KEY_SPEED = "playback_speed"
     private const val KEY_THEME = "theme_mode"
     private const val KEY_AUTOPLAY = "autoplay"
+    private const val KEY_SHUFFLE_ENABLED = "shuffle_enabled"
+    private const val KEY_REPEAT_MODE = "repeat_mode"
     private const val KEY_NERD_STATS = "show_nerd_stats"
     private const val KEY_CACHE_LIMIT = "audio_cache_limit_bytes"
     private const val KEY_REDUCE_ANIMATION = "reduce_animation"

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -2933,7 +2933,7 @@ class PlaybackService : MediaSessionService() {
         player.setPlaybackSpeed(AppSettings.playbackSpeed.value)
         // Restore persisted shuffle and repeat states on startup.
         if (AppSettings.shuffleEnabled.value) {
-            QueueShuffle.enabled.value = true
+            QueueShuffle.setEnabled(true)
         }
         player.repeatMode = AppSettings.repeatMode.value
     }

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -2931,6 +2931,11 @@ class PlaybackService : MediaSessionService() {
     private fun applySettings(player: ExoPlayer) {
         player.skipSilenceEnabled = AppSettings.skipSilence.value
         player.setPlaybackSpeed(AppSettings.playbackSpeed.value)
+        // Restore persisted shuffle and repeat states on startup.
+        if (AppSettings.shuffleEnabled.value) {
+            QueueShuffle.enabled.value = true
+        }
+        player.repeatMode = AppSettings.repeatMode.value
     }
 
     /** Runs [body] against both players, in whichever roles they currently hold. */

--- a/app/src/main/java/com/music/bitchord/playback/QueueShuffle.kt
+++ b/app/src/main/java/com/music/bitchord/playback/QueueShuffle.kt
@@ -31,7 +31,9 @@ object QueueShuffle {
 
     /** Whether the queue is currently held in shuffled order. */
     val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
-
+    fun setEnabled(enabled: Boolean) {
+        _enabled.value = enabled
+    }
     /** Media ids in their pre-shuffle order. Empty while shuffle is off. */
     private var original: List<String> = emptyList()
 

--- a/app/src/main/java/com/music/bitchord/playback/QueueShuffle.kt
+++ b/app/src/main/java/com/music/bitchord/playback/QueueShuffle.kt
@@ -2,6 +2,7 @@ package com.music.bitchord.playback
 
 import androidx.media3.common.Player
 import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.settings.AppSettings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,6 +37,8 @@ object QueueShuffle {
 
     fun toggle(player: Player) {
         if (_enabled.value) restore(player) else shuffle(player)
+        // Persist the new state so it survives app restarts.
+        AppSettings.setShuffleEnabled(_enabled.value)
     }
 
     /**
@@ -46,6 +49,7 @@ object QueueShuffle {
     fun enableForNextQueue() {
         original = emptyList()
         _enabled.value = true
+        AppSettings.setShuffleEnabled(true)
     }
 
     /**


### PR DESCRIPTION
Persist Shuffle/Mix and Repeat/Loop states across app restarts 

This PR implements persistence for the **Mix (Shuffle)** and **Loop (Repeat)** button states, following the existing Autoplay persistence pattern.

## Changes

- **`AppSettings.kt`** - Added `shuffleEnabled` (Boolean) and `repeatMode` (Int: Off/All/One) as persisted settings with SharedPreferences storage, read in `readAll()`, and setters for updating
- **`QueueShuffle.kt`** - Persist shuffle state on toggle and enable-for-next-queue
- **`PlaybackService.applySettings()`** - Restore repeat mode and shuffle state on boot
- **`MainActivity.kt`** - Player screen shuffle/repeat callbacks now persist via AppSettings

## Value

Users who prefer to keep shuffle or repeat enabled won't need to re-enable them manually every time they open the app. Brings player control behavior in line with standard music players and the existing Autoplay persistence logic.

---

Closes #76 #132

Automated PR generated 100% via Hermes Agent.
