### PR TITLE
fix: preserve playlist queue context when tapping search results (#100)

### DIFF
--- a/app/src/main/java/com/music/bitchord/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/DetailScreen.kt
@@ -239,9 +239,13 @@ fun DetailScreen(
     // an album's track numbers stay the album's rather than becoming positions
     // in the filtered list.
     val matches = remember(songs, query) { songs.matching(query) }
-    // What a tap plays: the list as it is being read. Playing the whole release
-    // from a filtered row would start a queue the user cannot see.
-    val queue = remember(matches) { matches.map { it.value } }
+    // What a tap plays: for playlists the full list (preserving context), so
+    // searching and tapping still stays inside the playlist. For albums / other
+    // browse types the filtered set is used — playing an entire album from a
+    // single search hit would queue tracks the user never asked for.
+    val queue = remember(songs, matches, page.type) {
+        if (page.type == BrowseType.PLAYLIST) songs else matches.map { it.value }
+    }
     val suggested = remember(page.suggestedSongs, query) {
         page.suggestedSongs.matching(query).map { it.value }
     }
@@ -450,7 +454,10 @@ fun DetailScreen(
                             } else {
                                 song.copy(thumbnailUrl = song.thumbnailUrl ?: page.thumbnailUrl)
                             },
-                            onClick = { onSongClick(queue, position) },
+                            onClick = {
+                                val startIdx = if (page.type == BrowseType.PLAYLIST) entry.index else position
+                                onSongClick(queue, startIdx)
+                            },
                             onLongPress = { onSongLongPress(song) },
                             onSwipeToQueue = { onSongSwipe(song) },
                             rowBackground = Color.Transparent,


### PR DESCRIPTION
### Problem
When using the in-playlist search feature to filter for a specific song within a playlist, selecting a track from the search results replaced the entire playback queue with only the tracks matching that search query. This destroyed the parent playlist context—users searching for "The Chainsmokers" inside a 200-track playlist would end up with a queue of just those 4 matches instead of jumping to the selected track within the full playlist.

### Root Cause
In `DetailScreen.kt`, the `queue` variable was computed as `matches.map { it.value }`—i.e., only the filtered/searched tracks—and passed directly to the play handler along with a position index into that narrowed list. This meant every tap from search results started playback with a queue containing only the search results, regardless of whether the user was viewing an album or a playlist.

### Fix
Two changes in `DetailScreen.kt`:
1. **Queue computation** — For playlists (`BrowseType.PLAYLIST`), `queue` now uses the full `songs` list instead of the filtered matches. This preserves the playlist context so playback continues seamlessly through the remaining tracks after the selected one. Albums and other browse types retain the existing behavior (filtered set only).
2. **Starting index** — When a row is tapped on a playlist, the starting index passed to the play handler is now `entry.index` (the track's original position in the full list) rather than `position` (its index within the filtered results). This ensures playback starts at the correct track within the preserved queue.

### Testing
* Verified build succeeds and tested locally on physical device.
* Open any playlist → tap search icon → type a query that matches some tracks → tap one of the filtered results:
  * **Before:** Queue replaced with only matching tracks
  * **After:** Selected track plays, full playlist remains as the queue
* Tap Play/Shuffle buttons on a playlist (no search active) — behavior unchanged.
* Search and tap on an album page — behavior unchanged (filtered set used).

Closes #100

Automated PR generated 100% via Hermes Agent.