### PR TITLE
(feat) on-device lyrics translation and some fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,6 +229,9 @@ dependencies {
     // (ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED). See withResolvedStreamType.
     implementation("androidx.media3:media3-exoplayer-dash:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.9.0")
+    implementation("com.google.mlkit:language-id:17.0.6")
+    implementation("com.google.mlkit:translate:17.0.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.9.0")
 
     // ---- Images: Coil 3 + Palette (dominant colors for the mesh gradient) ----
     implementation("io.coil-kt.coil3:coil-compose:3.0.4")

--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -181,6 +181,7 @@ import com.music.bitchord.ui.components.TopBarDownloadButton
 import com.music.bitchord.ui.components.TopFadeBlur
 import com.music.bitchord.ui.components.topBarContentPadding
 import com.music.bitchord.ui.components.AppLanguageDialog
+import com.music.bitchord.ui.components.LanguagePickerDialog
 import com.music.bitchord.ui.components.LyricsSourcesDialog
 import com.music.bitchord.ui.components.UpdateAvailableDialog
 import com.music.bitchord.ui.icons.BitChordIcons
@@ -406,6 +407,7 @@ private fun BitChordApp(
     var librarySortMenuOpen by remember { mutableStateOf(false) }
     var showLyricsSources by remember { mutableStateOf(false) }
     var showAppLanguage by remember { mutableStateOf(false) }
+    var showLyricsTranslationLanguage by remember { mutableStateOf(false) }
     var showAccountSelector by remember { mutableStateOf(false) }
     var showListenBrainzLogin by remember { mutableStateOf(false) }
     var showLastfmLogin by remember { mutableStateOf(false) }
@@ -516,6 +518,7 @@ private fun BitChordApp(
     val lyrics by viewModel.lyrics.collectAsStateWithLifecycle()
     val lyricsSource by viewModel.lyricsSource.collectAsStateWithLifecycle()
     val lyricsChecked by viewModel.lyricsChecked.collectAsStateWithLifecycle()
+    val lyricsTranslation by viewModel.lyricsTranslation.collectAsStateWithLifecycle()
     val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
     val searchSuggestions by viewModel.suggestions.collectAsStateWithLifecycle()
     val searchLoadingMore by viewModel.searchLoadingMore.collectAsStateWithLifecycle()
@@ -1563,6 +1566,10 @@ private fun BitChordApp(
             lyrics = lyrics,
             lyricsSource = lyricsSource,
             lyricsUnavailable = lyricsChecked && lyrics.isNullOrEmpty(),
+            lyricsChecked = lyricsChecked,
+            lyricsTranslation = lyricsTranslation,
+            onTranslateLyrics = viewModel::translateLyrics,
+            onShowOriginalLyrics = viewModel::showOriginalLyrics,
             docked = docked,
             onClearQueue = {
                 // Keep what's playing; drop everything queued after it.
@@ -1844,6 +1851,7 @@ private fun BitChordApp(
                             onSources = { showSources = true },
                             onSpotifyCanvasAuth = { showSpotifyCanvasAuth = true },
                             onAppLanguage = { showAppLanguage = true },
+                            onLyricsTranslationLanguage = { showLyricsTranslationLanguage = true },
                             contentPadding = listPadding,
                         )
                     } else if (page != null && page.browseId.isDeviceFolder()) {
@@ -2970,7 +2978,6 @@ private fun BitChordApp(
         }
 
         if (showLyricsSources) {
-            BackHandler { showLyricsSources = false }
             LyricsSourcesDialog(
                 hazeState = hazeState,
                 onDismiss = { showLyricsSources = false },
@@ -3002,10 +3009,20 @@ private fun BitChordApp(
         }
 
         if (showAppLanguage) {
-            BackHandler { showAppLanguage = false }
             AppLanguageDialog(
                 hazeState = hazeState,
                 onDismiss = { showAppLanguage = false },
+            )
+        }
+
+        if (showLyricsTranslationLanguage) {
+            LanguagePickerDialog(
+                hazeState = hazeState,
+                titleRes = R.string.lyrics_translation_language,
+                descriptionRes = R.string.lyrics_translation_language_subtitle,
+                selectedTag = AppSettings.lyricsTranslationLanguage.collectAsStateWithLifecycle().value,
+                onSelect = AppSettings::setLyricsTranslationLanguage,
+                onDismiss = { showLyricsTranslationLanguage = false },
             )
         }
 

--- a/app/src/main/java/com/music/bitchord/data/lyrics/Genius.kt
+++ b/app/src/main/java/com/music/bitchord/data/lyrics/Genius.kt
@@ -36,7 +36,7 @@ object Genius {
     private const val BROWSER_AGENT =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json by lazy { Json { ignoreUnknownKeys = true; isLenient = true } }
 
     private val httpClient by lazy {
         Http.client.newBuilder()
@@ -46,40 +46,63 @@ object Genius {
     }
 
     suspend fun lyrics(title: String, artist: String): List<LyricLine>? = withContext(Dispatchers.IO) {
+        runCatching {
+            scrapeLyrics(title, artist)
+        }.onFailure {
+            LyricsLog.e("Genius", "Scraper failed: ${it::class.simpleName}: ${it.message}")
+        }.getOrNull()
+    }
+
+    private fun scrapeLyrics(title: String, artist: String): List<LyricLine>? {
         LyricsLog.i("Genius", "Fallback scraper triggered for: \"$title\" by \"$artist\"")
         val cleanTitle = cleanQuery(title)
         val cleanArtist = cleanQuery(artist)
 
-        val songUrl = searchSongUrl(cleanTitle, cleanArtist)
+        val titleWithoutParentheses = cleanTitle
+            .replace(BRACKETED_CONTENT, " ")
+            .replace(NON_ALPHANUMERIC, " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+        val searchAttempts = listOf(
+            SearchAttempt("$cleanArtist $cleanTitle".trim(), cleanTitle, cleanArtist),
+            SearchAttempt("$cleanArtist $titleWithoutParentheses".trim(), titleWithoutParentheses, cleanArtist),
+            SearchAttempt(titleWithoutParentheses, titleWithoutParentheses, ""),
+        ).distinctBy { it.query }
+        val songUrl = searchAttempts.asSequence()
+            .mapNotNull { attempt -> searchSongUrl(attempt.query, attempt.title, attempt.artist) }
+            .firstOrNull()
         if (songUrl == null) {
             LyricsLog.w("Genius", "No matching song found on Genius")
-            return@withContext null
+            return null
         }
 
         LyricsLog.i("Genius", "Found song page: $songUrl")
         val html = fetchHtml(songUrl)
         if (html.isNullOrBlank()) {
             LyricsLog.e("Genius", "Failed to fetch HTML from song page")
-            return@withContext null
+            return null
         }
 
         val lines = parseHtml(html)
         if (lines.isNullOrEmpty()) {
             LyricsLog.w("Genius", "HTML parsed but no lyric lines could be extracted")
-            return@withContext null
+            return null
         }
 
         val sectionCount = lines.count { isSectionHeader(it.text) }
         val sungCount = lines.count { !it.isGap && !isSectionHeader(it.text) }
         LyricsLog.s("Genius", "Successfully scraped $sungCount lines and $sectionCount sections")
-        lines
+        return lines
     }
 
     /**
      * Searches Genius for the track and returns the song's page URL.
      */
     internal fun searchSongUrl(cleanTitle: String, cleanArtist: String): String? {
-        val query = "$cleanArtist $cleanTitle".trim()
+        return searchSongUrl("$cleanArtist $cleanTitle".trim(), cleanTitle, cleanArtist)
+    }
+
+    private fun searchSongUrl(query: String, targetTitle: String, targetArtist: String): String? {
         val url = "https://genius.com/api/search/multi?q=${URLEncoder.encode(query, "UTF-8")}"
         LyricsLog.i("Genius", "Querying Genius search API: $query")
 
@@ -100,7 +123,7 @@ object Genius {
             val hits = songSection["hits"]?.jsonArray ?: return null
             val candidates = hits.mapNotNull { (it as? JsonObject)?.get("result")?.jsonObject }
 
-            val best = bestMatch(candidates, cleanTitle, cleanArtist)
+            val best = bestMatch(candidates, targetTitle, targetArtist)
             best?.get("url")?.jsonPrimitive?.contentOrNull
         }.onFailure {
             LyricsLog.e("Genius", "Failed to parse search response: ${it.message}")
@@ -124,7 +147,7 @@ object Genius {
             if (title == normTitle) score += 50
             else if (title.contains(normTitle) || normTitle.contains(title)) score += 25
 
-            if (artist.contains(normArtist) || normArtist.contains(artist)) score += 40
+            if (normArtist.isNotBlank() && (artist.contains(normArtist) || normArtist.contains(artist))) score += 40
 
             // Penalize translations / instrumentals / reviews unless specifically requested
             val path = item["path"]?.jsonPrimitive?.contentOrNull ?: ""
@@ -141,6 +164,14 @@ object Genius {
      * stanzas and section headers.
      */
     internal fun parseHtml(html: String): List<LyricLine>? {
+        return runCatching {
+            parseHtmlUnsafe(html)
+        }.onFailure {
+            LyricsLog.e("Genius", "Lyrics HTML parsing failed: ${it::class.simpleName}: ${it.message}")
+        }.getOrNull()
+    }
+
+    private fun parseHtmlUnsafe(html: String): List<LyricLine>? {
         val doc = Jsoup.parse(html)
 
         // Modern Genius uses data-lyrics-container="true", older pages use div.lyrics
@@ -178,7 +209,7 @@ object Genius {
         if (rawLyrics.isBlank()) return null
 
         val cleaned = stripArtifacts(rawLyrics)
-        return textToLyricLines(cleaned)
+        return textToLyricLines(cleaned).takeIf { it.isNotEmpty() }
     }
 
     /**
@@ -244,6 +275,12 @@ object Genius {
         .trim()
         .ifBlank { text }
 
+    private data class SearchAttempt(
+        val query: String,
+        val title: String,
+        val artist: String,
+    )
+
     private fun httpGet(url: String): String? = runCatching {
         val request = Request.Builder()
             .url(url)
@@ -258,12 +295,15 @@ object Genius {
 
     private fun fetchHtml(url: String): String? = httpGet(url)
 
-    private val NOISE = Regex(
-        """\((?:from|feat\.?|official|lyrical|video|audio|remix|music video|visualizer)[^)]*\)|\[[^]]*]|""" +
-            """\b(?:official (?:video|audio|music video)|lyrical|full song|4k video)\b""",
-        RegexOption.IGNORE_CASE,
-    )
-
-    private val YOU_MIGHT_ALSO_LIKE = Regex("""\d*You might also like""", RegexOption.IGNORE_CASE)
-    private val TRAILING_EMBED = Regex("""\d*Embed\s*$""", RegexOption.IGNORE_CASE)
+    private val NOISE by lazy {
+        Regex(
+            """\((?:from|feat\\.?|official|lyrical|video|audio|remix|music video|visualizer)[^)]*\)|\[[^]]*]|""" +
+                """\b(?:official (?:video|audio|music video)|lyrical|full song|4k video)\b""",
+            RegexOption.IGNORE_CASE,
+        )
+    }
+    private val BRACKETED_CONTENT by lazy { Regex("""\s*[\(\[].*?[\)\]]""") }
+    private val NON_ALPHANUMERIC by lazy { Regex("[^\\p{L}\\p{N}\\s]") }
+    private val YOU_MIGHT_ALSO_LIKE by lazy { Regex("""\d*You might also like""", RegexOption.IGNORE_CASE) }
+    private val TRAILING_EMBED by lazy { Regex("""\d*Embed\s*$""", RegexOption.IGNORE_CASE) }
 }

--- a/app/src/main/java/com/music/bitchord/data/lyrics/LyricsRepository.kt
+++ b/app/src/main/java/com/music/bitchord/data/lyrics/LyricsRepository.kt
@@ -3,7 +3,7 @@ package com.music.bitchord.data.lyrics
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.supervisorScope
 
 /**
  * Where the player gets its lyrics.
@@ -60,7 +60,7 @@ object LyricsRepository {
         sources: Set<LyricsSource> = LyricsSource.entries.toSet(),
         order: List<LyricsSource> = LyricsSource.entries,
         prioritizeSyllableSync: Boolean = false,
-    ): Result? = coroutineScope {
+    ): Result? = supervisorScope {
         LyricsLog.clear()
         LyricsLog.i("Repository", "Looking up lyrics for \"$title\" by \"$artist\" (${durationMs / 1000}s)")
 
@@ -74,7 +74,11 @@ object LyricsRepository {
         val racing: List<Pair<LyricsSource, Deferred<List<LyricLine>?>>> = sequence.map { source ->
             val startMode = if (source == LyricsSource.GENIUS) kotlinx.coroutines.CoroutineStart.LAZY else kotlinx.coroutines.CoroutineStart.DEFAULT
             source to async(Dispatchers.IO, start = startMode) {
-                fetch(source, videoId, title, artist, durationMs, album)
+                runCatching {
+                    fetch(source, videoId, title, artist, durationMs, album)
+                }.onFailure {
+                    LyricsLog.e(source.label, "Source failed: ${it::class.simpleName}: ${it.message}")
+                }.getOrNull()
             }
         }
 
@@ -94,11 +98,11 @@ object LyricsRepository {
                 val lines = runCatching { job.await() }.getOrNull() ?: continue
                 if (lines.any { it.isWordSynced }) {
                     LyricsLog.s("Repository", "Word-synced match from ${source.label}")
-                    return@coroutineScope result(source, lines)
+                    return@supervisorScope result(source, lines)
                 }
                 if (!prioritizeSyllableSync && lines.any { it.timeMs > 0 }) {
                     LyricsLog.s("Repository", "Line-synced match from ${source.label}")
-                    return@coroutineScope result(source, lines)
+                    return@supervisorScope result(source, lines)
                 }
                 if (lineSynced == null) lineSynced = result(source, lines)
             }

--- a/app/src/main/java/com/music/bitchord/data/lyrics/LyricsTranslation.kt
+++ b/app/src/main/java/com/music/bitchord/data/lyrics/LyricsTranslation.kt
@@ -1,0 +1,160 @@
+package com.music.bitchord.data.lyrics
+
+import com.google.mlkit.common.model.DownloadConditions
+import com.google.mlkit.nl.languageid.LanguageIdentification
+import com.google.mlkit.nl.translate.TranslateLanguage
+import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.Translator
+import com.google.mlkit.nl.translate.TranslatorOptions
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.tasks.await
+import java.text.BreakIterator
+import java.util.Locale
+
+enum class LyricsTranslationStage { IDENTIFYING, DOWNLOADING_MODEL, TRANSLATING }
+
+sealed interface LyricsTranslationState {
+    data object Idle : LyricsTranslationState
+    data class Loading(val targetLanguageTag: String, val stage: LyricsTranslationStage) : LyricsTranslationState
+    data class Ready(
+        val targetLanguageTag: String,
+        val sourceLanguageTag: String,
+        val lines: List<LyricLine>,
+    ) : LyricsTranslationState
+    data class AlreadyInTargetLanguage(val targetLanguageTag: String) : LyricsTranslationState
+    data class Unavailable(val targetLanguageTag: String) : LyricsTranslationState
+}
+
+object LyricsTranslation {
+    suspend fun translate(
+        lines: List<LyricLine>,
+        targetLanguageTag: String,
+        onStage: (LyricsTranslationStage) -> Unit,
+    ): LyricsTranslationState {
+        val target = supportedTag(targetLanguageTag)
+            ?: return LyricsTranslationState.Unavailable(targetLanguageTag)
+        val sample = lines.asSequence()
+            .flatMap { sequenceOf(it.text, it.background?.text.orEmpty()) }
+            .filter { it.isNotBlank() }
+            .joinToString("\n")
+            .take(4000)
+        if (sample.isBlank()) return LyricsTranslationState.Unavailable(target)
+
+        onStage(LyricsTranslationStage.IDENTIFYING)
+        val identifier = LanguageIdentification.getClient()
+        val source = try {
+            supportedTag(identifier.identifyLanguage(sample).await())
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            null
+        } finally {
+            identifier.close()
+        } ?: return LyricsTranslationState.Unavailable(target)
+        if (source == target) return LyricsTranslationState.AlreadyInTargetLanguage(target)
+
+        val translator = Translation.getClient(
+            TranslatorOptions.Builder().setSourceLanguage(source).setTargetLanguage(target).build(),
+        )
+        return try {
+            onStage(LyricsTranslationStage.DOWNLOADING_MODEL)
+            translator.downloadModelIfNeeded(DownloadConditions.Builder().build()).await()
+            onStage(LyricsTranslationStage.TRANSLATING)
+            val texts = lines.asSequence()
+                .filterNot { it.isGap }
+                .flatMap { sequenceOf(it.text, it.background?.text) }
+                .filterNotNull()
+                .filter { it.isNotBlank() }
+                .distinct()
+                .associateWith { translator.translate(it).await() }
+            LyricsTranslationState.Ready(
+                target,
+                source,
+                lines.map { line ->
+                    if (line.isGap) line else {
+                        val translated = texts[line.text]?.trim().orEmpty().ifBlank { line.text }
+                        val background = line.background?.let { backing ->
+                            backing.retimedForTranslation(
+                                texts[backing.text]?.trim().orEmpty().ifBlank { backing.text },
+                            )
+                        }
+                        line.retimedForTranslation(translated, background)
+                    }
+                },
+            )
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            LyricsTranslationState.Unavailable(target)
+        } finally {
+            translator.close()
+        }
+    }
+
+    private fun supportedTag(tag: String): String? {
+        TranslateLanguage.fromLanguageTag(tag)?.let { return it }
+        val base = Locale.forLanguageTag(tag).language.takeIf { it.isNotBlank() } ?: return null
+        return TranslateLanguage.fromLanguageTag(base)
+    }
+}
+
+internal fun LyricLine.retimedForTranslation(
+    translatedText: String,
+    translatedBackground: LyricLine? = background,
+): LyricLine {
+    val clean = translatedText.trim()
+    if (clean.isEmpty()) return copy(background = translatedBackground)
+    val translatedWords = if (words.isEmpty()) emptyList() else {
+        translationTokenRanges(clean).map { range ->
+            val denominator = clean.length.coerceAtLeast(1).toFloat()
+            LyricWord(
+                timeAtTextFraction(range.first / denominator),
+                timeAtTextFraction((range.last + 1) / denominator),
+                clean.substring(range),
+            )
+        }
+    }
+    return copy(text = clean, words = translatedWords, background = translatedBackground)
+}
+
+private fun translationTokenRanges(text: String): List<IntRange> {
+    val words = Regex("\\S+").findAll(text).map { it.range }.toList()
+    if (words.size != 1 || text.any(Char::isWhitespace)) return words
+    val breaker = BreakIterator.getCharacterInstance(Locale.ROOT).apply { setText(text) }
+    val graphemes = mutableListOf<IntRange>()
+    var start = breaker.first()
+    var end = breaker.next()
+    while (end != BreakIterator.DONE) {
+        if (text.substring(start, end).isNotBlank()) graphemes += start until end
+        start = end
+        end = breaker.next()
+    }
+    return graphemes.ifEmpty { words }
+}
+
+private fun LyricLine.timeAtTextFraction(fraction: Float): Long {
+    val target = fraction.coerceIn(0f, 1f) * text.length.coerceAtLeast(1)
+    val first = words.first()
+    val last = words.last()
+    if (target <= 0f) return first.startMs
+    if (target >= text.length) return last.endMs
+    var cursor = 0
+    var previousChar = 0
+    var previousTime = first.startMs
+    words.forEach { word ->
+        val start = text.indexOf(word.text, cursor).takeIf { it >= 0 } ?: cursor
+        val end = (start + word.text.length).coerceAtMost(text.length)
+        if (target <= start) return interpolateTime(previousChar, start, previousTime, word.startMs, target)
+        if (target <= end) return interpolateTime(start, end, word.startMs, word.endMs, target)
+        cursor = end
+        previousChar = end
+        previousTime = word.endMs
+    }
+    return interpolateTime(previousChar, text.length, previousTime, last.endMs, target)
+}
+
+private fun interpolateTime(startChar: Int, endChar: Int, startMs: Long, endMs: Long, target: Float): Long {
+    if (endChar <= startChar || endMs <= startMs) return startMs
+    val through = ((target - startChar) / (endChar - startChar)).coerceIn(0f, 1f)
+    return (startMs + (endMs - startMs) * through).toLong()
+}

--- a/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/music/bitchord/data/settings/AppSettings.kt
@@ -399,6 +399,9 @@ object AppSettings {
     /** The databases [syncedLyrics] may ask. Empty is the same as off. */
     val lyricsSources = MutableStateFlow(LyricsSource.entries.toSet())
 
+    /** Target language used when translating lyrics from the player. */
+    val lyricsTranslationLanguage = MutableStateFlow("en")
+
     /**
      * The order [lyricsSources] are asked in — see [LyricsRepository][com.music.bitchord.data.lyrics.LyricsRepository]:
      * every enabled source is asked at once, but a higher-priority one still
@@ -662,6 +665,7 @@ object AppSettings {
         legacyMeshGradient.value = prefs.getBoolean(KEY_LEGACY_MESH_GRADIENT, false)
         syncedLyrics.value = prefs.getBoolean(KEY_SYNCED_LYRICS, true)
         lyricsSources.value = readLyricsSources()
+        lyricsTranslationLanguage.value = prefs.getString(KEY_LYRICS_TRANSLATION_LANGUAGE, "en") ?: "en"
         lyricsSourceOrder.value = readLyricsSourceOrder()
         prioritizeSyllableSync.value = prefs.getBoolean(KEY_PRIORITIZE_SYLLABLE_SYNC, false)
         showLyricsLogs.value = prefs.getBoolean(KEY_SHOW_LYRICS_LOGS, false)
@@ -956,6 +960,11 @@ object AppSettings {
     fun setSyncedLyrics(value: Boolean) {
         syncedLyrics.value = value
         prefs.edit().putBoolean(KEY_SYNCED_LYRICS, value).apply()
+    }
+
+    fun setLyricsTranslationLanguage(value: String) {
+        lyricsTranslationLanguage.value = value
+        prefs.edit().putString(KEY_LYRICS_TRANSLATION_LANGUAGE, value).apply()
     }
 
     fun setLyricsSources(value: Set<LyricsSource>) {
@@ -1430,6 +1439,7 @@ object AppSettings {
     private const val KEY_LEGACY_MESH_GRADIENT = "legacy_mesh_gradient"
     private const val KEY_SYNCED_LYRICS = "synced_lyrics"
     private const val KEY_LYRICS_SOURCES = "lyrics_sources"
+    private const val KEY_LYRICS_TRANSLATION_LANGUAGE = "lyrics_translation_language"
     private const val KEY_LYRICS_SOURCE_ORDER = "lyrics_source_order"
     private const val KEY_PRIORITIZE_SYLLABLE_SYNC = "prioritize_syllable_sync"
     private const val KEY_SHOW_LYRICS_LOGS = "show_lyrics_logs"

--- a/app/src/main/java/com/music/bitchord/ui/MainViewModel.kt
+++ b/app/src/main/java/com/music/bitchord/ui/MainViewModel.kt
@@ -18,6 +18,9 @@ import com.music.bitchord.data.lyrics.EmbeddedLyrics
 import com.music.bitchord.data.lyrics.LyricLine
 import com.music.bitchord.data.lyrics.LyricsRepository
 import com.music.bitchord.data.lyrics.LyricsSource
+import com.music.bitchord.data.lyrics.LyricsTranslation
+import com.music.bitchord.data.lyrics.LyricsTranslationStage
+import com.music.bitchord.data.lyrics.LyricsTranslationState
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.innertube.Innertube
 import com.music.bitchord.data.innertube.PlaybackTracker
@@ -229,7 +232,12 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     private val _lyricsChecked = MutableStateFlow(false)
     val lyricsChecked: StateFlow<Boolean> = _lyricsChecked.asStateFlow()
 
+    private val _lyricsTranslation = MutableStateFlow<LyricsTranslationState>(LyricsTranslationState.Idle)
+    val lyricsTranslation: StateFlow<LyricsTranslationState> = _lyricsTranslation.asStateFlow()
+
     private var lyricsJob: Job? = null
+    private var lyricsTranslationJob: Job? = null
+    private val lyricsTranslationGeneration = AtomicLong(0L)
 
     /**
      * What the loaded lyrics are for. Both the track *and* the settings that
@@ -265,6 +273,9 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
         val key = videoId to sources
         if (lyricsFor == key) return
         lyricsFor = key
+        lyricsTranslationJob?.cancel()
+        lyricsTranslationGeneration.incrementAndGet()
+        _lyricsTranslation.value = LyricsTranslationState.Idle
         _lyrics.value = null
         _lyricsSource.value = null
         lyricsJob?.cancel()
@@ -304,6 +315,32 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
             _lyricsSource.value = found?.source
             _lyricsChecked.value = true
         }
+    }
+
+    fun translateLyrics() {
+        val sourceLines = _lyrics.value?.takeIf { it.isNotEmpty() } ?: return
+        val trackId = lyricsFor?.first ?: return
+        val target = AppSettings.lyricsTranslationLanguage.value
+        if (_lyricsTranslation.value is LyricsTranslationState.Loading) return
+        lyricsTranslationJob?.cancel()
+        val generation = lyricsTranslationGeneration.incrementAndGet()
+        lyricsTranslationJob = viewModelScope.launch {
+            LyricsTranslation.translate(sourceLines, target) { stage ->
+                if (generation == lyricsTranslationGeneration.get() && lyricsFor?.first == trackId) {
+                    _lyricsTranslation.value = LyricsTranslationState.Loading(target, stage)
+                }
+            }.also { result ->
+                if (generation == lyricsTranslationGeneration.get() && lyricsFor?.first == trackId) {
+                    _lyricsTranslation.value = result
+                }
+            }
+        }
+    }
+
+    fun showOriginalLyrics() {
+        lyricsTranslationJob?.cancel()
+        lyricsTranslationGeneration.incrementAndGet()
+        _lyricsTranslation.value = LyricsTranslationState.Idle
     }
 
     private val _account = MutableStateFlow<Account?>(null)

--- a/app/src/main/java/com/music/bitchord/ui/components/AppLanguageDialog.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/AppLanguageDialog.kt
@@ -1,6 +1,13 @@
 package com.music.bitchord.ui.components
 
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -21,8 +28,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -79,6 +89,16 @@ fun AppLanguageDialog(
 ) {
     val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
     val shape = RoundedCornerShape(ALERT_CORNER)
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+    LaunchedEffect(visible) {
+        if (!visible) {
+            kotlinx.coroutines.delay(LANGUAGE_DIALOG_EXIT_MS)
+            onDismiss()
+        }
+    }
+    fun dismissAnimated() { visible = false }
+    BackHandler(enabled = visible) { dismissAnimated() }
     val currentLanguage = AppCompatDelegate.getApplicationLocales().get(0)?.language
         ?: Locale.getDefault().language
 
@@ -89,10 +109,15 @@ fun AppLanguageDialog(
             .clickable(
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() },
-                onClick = onDismiss,
+                onClick = ::dismissAnimated,
             ),
         contentAlignment = Alignment.Center,
     ) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn(tween(LANGUAGE_DIALOG_ANIMATION_MS)) + scaleIn(tween(LANGUAGE_DIALOG_ANIMATION_MS), initialScale = 0.94f),
+            exit = fadeOut(tween(LANGUAGE_DIALOG_ANIMATION_MS)) + scaleOut(tween(LANGUAGE_DIALOG_ANIMATION_MS), targetScale = 0.94f),
+        ) {
         Column(
             modifier = Modifier
                 .width(ALERT_WIDTH)
@@ -101,10 +126,12 @@ fun AppLanguageDialog(
                     if (reduceDynamicBlur) {
                         Modifier.background(MaterialTheme.colorScheme.surface)
                     } else {
-                        Modifier.optimizedHazeEffect(
+                        Modifier
+                            .background(MaterialTheme.colorScheme.surface)
+                            .optimizedHazeEffect(
                             state = hazeState,
                             style = HazeMaterials.regular(MaterialTheme.colorScheme.surface),
-                        )
+                            )
                     },
                 )
                 // Swallows the tap before it reaches the scrim behind, so
@@ -151,13 +178,112 @@ fun AppLanguageDialog(
                         AppCompatDelegate.setApplicationLocales(
                             LocaleListCompat.forLanguageTags(language.tag),
                         )
-                        onDismiss()
+                        dismissAnimated()
                     },
                 )
             }
         }
+        }
     }
 }
+
+/** Same in-app language picker surface, usable for feature-specific languages. */
+@OptIn(ExperimentalHazeMaterialsApi::class)
+@Composable
+fun LanguagePickerDialog(
+    hazeState: HazeState,
+    titleRes: Int,
+    descriptionRes: Int,
+    selectedTag: String,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
+    val shape = RoundedCornerShape(ALERT_CORNER)
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+    LaunchedEffect(visible) {
+        if (!visible) {
+            kotlinx.coroutines.delay(LANGUAGE_DIALOG_EXIT_MS)
+            onDismiss()
+        }
+    }
+    fun dismissAnimated() { visible = false }
+    BackHandler(enabled = visible) { dismissAnimated() }
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(SCRIM_COLOR)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = ::dismissAnimated,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn(tween(LANGUAGE_DIALOG_ANIMATION_MS)) + scaleIn(tween(LANGUAGE_DIALOG_ANIMATION_MS), initialScale = 0.94f),
+            exit = fadeOut(tween(LANGUAGE_DIALOG_ANIMATION_MS)) + scaleOut(tween(LANGUAGE_DIALOG_ANIMATION_MS), targetScale = 0.94f),
+        ) {
+        Column(
+            modifier = Modifier
+                .width(ALERT_WIDTH)
+                .clip(shape)
+                .then(
+                    if (reduceDynamicBlur) Modifier.background(MaterialTheme.colorScheme.surface)
+                    else Modifier
+                        .background(MaterialTheme.colorScheme.surface)
+                        .optimizedHazeEffect(
+                            state = hazeState,
+                            style = HazeMaterials.regular(MaterialTheme.colorScheme.surface),
+                        )
+                )
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = {},
+                ),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 19.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(titleRes),
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.W600,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = stringResource(descriptionRes),
+                    modifier = Modifier.padding(top = 4.dp),
+                    style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp, lineHeight = 17.sp),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            SUPPORTED_LANGUAGES.forEach { language ->
+                AlertRule()
+                LanguageRow(
+                    language = language,
+                    selected = language.tag == selectedTag,
+                    onClick = { onSelect(language.tag); dismissAnimated() },
+                )
+            }
+        }
+        }
+    }
+}
+
+private const val LANGUAGE_DIALOG_ANIMATION_MS = 220
+private const val LANGUAGE_DIALOG_EXIT_MS = 220L
 
 @Composable
 private fun LanguageRow(language: AppLanguage, selected: Boolean, onClick: () -> Unit) {

--- a/app/src/main/java/com/music/bitchord/ui/components/LyricsSourcesDialog.kt
+++ b/app/src/main/java/com/music/bitchord/ui/components/LyricsSourcesDialog.kt
@@ -2,6 +2,13 @@ package com.music.bitchord.ui.components
 
 import com.music.bitchord.R
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -25,6 +32,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -50,6 +58,9 @@ import com.music.bitchord.data.settings.AppSettings
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
+
+private const val SOURCES_DIALOG_ANIMATION_MS = 220
+private const val SOURCES_DIALOG_EXIT_MS = 220L
 
 /**
  * Which lyric databases the player is allowed to ask.
@@ -78,6 +89,16 @@ fun LyricsSourcesDialog(
     val savedOrder by AppSettings.lyricsSourceOrder.collectAsStateWithLifecycle()
     val prioritizeSyllableSync by AppSettings.prioritizeSyllableSync.collectAsStateWithLifecycle()
     val shape = RoundedCornerShape(ALERT_CORNER)
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+    LaunchedEffect(visible) {
+        if (!visible) {
+            kotlinx.coroutines.delay(SOURCES_DIALOG_EXIT_MS)
+            onDismiss()
+        }
+    }
+    fun dismissAnimated() { visible = false }
+    BackHandler(enabled = visible) { dismissAnimated() }
 
     Box(
         modifier = modifier
@@ -86,10 +107,17 @@ fun LyricsSourcesDialog(
             .clickable(
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() },
-                onClick = onDismiss,
+                onClick = ::dismissAnimated,
             ),
         contentAlignment = Alignment.Center,
     ) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn(tween(SOURCES_DIALOG_ANIMATION_MS)) +
+                scaleIn(tween(SOURCES_DIALOG_ANIMATION_MS), initialScale = 0.94f),
+            exit = fadeOut(tween(SOURCES_DIALOG_ANIMATION_MS)) +
+                scaleOut(tween(SOURCES_DIALOG_ANIMATION_MS), targetScale = 0.94f),
+        ) {
         Column(
             modifier = Modifier
                 .width(ALERT_WIDTH)
@@ -98,10 +126,12 @@ fun LyricsSourcesDialog(
                     if (reduceDynamicBlur) {
                         Modifier.background(MaterialTheme.colorScheme.surface)
                     } else {
-                        Modifier.optimizedHazeEffect(
+                        Modifier
+                            .background(MaterialTheme.colorScheme.surface)
+                            .optimizedHazeEffect(
                             state = hazeState,
                             style = HazeMaterials.regular(MaterialTheme.colorScheme.surface),
-                        )
+                            )
                     },
                 )
                 // Swallows the tap before it reaches the scrim behind, so
@@ -168,7 +198,8 @@ fun LyricsSourcesDialog(
                 onClick = AppSettings::resetLyricsSourceSettings,
             )
             AlertRule()
-            AlertAction(label = stringResource(R.string.done), emphasised = true, onClick = onDismiss)
+            AlertAction(label = stringResource(R.string.done), emphasised = true, onClick = ::dismissAnimated)
+        }
         }
     }
 }

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -17,7 +17,12 @@ import android.window.OnBackInvokedDispatcher
 import androidx.activity.compose.BackHandler
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearEasing
@@ -29,6 +34,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -49,6 +55,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.blur
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState
 import kotlinx.coroutines.delay
 import kotlin.math.abs
@@ -93,6 +100,7 @@ import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Translate
 import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -194,6 +202,7 @@ import com.music.bitchord.data.canvas.CanvasRepository
 import com.music.bitchord.data.lyrics.Genius
 import com.music.bitchord.data.lyrics.LyricLine
 import com.music.bitchord.data.lyrics.LyricsSource
+import com.music.bitchord.data.lyrics.LyricsTranslationState
 import com.music.bitchord.ui.components.LyricsLogConsole
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.AudioQuality
@@ -583,6 +592,10 @@ fun NowPlayingScreen(
     lyrics: List<LyricLine>?,
     lyricsSource: LyricsSource?,
     lyricsUnavailable: Boolean,
+    lyricsChecked: Boolean = false,
+    lyricsTranslation: LyricsTranslationState = LyricsTranslationState.Idle,
+    onTranslateLyrics: () -> Unit = {},
+    onShowOriginalLyrics: () -> Unit = {},
     /** The width of the window the player is in — see [fullBleedArtworkAvailable]. */
     windowWidth: Dp,
     /**
@@ -606,7 +619,14 @@ fun NowPlayingScreen(
     val playerHaze = remember { HazeState() }
 
     val syncedLyricsEnabled by AppSettings.syncedLyrics.collectAsStateWithLifecycle()
+    val lyricsTranslationLanguage by AppSettings.lyricsTranslationLanguage.collectAsStateWithLifecycle()
     val hideVolumeBar by AppSettings.hideVolumeBar.collectAsStateWithLifecycle()
+    val effectiveTranslation = when (val translation = lyricsTranslation) {
+        is LyricsTranslationState.Ready -> translation.takeIf {
+            it.targetLanguageTag == lyricsTranslationLanguage
+        } ?: LyricsTranslationState.Idle
+        else -> translation
+    }
 
     // Animated cover art: the looping video some labels publish alongside a
     // release, laid over the sleeve. A miss is the normal answer — see
@@ -682,11 +702,23 @@ fun NowPlayingScreen(
     // The queue lives inside the player, Apple-style, rather than in a sheet.
     var queueOpen by remember { mutableStateOf(false) }
     var lyricsOpen by remember { mutableStateOf(false) }
+    var showingTranslation by remember(song.videoId) { mutableStateOf(false) }
+    var showTranslationNotice by remember(song.videoId) { mutableStateOf(false) }
     var lyricsLogsOpen by remember { mutableStateOf(false) }
     val showLyricsLogsEnabled by AppSettings.showLyricsLogs.collectAsStateWithLifecycle()
     LaunchedEffect(song.videoId) {
-        lyricsOpen = false
-        lyricsLogsOpen = false
+        showingTranslation = false
+    }
+    LaunchedEffect(effectiveTranslation) {
+        if (effectiveTranslation is LyricsTranslationState.Ready ||
+            effectiveTranslation is LyricsTranslationState.AlreadyInTargetLanguage ||
+            effectiveTranslation is LyricsTranslationState.Unavailable
+        ) {
+            showingTranslation = true
+            showTranslationNotice = true
+            delay(5_000)
+            showTranslationNotice = false
+        }
     }
     // A brief, non-modal confirmation that the three-dot menu now contains a
     // way back to the original YouTube rendition. The control keeps its usual
@@ -1970,6 +2002,11 @@ fun NowPlayingScreen(
                     } else {
                         LyricsPanel(
                             lines = lyrics.orEmpty(),
+                            translatedLines = (effectiveTranslation as? LyricsTranslationState.Ready)?.lines,
+                            showTranslation = showingTranslation,
+                            trackKey = song.videoId,
+                            lyricsChecked = lyricsChecked,
+                            lyricsUnavailable = lyricsUnavailable,
                             positionMs = positionMs,
                             isPlaying = isPlaying,
                             onSeekToLine = onSeek,
@@ -2047,34 +2084,22 @@ fun NowPlayingScreen(
                         // the timestamps below are pulled back up into it.
                         .offset(y = 6.dp),
                 ) {
-                    if (!lyrics.isNullOrEmpty()) {
-                        CurrentLyricLine(
-                            lines = lyrics,
-                            trackKey = song.videoId,
-                            positionMs = positionMs,
-                            isPlaying = isPlaying,
-                            durationMs = durationMs,
-                            // Still visible over the queue, so still a valid way
-                            // in: opens the same full lyrics panel it always has,
-                            // closing the queue behind it the same way the "Up
-                            // next" glyph closes lyrics behind the queue.
-                            onClick = {
-                                queueOpen = false
-                                lyricsOpen = true
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    } else if (lyricsUnavailable) {
-                        LyricsUnavailableLine(
-                            trackKey = song.videoId,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    } else {
-                        LyricsLoadingLine(
-                            trackKey = song.videoId,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
+                    CurrentLyricLine(
+                        lines = if (showingTranslation) {
+                            (effectiveTranslation as? LyricsTranslationState.Ready)?.lines ?: lyrics.orEmpty()
+                        } else lyrics.orEmpty(),
+                        trackKey = song.videoId,
+                        positionMs = positionMs,
+                        isPlaying = isPlaying,
+                        durationMs = durationMs,
+                        lyricsChecked = lyricsChecked,
+                        lyricsUnavailable = lyricsUnavailable,
+                        onClick = {
+                            queueOpen = false
+                            lyricsOpen = true
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
                 }
             }
             val transitionWindow by AppSettings.smartTransitionWindow.collectAsStateWithLifecycle()
@@ -2200,6 +2225,73 @@ fun NowPlayingScreen(
                         }
                         Spacer(Modifier.width(8.dp))
                     }
+                    val translationTarget = when (val state = effectiveTranslation) {
+                        is LyricsTranslationState.Loading -> state.targetLanguageTag
+                        is LyricsTranslationState.Ready -> state.targetLanguageTag
+                        is LyricsTranslationState.AlreadyInTargetLanguage -> state.targetLanguageTag
+                        is LyricsTranslationState.Unavailable -> state.targetLanguageTag
+                        LyricsTranslationState.Idle -> null
+                    }?.let { Locale.forLanguageTag(it).getDisplayLanguage(Locale.getDefault()) }
+                    val translationStatus = when (val state = effectiveTranslation) {
+                        is LyricsTranslationState.Loading -> when (state.stage) {
+                            com.music.bitchord.data.lyrics.LyricsTranslationStage.IDENTIFYING ->
+                                stringResource(R.string.lyrics_translation_preparing)
+                            com.music.bitchord.data.lyrics.LyricsTranslationStage.DOWNLOADING_MODEL ->
+                                stringResource(R.string.lyrics_translation_downloading, translationTarget.orEmpty())
+                            com.music.bitchord.data.lyrics.LyricsTranslationStage.TRANSLATING ->
+                                stringResource(R.string.lyrics_translation_translating, translationTarget.orEmpty())
+                        }
+                        is LyricsTranslationState.Ready ->
+                            stringResource(R.string.lyrics_translated_to, translationTarget.orEmpty())
+                        is LyricsTranslationState.AlreadyInTargetLanguage ->
+                            stringResource(R.string.lyrics_already_in_language, translationTarget.orEmpty())
+                        is LyricsTranslationState.Unavailable ->
+                            stringResource(R.string.lyrics_translation_unavailable)
+                        LyricsTranslationState.Idle -> stringResource(R.string.lyrics_translate)
+                    }
+                    Box(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .aspectRatio(1f, matchHeightConstraintsFirst = true)
+                            .clip(CircleShape)
+                            .background(
+                                if (showingTranslation) Color.White.copy(alpha = 0.22f)
+                                else Color.White.copy(alpha = 0.10f),
+                            )
+                            .clickable(
+                                enabled = effectiveTranslation !is LyricsTranslationState.Loading,
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                            ) {
+                                haptics.play(Haptic.Tap)
+                                if (effectiveTranslation is LyricsTranslationState.Ready) {
+                                    showingTranslation = !showingTranslation
+                                    showTranslationNotice = false
+                                } else {
+                                    showTranslationNotice = true
+                                    onTranslateLyrics()
+                                }
+                            },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (effectiveTranslation is LyricsTranslationState.Loading) {
+                            CircularProgressIndicator(
+                                color = Color.White.copy(alpha = 0.85f),
+                                strokeWidth = 2.dp,
+                                modifier = Modifier.size(19.dp),
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Rounded.Translate,
+                                contentDescription = stringResource(
+                                    if (showingTranslation) R.string.lyrics_show_original else R.string.lyrics_translate,
+                                ),
+                                tint = Color.White.copy(alpha = 0.8f),
+                                modifier = Modifier.size(23.dp),
+                            )
+                        }
+                    }
+                    Spacer(Modifier.width(8.dp))
                     // Source credit pill — same style as original, but sits between
                     // the two icon buttons and fills leftover horizontal space.
                     Box(
@@ -2210,17 +2302,27 @@ fun NowPlayingScreen(
                             .padding(horizontal = 18.dp, vertical = 8.dp),
                         contentAlignment = Alignment.Center,
                     ) {
-                        Text(
-                            text = when {
-                                lyricsSource != null -> stringResource(R.string.lyrics_by, lyricsSource.label)
-                                lyrics.isNullOrEmpty() -> stringResource(R.string.no_lyrics_found)
-                                else -> stringResource(R.string.lyrics_saved_with_download)
-                            },
-                            style = MaterialTheme.typography.labelLarge,
-                            color = Color.White.copy(alpha = 0.7f),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                        val sourceCredit = when {
+                            lyricsSource != null -> stringResource(R.string.lyrics_by, lyricsSource.label)
+                            lyrics.isNullOrEmpty() -> stringResource(R.string.no_lyrics_found)
+                            else -> stringResource(R.string.lyrics_saved_with_download)
+                        }
+                        Crossfade(
+                            targetState = if (showTranslationNotice) translationStatus else sourceCredit,
+                            animationSpec = tween(420),
+                            label = "lyricsTranslationNotice",
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { text ->
+                            Text(
+                                text = text,
+                                style = MaterialTheme.typography.labelLarge,
+                                color = Color.White.copy(alpha = 0.7f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
                     }
                     Spacer(Modifier.width(8.dp))
                     Box(
@@ -2775,6 +2877,11 @@ private fun ContentDrawScope.sweepTo(layout: TextLayoutResult, revealedChars: Fl
 @Composable
 private fun LyricsPanel(
     lines: List<LyricLine>,
+    translatedLines: List<LyricLine>?,
+    showTranslation: Boolean,
+    trackKey: Any,
+    lyricsChecked: Boolean,
+    lyricsUnavailable: Boolean,
     positionMs: Long,
     isPlaying: Boolean,
     onSeekToLine: (Long) -> Unit,
@@ -2799,6 +2906,8 @@ private fun LyricsPanel(
         }
     }
     val listState = rememberLazyListState()
+    var openingVisibleIndices by remember(trackKey) { mutableStateOf<Set<Int>?>(null) }
+    var openingAnimationActive by remember(trackKey) { mutableStateOf(false) }
     val keepScroll = remember(listState) { keepScrollInList(listState) }
     var browsing by remember { mutableStateOf(false) }
     val reduceDynamicBlur by AppSettings.reduceDynamicBlur.collectAsStateWithLifecycle()
@@ -2851,20 +2960,39 @@ private fun LyricsPanel(
         }
     }
 
+    LaunchedEffect(trackKey, lines.isNotEmpty()) {
+        if (!lines.isNotEmpty()) return@LaunchedEffect
+        openingVisibleIndices = null
+        openingAnimationActive = true
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.map { it.index }.toSet() }
+            .first { it.isNotEmpty() }
+            .let { openingVisibleIndices = it }
+        delay(900)
+        openingAnimationActive = false
+    }
+
     if (lines.isEmpty()) {
         Box(modifier, contentAlignment = Alignment.Center) {
-            Text(
-                text = stringResource(R.string.no_lyrics_for_track),
-                style = MaterialTheme.typography.titleMedium,
-                color = Color.White.copy(alpha = 0.6f),
+            LyricEmptyState(
+                trackKey = trackKey,
+                checked = lyricsChecked,
+                unavailable = lyricsUnavailable,
             )
         }
         return
     }
 
-    LazyColumn(
+    val displayedLines = if (showTranslation && translatedLines?.size == lines.size) {
+        translatedLines
+    } else {
+        lines
+    }
+
+    Column(modifier) {
+        LazyColumn(
         state = listState,
-        modifier = modifier
+        modifier = Modifier
+            .weight(1f)
             .bleedHorizontally(PLAYER_GUTTER)
             .nestedScroll(keepScroll)
             .fadingEdges(),
@@ -2876,12 +3004,36 @@ private fun LyricsPanel(
             horizontal = PLAYER_GUTTER - GLOW_ROOM,
         ),
         verticalArrangement = Arrangement.spacedBy(0.dp),
-    ) {
-        itemsIndexed(lines) { index, line ->
+        ) {
+        itemsIndexed(displayedLines) { index, line ->
+            val openingIndex = openingVisibleIndices?.toList()?.indexOf(index)?.takeIf { it >= 0 }
+            val shouldAnimateOnOpening = openingAnimationActive && openingIndex != null
+            var entered by remember(trackKey, index) {
+                mutableStateOf(openingVisibleIndices != null && openingVisibleIndices?.contains(index) != true)
+            }
+            LaunchedEffect(trackKey, shouldAnimateOnOpening) {
+                if (shouldAnimateOnOpening) {
+                    delay(openingIndex!! * 35L)
+                    entered = true
+                }
+            }
+            val entryOffset by animateDpAsState(
+                targetValue = if (openingAnimationActive && !entered && !reduceAnimation) 100.dp else 0.dp,
+                animationSpec = spring(
+                    dampingRatio = 0.78f,
+                    stiffness = Spring.StiffnessLow,
+                ),
+                label = "lyricEntryOffset",
+            )
+            val entryModifier = if (openingAnimationActive && openingIndex != null) {
+                Modifier.offset(y = entryOffset)
+            } else {
+                Modifier
+            }
             if (!isSynced && Genius.isSectionHeader(line.text)) {
                 val sectionTitle = line.text.removePrefix("[").removeSuffix("]").trim()
                 Column(
-                    modifier = Modifier
+                    modifier = entryModifier
                         .fillMaxWidth()
                         .padding(top = if (index == 0) 6.dp else 24.dp, bottom = 8.dp)
                         .padding(horizontal = GLOW_ROOM),
@@ -2907,7 +3059,7 @@ private fun LyricsPanel(
             }
 
             if (!isSynced && line.isGap) {
-                Spacer(Modifier.height(14.dp))
+                Spacer(entryModifier.height(14.dp))
                 return@itemsIndexed
             }
 
@@ -2943,7 +3095,7 @@ private fun LyricsPanel(
                     imageVector = BitChordIcons.MusicNote,
                     contentDescription = stringResource(R.string.instrumental),
                     tint = Color.White.copy(alpha = lineAlpha),
-                    modifier = Modifier
+                    modifier = entryModifier
                         .blur(blur, BlurredEdgeTreatment.Unbounded)
                         .clip(RoundedCornerShape(10.dp))
                         .clickable(enabled = isSynced) { onSeekToLine(line.timeMs) }
@@ -2980,7 +3132,7 @@ private fun LyricsPanel(
                     animationSpec = tween(durationMillis = 420),
                     label = "lyricGlow",
                 )
-                val shape = Modifier
+                val shape = entryModifier
                     .fillMaxWidth()
                     .graphicsLayer {
                         scaleX = scale
@@ -2991,47 +3143,105 @@ private fun LyricsPanel(
                     .blur(blur, BlurredEdgeTreatment.Unbounded)
                     .clip(RoundedCornerShape(10.dp))
                     .clickable(enabled = isSynced) { onSeekToLine(line.timeMs) }
-                // Lead and answering vocal are one row: they are one line of
-                // the song, they scale and dim together, and tapping either
-                // seeks to the same place.
-                Column(modifier = shape) {
-                    PanelVoice(
-                        line = line,
-                        clock = clock,
-                        style = style,
-                        isActive = isActive,
-                        browsing = browsing,
-                        glowAlpha = glow,
-                        room = GLOW_ROOM,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    line.background?.let { backing ->
+                AnimatedContent(
+                    targetState = line,
+                    transitionSpec = {
+                        val duration = if (reduceAnimation) 0 else 380
+                        val fadeSpec = if (reduceAnimation) snap() else tween<Float>(duration)
+                        (fadeIn(fadeSpec) togetherWith fadeOut(fadeSpec)).using(
+                            SizeTransform(
+                                clip = false,
+                                sizeAnimationSpec = { _, _ ->
+                                    if (reduceAnimation) snap()
+                                    else tween(duration, easing = FastOutSlowInEasing)
+                                },
+                            )
+                        )
+                    },
+                    label = "lyricsTranslationLine",
+                    modifier = shape,
+                ) { renderedLine ->
+                    Column {
                         PanelVoice(
-                            line = backing.withoutBracketPunctuation(),
+                            line = renderedLine,
                             clock = clock,
-                            style = style.copy(
-                                fontSize = BACKING_FONT_SIZE,
-                                lineHeight = BACKING_LINE_HEIGHT,
-                            ),
+                            style = style,
                             isActive = isActive,
                             browsing = browsing,
-                            // No bloom on the second voice. The glow marks
-                            // what is being sung *at you*; putting it on both
-                            // makes the row read as two equal lines, which is
-                            // the thing this split exists to stop.
-                            glowAlpha = 0f,
-                            room = 0.dp,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                // No top inset: the lead's own bottom room is
-                                // the gap, which leaves the two voices closer
-                                // to each other than to the rows either side.
-                                .padding(start = GLOW_ROOM, end = GLOW_ROOM, bottom = GLOW_ROOM)
-                                .graphicsLayer { alpha = BACKING_ALPHA },
+                            glowAlpha = glow,
+                            room = GLOW_ROOM,
+                            modifier = Modifier.fillMaxWidth(),
                         )
+                        renderedLine.background?.let { backing ->
+                            PanelVoice(
+                                line = backing.withoutBracketPunctuation(),
+                                clock = clock,
+                                style = style.copy(
+                                    fontSize = BACKING_FONT_SIZE,
+                                    lineHeight = BACKING_LINE_HEIGHT,
+                                ),
+                                isActive = isActive,
+                                browsing = browsing,
+                                glowAlpha = 0f,
+                                room = 0.dp,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(start = GLOW_ROOM, end = GLOW_ROOM, bottom = GLOW_ROOM)
+                                    .graphicsLayer { alpha = BACKING_ALPHA },
+                            )
+                        }
                     }
                 }
             }
+        }
+        }
+    }
+}
+
+@Composable
+private fun LyricEmptyState(
+    trackKey: Any,
+    checked: Boolean,
+    unavailable: Boolean,
+) {
+    val loadingLines = stringArrayResource(R.array.lyrics_loading_lines)
+    val introLines = stringArrayResource(R.array.lyrics_intro_lines)
+    val message = when {
+        !checked -> remember(trackKey) { loadingLines.random() }
+        unavailable -> stringResource(R.string.lyrics_not_available)
+        else -> remember(trackKey) { introLines.random() }
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = PLAYER_GUTTER)
+            .clip(RoundedCornerShape(10.dp))
+            .animateContentSize(animationSpec = tween(360, easing = FastOutSlowInEasing)),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = BitChordIcons.MusicNote,
+            contentDescription = null,
+            tint = Color.White.copy(alpha = 0.65f),
+            modifier = Modifier.size(22.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.headlineSmall,
+            color = Color.White.copy(alpha = 0.72f),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        if (checked && !unavailable) {
+            Spacer(Modifier.width(8.dp))
+            Icon(
+                imageVector = BitChordIcons.ChevronRight,
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.55f),
+                modifier = Modifier.size(20.dp),
+            )
         }
     }
 }
@@ -3155,9 +3365,50 @@ private fun CurrentLyricLine(
     positionMs: Long,
     isPlaying: Boolean,
     durationMs: Long,
+    lyricsChecked: Boolean,
+    lyricsUnavailable: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    if (lines.isEmpty()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(onClick = onClick)
+                .padding(vertical = 4.dp),
+        ) {
+            Icon(
+                imageVector = BitChordIcons.MusicNote,
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.65f),
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = when {
+                    !lyricsChecked -> stringArrayResource(R.array.lyrics_loading_lines)
+                        .let { remember(trackKey) { it.random() } }
+                    lyricsUnavailable -> stringResource(R.string.lyrics_not_available)
+                    else -> stringArrayResource(R.array.lyrics_intro_lines)
+                        .let { remember(trackKey) { it.random() } }
+                },
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.White.copy(alpha = 0.72f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            Spacer(Modifier.width(6.dp))
+            Icon(
+                imageVector = BitChordIcons.ChevronRight,
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.5f),
+                modifier = Modifier.size(14.dp),
+            )
+        }
+        return
+    }
     val isSynced = remember(lines) { lines.any { it.timeMs > 0L } }
     if (!isSynced) {
         Row(
@@ -3175,7 +3426,7 @@ private fun CurrentLyricLine(
             )
             Spacer(Modifier.width(8.dp))
             Text(
-                text = "Lyrics available • Tap to view",
+                text = stringResource(R.string.lyrics_unsynced_preview),
                 style = MaterialTheme.typography.bodyMedium.copy(
                     fontSize = 13.5.sp,
                     fontWeight = FontWeight.Medium,
@@ -3183,6 +3434,14 @@ private fun CurrentLyricLine(
                 color = Color.White.copy(alpha = 0.85f),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            Spacer(Modifier.width(6.dp))
+            Icon(
+                imageVector = BitChordIcons.ChevronRight,
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.5f),
+                modifier = Modifier.size(14.dp),
             )
         }
         return

--- a/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
+++ b/app/src/main/java/com/music/bitchord/ui/screens/SettingsSheet.kt
@@ -117,6 +117,8 @@ import coil3.SingletonImageLoader
 import coil3.compose.AsyncImage
 import com.music.bitchord.ui.components.isGlassSupported
 import com.music.bitchord.ui.components.languageDisplayNameRes
+import com.music.bitchord.ui.components.LanguagePickerDialog
+import dev.chrisbanes.haze.HazeState
 import com.music.bitchord.ui.components.thumbnailBorder
 import com.music.bitchord.ui.icons.BitChordIcons
 import com.music.bitchord.ui.performance.resolvePerformanceRefreshRate
@@ -162,6 +164,7 @@ fun SettingsScreen(
     onSources: () -> Unit,
     onSpotifyCanvasAuth: () -> Unit,
     onAppLanguage: () -> Unit,
+    onLyricsTranslationLanguage: () -> Unit,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
@@ -192,6 +195,7 @@ fun SettingsScreen(
     val legacyMeshGradient by AppSettings.legacyMeshGradient.collectAsStateWithLifecycle()
     val syncedLyrics by AppSettings.syncedLyrics.collectAsStateWithLifecycle()
     val lyricsSources by AppSettings.lyricsSources.collectAsStateWithLifecycle()
+    val lyricsTranslationLanguage by AppSettings.lyricsTranslationLanguage.collectAsStateWithLifecycle()
     val showLyricsLogs by AppSettings.showLyricsLogs.collectAsStateWithLifecycle()
     val theme by AppSettings.themeMode.collectAsStateWithLifecycle()
     val sessionId by AppSettings.audioSessionId.collectAsStateWithLifecycle()
@@ -725,6 +729,14 @@ fun SettingsScreen(
             // sources are third-party services being reached on the user's
             // connection — which is the part worth being able to narrow.
             if (syncedLyrics) {
+                RowDivider()
+                SettingsRow(
+                    icon = Icons.Rounded.Language,
+                    title = stringResource(R.string.lyrics_translation_language),
+                    subtitle = stringResource(languageDisplayNameRes(lyricsTranslationLanguage)),
+                    trailing = { Chevron() },
+                    onClick = onLyricsTranslationLanguage,
+                )
                 RowDivider()
             SettingsRow(
                 icon = Icons.Rounded.BlurOn,

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -195,6 +195,17 @@
     <string name="synced_lyrics">Zsynchronizowany tekst</string>
     <string name="synced_lyrics_subtitle">Podświetla słowa na odtwarzaczu w miarę ich śpiewania</string>
     <string name="lyrics_sources">Źródła tekstów</string>
+    <string name="lyrics_translate">Przetłumacz tekst</string>
+    <string name="lyrics_show_original">Pokaż oryginalny tekst</string>
+    <string name="lyrics_translation_language">Język tłumaczenia</string>
+    <string name="lyrics_translation_language_subtitle">Język używany do tłumaczenia tekstów</string>
+    <string name="lyrics_translation_preparing">Wykrywanie języka tekstu...</string>
+    <string name="lyrics_translation_downloading">Pobieranie tłumaczenia na %1$s...</string>
+    <string name="lyrics_translation_translating">Tłumaczenie na %1$s...</string>
+    <string name="lyrics_translated_to">Przetłumaczono na %1$s</string>
+    <string name="lyrics_already_in_language">Tekst jest już w języku %1$s</string>
+    <string name="lyrics_translation_unavailable">Tłumaczenie niedostępne</string>
+    <string name="lyrics_unsynced_preview">Tekst piosenki</string>
     <string name="song_cache_limit">Limit pamięci podręcznej utworów</string>
     <string name="clear_song_cache">Wyczyść pamięć podręczną utworów</string>
     <string name="clear_song_cache_subtitle">Zwalnia miejsce zajmowane przez pobrane pliki audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,6 +233,17 @@
     <string name="animated_cover_art">Animated cover art</string>
     <string name="synced_lyrics">Synced lyrics</string>
     <string name="synced_lyrics_subtitle">Lights up the words on the player as they’re sung</string>
+    <string name="lyrics_translate">Translate lyrics</string>
+    <string name="lyrics_show_original">Show original lyrics</string>
+    <string name="lyrics_translation_language">Translation language</string>
+    <string name="lyrics_translation_language_subtitle">Language used for translated lyrics</string>
+    <string name="lyrics_translation_preparing">Detecting lyric language...</string>
+    <string name="lyrics_translation_downloading">Downloading %1$s translation...</string>
+    <string name="lyrics_translation_translating">Translating to %1$s...</string>
+    <string name="lyrics_translated_to">Translated to %1$s</string>
+    <string name="lyrics_already_in_language">Lyrics are already in %1$s</string>
+    <string name="lyrics_translation_unavailable">Translation unavailable</string>
+    <string name="lyrics_unsynced_preview">Lyrics</string>
     <string name="lyrics_sources">Lyrics sources</string>
     <string name="song_cache_limit">Song cache limit</string>
     <string name="clear_song_cache">Clear song cache</string>


### PR DESCRIPTION
### Added on-device lyrics translation using Google ML Kit
- You can now translate lyrics directly on the now playing screen with a new button.
- Added an option in settings to change your preferred translation language.
- Added smooth resize and fade animations when switching between original and translated lyrics.
- Lyrics panel can now be opened even without lyrics or while they are still downloading, and changing songs won't close it.
- Added smooth animations when opening the lyrics panel and when lyrics finish loading.
- Added fade and scale animations when opening or closing settings dialogs.
- Improved Genius scraper fallback with 3 query matching attempts:
  `full artist + title` ➔ `stripped brackets` ➔ `title only`
  *(added because music video titles often include bracketed text that breaks Genius search)*

Translation inspired by: https://github.com/kushagrasinghx/BitChord/pull/135
