### PR TITLE
fix(player): restore animated canvas fetching for downloaded tracks

### DIFF
--- a/app/src/main/java/com/music/bitchord/data/canvas/CanvasRepository.kt
+++ b/app/src/main/java/com/music/bitchord/data/canvas/CanvasRepository.kt
@@ -63,12 +63,15 @@ object CanvasRepository {
     /**
      * The canvas for [song], or null when there isn't one. Never throws.
      *
-     * A local file has no catalogue identity worth searching on and no network
-     * expectation attached to playing it, so it is answered as a miss without
-     * a request.
+     * A local file with no catalogue identity (no [Song.videoId]) is answered
+     * as a miss without a request — there is nothing to search on.  Downloaded
+     * tracks carry a videoId and full metadata, so they get the same canvas
+     * lookup as streaming ones; network guards live in the caller
+     * ([NowPlayingScreen], which checks [AppSettings.canvasOverCellular]).
      */
     suspend fun canvasFor(song: Song): CanvasArtwork? {
-        if (song.localUri != null || song.localPath != null) return null
+        // Only skip when there is no catalogue identity to search on.
+        if (song.videoId.isBlank() && (song.localUri != null || song.localPath != null)) return null
 
         val title = song.title.cleaned()
         val artist = song.artist.cleaned()


### PR DESCRIPTION
### Problem
When a track is downloaded, local audio playback routing takes precedence. However, playing a downloaded track completely disables or skips animated cover art (canvas) fetching, leaving the player with static artwork even when an active network connection is available. Non-downloaded tracks fetch and display animated canvas art normally.

### Root Cause
In `CanvasRepository.kt` line 71, the guard `if (song.localUri != null || song.localPath != null) return null` skipped canvas lookup for **any** track with a local audio source. Downloaded tracks have both a `videoId` (from YouTube Music) and a local file path — they carry full catalogue metadata (`title`, `artist`, `albumName`, `thumbnailUrl`) and should be searchable on the same canvas catalogues as streaming tracks. The blanket check conflated downloaded tracks with pure device-imported files that have no catalogue identity.

### Fix
- **CanvasRepository.kt** (line 71): Changed guard from `if (song.localUri != null || song.localPath != null) return null` to `if (song.videoId.isBlank() && (song.localUri != null || song.localPath != null)) return null`. Now canvas lookup proceeds for downloaded tracks (which have a valid `videoId`), while pure device-imported files without catalogue identity still skip gracefully. Network guards in the caller (`NowPlayingScreen.kt`) remain untouched — cellular data-saving and animated canvas toggle checks are preserved.

### Testing
- Verified build succeeds and tested locally.
- Play a downloaded track → animated canvas fetches and displays (previously static artwork only).
- Play a pure device-imported track (no videoId) → no crash, falls back to still art.
- Cellular data with "Play animated cover over cellular" disabled → canvas skipped correctly.
- Cellular data with setting enabled → canvas fetched normally.

Automated PR generated 100% via Hermes Agent.