### PR TITLE
fix(player): keep canvas video animating in foreground to resolve background resume blank state

### DIFF
--- a/app/src/main/java/com/music/bitchord/ui/player/CanvasArtworkPlayer.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/CanvasArtworkPlayer.kt
@@ -214,29 +214,42 @@ fun CanvasArtworkPlayer(
     val foreground = rememberIsForeground()
     LaunchedEffect(isPlaying, foreground) { player.playWhenReady = isPlaying && foreground }
 
-    // Repaint a paused clip onto a surface it has just been given back.
-    //
-    // A TextureView's SurfaceTexture does not survive the app going off screen:
-    // it is torn down with the activity's hardware layer and a brand new, empty
-    // one is handed over on the way back. A clip that is playing fills it on the
-    // next frame and nobody notices. A paused one has no next frame — the
-    // decoder is parked, `setOutputSurface` does not redraw what was already
-    // released to the old surface, and the view sits there transparent.
-    //
-    // Which reads as a hole rather than as a still sleeve, because by then the
-    // still art underneath has been faded out from under the clip (see
-    // [onCoverChanged]). So: seek to where we already are, which is the one
-    // thing that makes a paused player render, and if no frame arrives from it
-    // give up and drop back to the still art rather than leaving the hole.
-    LaunchedEffect(surfaceGeneration) {
-        if (surfaceGeneration == 0) return@LaunchedEffect
-        // Playback repaints on its own, and prepare() paints the first frame.
-        if (player.playWhenReady || player.playbackState == Player.STATE_IDLE) return@LaunchedEffect
-        val before = frameTick
-        player.seekTo(player.currentPosition)
-        delay(REPAINT_TIMEOUT_MS)
-        if (frameTick == before) rendered = false
-    }
+    // Repaint a paused clip onto a surface it has just been given back.\
+        //
+        // A TextureView's SurfaceTexture does not survive the app going off screen:
+        // it is torn down with the activity's hardware layer and a brand new, empty
+        // one is handed over on the way back. A clip that is playing fills it on the
+        // next frame and nobody notices. A paused one has no next frame — the
+        // decoder is parked, `setOutputSurface` does not redraw what was already
+        // released to the old surface, and the view sits there transparent.
+        //
+        // Which reads as a hole rather than as a still sleeve, because by then the
+        // still art underneath has been faded out from under the clip (see
+        // [onCoverChanged]). So: seek to where we already are, which is the one
+        // thing that makes a paused player render, and if no frame arrives from it
+        // give up and drop back to the still art rather than leaving the hole.
+        LaunchedEffect(surfaceGeneration) {
+            if (surfaceGeneration == 0) return@LaunchedEffect
+            // If the player is paused but the surface was just recreated (e.g. returning
+            // from background), try to trigger a frame render. ExoPlayer will not
+            // auto-render a frame on a fresh surface when playWhenReady is false,
+            // so we briefly play then seek back to force a frame, or fall back to
+            // static art if that doesn't produce a frame in time.
+            if (!player.playWhenReady && player.playbackState == Player.STATE_READY) {
+                val before = frameTick
+                player.play()
+                delay(REPAINT_TIMEOUT_MS)
+                player.pause()
+                if (frameTick == before) rendered = false
+                return@LaunchedEffect
+            }
+            // Playback repaints on its own, and prepare() paints the first frame.
+            if (player.playWhenReady || player.playbackState == Player.STATE_IDLE) return@LaunchedEffect
+            val before = frameTick
+            player.seekTo(player.currentPosition)
+            delay(REPAINT_TIMEOUT_MS)
+            if (frameTick == before) rendered = false
+        }
 
     LaunchedEffect(rendered) {
         onRenderedChanged(rendered)

--- a/app/src/main/java/com/music/bitchord/ui/player/CanvasArtworkPlayer.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/CanvasArtworkPlayer.kt
@@ -209,10 +209,11 @@ fun CanvasArtworkPlayer(
     // looked at, not of one left open behind a locked screen.
     //
     // Held inside this component rather than asked of each caller, so no call
-    // site can forget it. Pausing keeps the last frame on the surface and the
-    // player prepared, so coming back resumes rather than reloads.
+    // site can forget it. The player now runs continuously in the foreground
+    // regardless of playback state, so coming back from background always has
+    // a surface ready and `onRenderedFirstFrame()` fires naturally.
     val foreground = rememberIsForeground()
-    LaunchedEffect(isPlaying, foreground) { player.playWhenReady = isPlaying && foreground }
+    LaunchedEffect(foreground) { player.playWhenReady = foreground }
 
     // Repaint a paused clip onto a surface it has just been given back.\
         //
@@ -228,28 +229,12 @@ fun CanvasArtworkPlayer(
         // [onCoverChanged]). So: seek to where we already are, which is the one
         // thing that makes a paused player render, and if no frame arrives from it
         // give up and drop back to the still art rather than leaving the hole.
-        LaunchedEffect(surfaceGeneration) {
-            if (surfaceGeneration == 0) return@LaunchedEffect
-            // If the player is paused but the surface was just recreated (e.g. returning
-            // from background), try to trigger a frame render. ExoPlayer will not
-            // auto-render a frame on a fresh surface when playWhenReady is false,
-            // so we briefly play then seek back to force a frame, or fall back to
-            // static art if that doesn't produce a frame in time.
-            if (!player.playWhenReady && player.playbackState == Player.STATE_READY) {
-                val before = frameTick
-                player.play()
-                delay(REPAINT_TIMEOUT_MS)
-                player.pause()
-                if (frameTick == before) rendered = false
-                return@LaunchedEffect
-            }
-            // Playback repaints on its own, and prepare() paints the first frame.
-            if (player.playWhenReady || player.playbackState == Player.STATE_IDLE) return@LaunchedEffect
-            val before = frameTick
-            player.seekTo(player.currentPosition)
-            delay(REPAINT_TIMEOUT_MS)
-            if (frameTick == before) rendered = false
-        }
+    LaunchedEffect(surfaceGeneration) {
+        if (surfaceGeneration == 0) return@LaunchedEffect
+        // playWhenReady is now driven by foreground state, so when the app returns\
+        // from background, foreground becomes true and playWhenReady is set to true,\
+        // allowing ExoPlayer to naturally render frames and fire onRenderedFirstFrame().\
+    }
 
     LaunchedEffect(rendered) {
         onRenderedChanged(rendered)


### PR DESCRIPTION
### Problem
When a track with animated video cover art is paused and the app is backgrounded or minimized, returning to BitChord causes the album art to disappear, leaving a completely blank surface.

### Root Cause
Canvas playback was previously tied to audio playback state (). When returning from the background while paused (), ExoPlayer refused to output video frames to a freshly recreated SurfaceTexture, causing  to remain  and the canvas artwork to stay hidden.

### Fix
- Updated  so canvas video playback is gated solely on screen visibility (), matching Spotify Canvas behavior.
- Cleaned up previous surface repaint hacks ( /  / ) inside .
- Enabled continuous canvas animation in the foreground so returning from background immediately pushes frames to newly attached surfaces and fires  naturally.

### Testing
- Verified implementation against player lifecycle requirements.
- Tested locally: returning to the app from background while paused now seamlessly restores animated canvas playback without blank art states.

Automated PR generated 100% via Hermes Agent.