### PR TITLE
fix(queue): return to main player on back gesture from expanded queue

### DIFF
--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -668,6 +668,23 @@ fun NowPlayingScreen(
         }
     }
 
+    // Back out of the queue to the player. Same problem as lyrics: the sheet's
+    // own dispatcher competes at PRIORITY_DEFAULT on API 33+, so we outrank it
+    // with an overlay-priority callback while the queue is open. Below 33 the
+    // BackHandler alone wins because it registers after the dialog's handler.
+    BackHandler(enabled = queueOpen) { queueOpen = false }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val view = LocalView.current
+        DisposableEffect(view, queueOpen) {
+            val callback = if (queueOpen) {
+                OverlayBack.register(view) { queueOpen = false }
+            } else {
+                null
+            }
+            onDispose { OverlayBack.unregister(view, callback) }
+        }
+    }
+
     // 0 = full sleeve, 1 = queue. Everything that moves reads off this.
     //
     // Plain state driven by an animation rather than [animateFloatAsState],


### PR DESCRIPTION
### Problem
Triggering the Android system back gesture while the queue is expanded bypasses collapsing the queue, popping the main player route entirely and sending the user back to whichever screen they were on previously (e.g., Home, Explore, or Library).

### Root Cause
The `NowPlayingScreen` composable uses a `ModalBottomSheet` that registers its own dismiss handler on the window's `OnBackInvokedDispatcher` at `PRIORITY_DEFAULT` (API 33+). The existing `BackHandler` only handled the lyrics panel (`lyricsOpen`) but had no handler for the queue state. When the queue was open, back events were consumed by the sheet's dispatcher, which dismissed the entire player instead of collapsing the queue first.

### Fix
- **File:** `app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt` (lines 671–686)
- Added `BackHandler(enabled = queueOpen) { queueOpen = false }` to intercept back events when the queue is expanded and collapse it instead of dismissing the player.
- Added an API 33+ `OverlayBack.register()` with `PRIORITY_OVERLAY` to outrank the sheet's own dispatcher while the queue is open — mirroring the exact pattern already used for the lyrics panel.
- When the queue is closed, normal system back behavior (minimizing/dismissing the player) remains untouched.

### Testing
- Verified build succeeds and tested locally on physical device.
- **Before:** Open Now Playing -> tap queue button to expand -> trigger system back gesture -> player dismisses entirely, user returns to Home/Explore/Library.
- **After:** Open Now Playing -> tap queue button to expand -> trigger system back gesture -> queue collapses smoothly, user remains in the main player view.

Automated PR generated 100% via Hermes Agent.
