### PR TITLE
fix(navigation): dismiss sources screen when selecting bottom nav item

### DIFF
--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -2306,6 +2306,7 @@ private fun BitChordApp(
                         viewModel.closeMoodGenre()
                         showSettings = false
                         showAccountScrobbling = false
+                        showSources = false
                         showReplay = false
                         showHistory = false
                         libraryShowAll = null


### PR DESCRIPTION
Added `showSources = false` to the `onTabSelected` handler in `MainActivity.kt`.

When on the Sources screen, tapping any bottom navigation tab now properly dismisses the Sources overlay so the target tab renders cleanly instead of being blocked by a frozen view.