### PR TITLE
feat: add app-language lyrics translation

### DIFF
--- a/app/src/main/java/com/music/bitchord/data/lyrics/LyricLine.kt
+++ b/app/src/main/java/com/music/bitchord/data/lyrics/LyricLine.kt
@@ -37,6 +37,8 @@ data class LyricLine(
     val words: List<LyricWord> = emptyList(),
     val sungUntilMs: Long? = null,
     val background: LyricLine? = null,
+    /** Display-only translation: drive its sweep and bloom from the original vocal. */
+    val timingSource: LyricLine? = null,
 ) {
     val isGap: Boolean get() = text.isEmpty()
 
@@ -78,6 +80,11 @@ data class LyricLine(
      * on rather than jumping ahead of the next word's first letter.
      */
     fun revealedChars(positionMs: Long): Float {
+        timingSource?.let { source ->
+            if (source.text.isEmpty()) return 0f
+            return (source.revealedChars(positionMs) / source.text.length)
+                .coerceIn(0f, 1f) * text.length
+        }
         if (words.isEmpty()) return if (positionMs >= timeMs) text.length.toFloat() else 0f
         var offset = 0
         words.forEachIndexed { index, word ->
@@ -121,6 +128,7 @@ data class LyricLine(
      * pauses dark and costs nothing to draw.
      */
     fun glowIntensity(positionMs: Long): Float {
+        timingSource?.let { return it.glowIntensity(positionMs) }
         val word = words.firstOrNull { positionMs < it.endMs } ?: return 0f
         if (positionMs < word.startMs) return 0f
 

--- a/app/src/main/java/com/music/bitchord/data/lyrics/LyricsTranslation.kt
+++ b/app/src/main/java/com/music/bitchord/data/lyrics/LyricsTranslation.kt
@@ -14,6 +14,7 @@ import java.util.zip.GZIPOutputStream
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -227,7 +228,13 @@ object LyricsTranslation {
             .header("Accept", "application/json")
             .post(body)
             .build()
-        val response = runCatching { client.newCall(request).awaitBody() }.getOrNull() ?: return null
+        val response = try {
+            client.newCall(request).awaitBody()
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: IOException) {
+            return null
+        }
         return runCatching {
             val root = json.parseToJsonElement(response).jsonArray
             val translatedBody = root[0].jsonArray.joinToString(separator = "") { segment ->
@@ -273,36 +280,29 @@ object LyricsTranslation {
             line.copy(
                 text = leadText,
                 words = retimeWords(line, leadText),
+                timingSource = line.takeIf { it.isWordSynced },
                 background = line.background?.let { source ->
                     val text = backing?.second ?: source.text
-                    source.copy(text = text, words = retimeWords(source, text))
+                    source.copy(
+                        text = text,
+                        words = retimeWords(source, text),
+                        timingSource = source.takeIf { it.isWordSynced },
+                    )
                 },
             )
         }
     }
 
     /**
-     * A translation changes word count, so source word boundaries cannot be
-     * copied. Re-spread the translated words across the exact original sung
-     * interval. The lyric sweep and line timing therefore remain continuous,
-     * while never pretending that a translated word has an exact phoneme stamp.
+     * Keep the source vocal bounds without inventing translated word timings.
+     * LyricLine.timingSource projects the original non-uniform character sweep
+     * onto the new text, preserving holds, pauses and the original glow envelope.
      */
     private fun retimeWords(source: LyricLine, translated: String): List<LyricWord> {
         if (source.words.isEmpty()) return emptyList()
-        val tokens = Regex("\\S+").findAll(translated).map { it.value }.toList()
-        if (tokens.isEmpty()) return emptyList()
+        if (translated.isEmpty()) return emptyList()
         val start = source.words.first().startMs
-        val end = source.words.last().endMs.coerceAtLeast(start + tokens.size)
-        val duration = end - start
-        val weights = tokens.map { token -> token.count(Char::isLetterOrDigit).coerceAtLeast(1) }
-        val total = weights.sum().coerceAtLeast(1)
-        var consumed = 0
-        return tokens.mapIndexed { index, token ->
-            val wordStart = start + duration * consumed / total
-            consumed += weights[index]
-            val wordEnd = if (index == tokens.lastIndex) end else start + duration * consumed / total
-            LyricWord(wordStart, wordEnd.coerceAtLeast(wordStart + 1), token)
-        }
+        return listOf(LyricWord(start, source.words.last().endMs, translated))
     }
 
     private fun canonicalLanguage(tag: String): String = when (

--- a/app/src/main/java/com/music/bitchord/data/lyrics/LyricsTranslation.kt
+++ b/app/src/main/java/com/music/bitchord/data/lyrics/LyricsTranslation.kt
@@ -1,0 +1,375 @@
+package com.music.bitchord.data.lyrics
+
+import android.content.Context
+import android.util.LruCache
+import com.music.bitchord.data.Http
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.FormBody
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+
+/**
+ * Lightweight, on-demand lyric translation.
+ *
+ * Translation models are deliberately not installed on the device. A model for
+ * every app language would cost tens of megabytes each; translated lyric text
+ * is normally only a few kilobytes. Requests are batched and the compact result
+ * is kept in a bounded cache under [Context.getCacheDir], so Android may reclaim
+ * it and the feature can never grow without limit.
+ */
+object LyricsTranslation {
+    sealed interface Result {
+        data class Translated(
+            val lines: List<LyricLine>,
+            val sourceLanguage: String,
+            val fromCache: Boolean,
+        ) : Result
+
+        data class SameLanguage(val language: String) : Result
+        data object Unavailable : Result
+    }
+
+    private const val ENDPOINT = "https://translate.googleapis.com/translate_a/single"
+    private const val CACHE_VERSION = 2
+    private const val CACHE_DIRECTORY = "lyrics_translation_v2"
+    private const val MAX_CACHE_BYTES = 2L * 1024L * 1024L
+    private const val MAX_BATCH_CHARS = 3_500
+    private const val MAX_PARALLEL_REQUESTS = 2
+    private val markerRegex = Regex("\\uE000\\d{4}\\uE001")
+    private val json = Json { ignoreUnknownKeys = true }
+    private val diskMutex = Mutex()
+    private val memory = LruCache<String, CachedTranslation>(12)
+    private val client by lazy {
+        Http.client.newBuilder()
+            .callTimeout(12, TimeUnit.SECONDS)
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Serializable
+    private data class CachedTranslation(
+        val version: Int = CACHE_VERSION,
+        val sourceLanguage: String,
+        val targetLanguage: String,
+        val texts: List<String>,
+    )
+
+    private data class TextSlot(
+        val lineIndex: Int,
+        val background: Boolean,
+        val text: String,
+        val sectionHeader: Boolean,
+    )
+
+    private data class Batch(
+        val slots: List<TextSlot>,
+        val payload: String,
+    )
+
+    private data class BatchAnswer(
+        val translations: List<String>,
+        val sourceLanguage: String,
+        val sourceWeight: Int,
+    )
+
+    suspend fun translate(
+        context: Context,
+        trackId: String,
+        lines: List<LyricLine>,
+        targetLanguageTag: String,
+    ): Result {
+        val target = canonicalLanguage(targetLanguageTag)
+        if (target.isBlank() || lines.isEmpty()) return Result.Unavailable
+
+        val slots = flatten(lines)
+        if (slots.isEmpty()) return Result.Unavailable
+        val cacheKey = cacheKey(trackId, target, slots)
+        val cached = memory.get(cacheKey) ?: readCache(context, cacheKey)?.also {
+            memory.put(cacheKey, it)
+        }
+        if (cached != null && cached.version == CACHE_VERSION && cached.texts.size == slots.size) {
+            return if (sameLanguage(cached.sourceLanguage, target)) {
+                Result.SameLanguage(cached.sourceLanguage)
+            } else {
+                Result.Translated(
+                    lines = rebuild(lines, slots, cached.texts),
+                    sourceLanguage = cached.sourceLanguage,
+                    fromCache = true,
+                )
+            }
+        }
+
+        val batches = batches(slots)
+        val answers = coroutineScope {
+            // Two short requests at a time keeps a long lyric fast without
+            // competing with playback for every connection in the pool.
+            batches.chunked(MAX_PARALLEL_REQUESTS).flatMap { group ->
+                group.map { batch -> async { requestBatch(batch, target) } }.awaitAll()
+            }
+        }
+        if (answers.any { it == null }) return Result.Unavailable
+        val complete = answers.filterNotNull()
+        val source = complete
+            .groupBy { canonicalLanguage(it.sourceLanguage) }
+            .maxByOrNull { (_, values) -> values.sumOf { it.sourceWeight } }
+            ?.key
+            .orEmpty()
+        if (source.isBlank()) return Result.Unavailable
+
+        val translated = complete.flatMap { it.translations }
+        if (translated.size != slots.size) return Result.Unavailable
+        val entry = CachedTranslation(
+            sourceLanguage = source,
+            targetLanguage = target,
+            texts = translated,
+        )
+        memory.put(cacheKey, entry)
+        writeCache(context, cacheKey, entry)
+
+        return if (sameLanguage(source, target)) {
+            Result.SameLanguage(source)
+        } else {
+            Result.Translated(
+                lines = rebuild(lines, slots, translated),
+                sourceLanguage = source,
+                fromCache = false,
+            )
+        }
+    }
+
+    private fun flatten(lines: List<LyricLine>): List<TextSlot> = buildList {
+        lines.forEachIndexed { index, line ->
+            if (line.text.isNotBlank()) {
+                val header = Genius.isSectionHeader(line.text)
+                add(
+                    TextSlot(
+                        lineIndex = index,
+                        background = false,
+                        text = if (header) line.text.removePrefix("[").removeSuffix("]").trim() else line.text,
+                        sectionHeader = header,
+                    ),
+                )
+            }
+            line.background?.takeIf { it.text.isNotBlank() }?.let { background ->
+                add(TextSlot(index, background = true, background.text, sectionHeader = false))
+            }
+        }
+    }
+
+    private fun batches(slots: List<TextSlot>): List<Batch> {
+        val result = mutableListOf<Batch>()
+        var current = mutableListOf<TextSlot>()
+        var length = 0
+
+        fun flush() {
+            if (current.isEmpty()) return
+            result += Batch(current.toList(), payload(current))
+            current = mutableListOf()
+            length = 0
+        }
+
+        slots.forEach { slot ->
+            val added = slot.text.length + if (current.isEmpty()) 0 else 8
+            if (current.isNotEmpty() && length + added > MAX_BATCH_CHARS) flush()
+            current += slot
+            length += added
+        }
+        flush()
+        return result
+    }
+
+    private fun payload(slots: List<TextSlot>): String = buildString {
+        slots.forEachIndexed { index, slot ->
+            if (index > 0) append('\n').append(marker(index)).append('\n')
+            append(slot.text)
+        }
+    }
+
+    private fun marker(index: Int): String = "\uE000${index.toString().padStart(4, '0')}\uE001"
+
+    private suspend fun requestBatch(batch: Batch, target: String): BatchAnswer? {
+        val body = FormBody.Builder()
+            .add("client", "dict-chrome-ex")
+            .add("sl", "auto")
+            .add("tl", target)
+            .add("dt", "t")
+            .add("q", batch.payload)
+            .build()
+        val request = Request.Builder()
+            .url(ENDPOINT)
+            .header("User-Agent", "BitChord/1.5.2")
+            .header("Accept", "application/json")
+            .post(body)
+            .build()
+        val response = runCatching { client.newCall(request).awaitBody() }.getOrNull() ?: return null
+        return runCatching {
+            val root = json.parseToJsonElement(response).jsonArray
+            val translatedBody = root[0].jsonArray.joinToString(separator = "") { segment ->
+                segment.jsonArray.getOrNull(0)?.jsonPrimitive?.contentOrNull.orEmpty()
+            }
+            val source = root.getOrNull(2)?.jsonPrimitive?.contentOrNull.orEmpty()
+            val parts = translatedBody.split(markerRegex).map(String::trim)
+            if (parts.size != batch.slots.size || parts.any { it.isBlank() }) return@runCatching null
+            BatchAnswer(parts, source, batch.payload.length)
+        }.getOrNull()
+    }
+
+    private suspend fun Call.awaitBody(): String = suspendCancellableCoroutine { continuation ->
+        continuation.invokeOnCancellation { cancel() }
+        enqueue(object : Callback {
+            override fun onFailure(call: Call, error: IOException) {
+                if (continuation.isActive) continuation.resumeWithException(error)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                response.use {
+                    val body = if (it.isSuccessful) it.body?.string() else null
+                    if (!continuation.isActive) return
+                    if (body != null) continuation.resume(body)
+                    else continuation.resumeWithException(IOException("Translation HTTP ${it.code}"))
+                }
+            }
+        })
+    }
+
+    private fun rebuild(
+        original: List<LyricLine>,
+        slots: List<TextSlot>,
+        translated: List<String>,
+    ): List<LyricLine> {
+        val byLine = slots.zip(translated).groupBy { it.first.lineIndex }
+        return original.mapIndexed { index, line ->
+            val entries = byLine[index].orEmpty()
+            val lead = entries.firstOrNull { !it.first.background }
+            val backing = entries.firstOrNull { it.first.background }
+            val leadText = lead?.let { (slot, text) -> if (slot.sectionHeader) "[$text]" else text }
+                ?: line.text
+            line.copy(
+                text = leadText,
+                words = retimeWords(line, leadText),
+                background = line.background?.let { source ->
+                    val text = backing?.second ?: source.text
+                    source.copy(text = text, words = retimeWords(source, text))
+                },
+            )
+        }
+    }
+
+    /**
+     * A translation changes word count, so source word boundaries cannot be
+     * copied. Re-spread the translated words across the exact original sung
+     * interval. The lyric sweep and line timing therefore remain continuous,
+     * while never pretending that a translated word has an exact phoneme stamp.
+     */
+    private fun retimeWords(source: LyricLine, translated: String): List<LyricWord> {
+        if (source.words.isEmpty()) return emptyList()
+        val tokens = Regex("\\S+").findAll(translated).map { it.value }.toList()
+        if (tokens.isEmpty()) return emptyList()
+        val start = source.words.first().startMs
+        val end = source.words.last().endMs.coerceAtLeast(start + tokens.size)
+        val duration = end - start
+        val weights = tokens.map { token -> token.count(Char::isLetterOrDigit).coerceAtLeast(1) }
+        val total = weights.sum().coerceAtLeast(1)
+        var consumed = 0
+        return tokens.mapIndexed { index, token ->
+            val wordStart = start + duration * consumed / total
+            consumed += weights[index]
+            val wordEnd = if (index == tokens.lastIndex) end else start + duration * consumed / total
+            LyricWord(wordStart, wordEnd.coerceAtLeast(wordStart + 1), token)
+        }
+    }
+
+    private fun canonicalLanguage(tag: String): String = when (
+        Locale.forLanguageTag(tag.replace('_', '-')).language.lowercase(Locale.ROOT)
+    ) {
+        "iw" -> "he"
+        "in" -> "id"
+        "ji" -> "yi"
+        else -> Locale.forLanguageTag(tag.replace('_', '-')).language.lowercase(Locale.ROOT)
+    }
+
+    private fun sameLanguage(first: String, second: String): Boolean =
+        canonicalLanguage(first) == canonicalLanguage(second)
+
+    private fun cacheKey(trackId: String, target: String, slots: List<TextSlot>): String {
+        val source = buildString {
+            append(trackId).append('\u0000').append(target)
+            slots.forEach { append('\u0000').append(it.text) }
+        }
+        return MessageDigest.getInstance("SHA-256")
+            .digest(source.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private suspend fun readCache(context: Context, key: String): CachedTranslation? =
+        withContext(Dispatchers.IO) {
+            diskMutex.withLock {
+                val file = File(File(context.cacheDir, CACHE_DIRECTORY), "$key.json.gz")
+                if (!file.isFile) return@withLock null
+                runCatching {
+                    val value = GZIPInputStream(FileInputStream(file)).bufferedReader().use {
+                        json.decodeFromString<CachedTranslation>(it.readText())
+                    }
+                    file.setLastModified(System.currentTimeMillis())
+                    value.takeIf { it.version == CACHE_VERSION }
+                }.getOrNull()
+            }
+        }
+
+    private suspend fun writeCache(context: Context, key: String, value: CachedTranslation) =
+        withContext(Dispatchers.IO) {
+            diskMutex.withLock {
+                val directory = File(context.cacheDir, CACHE_DIRECTORY)
+                if (!directory.exists() && !directory.mkdirs()) return@withLock
+                val destination = File(directory, "$key.json.gz")
+                val temporary = File(directory, "$key.tmp")
+                runCatching {
+                    GZIPOutputStream(FileOutputStream(temporary)).bufferedWriter().use {
+                        it.write(json.encodeToString(value))
+                    }
+                    if (!temporary.renameTo(destination)) {
+                        temporary.copyTo(destination, overwrite = true)
+                        temporary.delete()
+                    }
+                    trimCache(directory)
+                }.onFailure { temporary.delete() }
+            }
+        }
+
+    private fun trimCache(directory: File) {
+        val files = directory.listFiles { file -> file.extension == "gz" }
+            ?.sortedByDescending(File::lastModified)
+            .orEmpty()
+        var kept = 0L
+        files.forEach { file ->
+            kept += file.length()
+            if (kept > MAX_CACHE_BYTES) file.delete()
+        }
+    }
+}

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -12,10 +12,12 @@ import android.os.Looper
 import android.os.SystemClock
 import android.provider.Settings
 import android.view.View
+import android.widget.Toast
 import android.window.OnBackInvokedCallback
 import android.window.OnBackInvokedDispatcher
 import androidx.activity.compose.BackHandler
 import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.Animatable
@@ -32,6 +34,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -93,6 +96,7 @@ import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Translate
 import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -194,6 +198,7 @@ import com.music.bitchord.data.canvas.CanvasRepository
 import com.music.bitchord.data.lyrics.Genius
 import com.music.bitchord.data.lyrics.LyricLine
 import com.music.bitchord.data.lyrics.LyricsSource
+import com.music.bitchord.data.lyrics.LyricsTranslation
 import com.music.bitchord.ui.components.LyricsLogConsole
 import com.music.bitchord.data.settings.AppSettings
 import com.music.bitchord.data.settings.AudioQuality
@@ -204,6 +209,7 @@ import com.music.bitchord.data.model.artworkAt
 import com.music.bitchord.playback.BACK_RESTARTS_AFTER_MS
 import com.music.bitchord.playback.autoplaySectionStart
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Job
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
@@ -211,7 +217,11 @@ import dev.chrisbanes.haze.materials.HazeMaterials
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
+import kotlin.math.PI
+import kotlin.math.cos
 import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.random.Random
 
 /** Collapsed-header geometry, shared by the layout and its animation. */
 /**
@@ -524,6 +534,23 @@ private const val BACKING_ALPHA = 0.72f
 private const val LYRICS_UNAVAILABLE_HOLD_MS = 5_000L
 private const val LYRICS_UNAVAILABLE_FADE_MS = 900
 
+private sealed interface LyricsTranslationUiState {
+    data object Idle : LyricsTranslationUiState
+    data object Loading : LyricsTranslationUiState
+    data class Ready(val lines: List<LyricLine>) : LyricsTranslationUiState
+    data object SameLanguage : LyricsTranslationUiState
+}
+
+private data class TranslationParticle(
+    val x: Float,
+    val y: Float,
+    val angle: Float,
+    val distance: Float,
+    val radius: Float,
+    val delay: Float,
+    val cool: Boolean,
+)
+
 /**
  * Apple Music's Now Playing, closely: artwork that shrinks when paused, a
  * hairline scrubber with elapsed / remaining either side, oversized transport
@@ -684,6 +711,98 @@ fun NowPlayingScreen(
     var lyricsOpen by remember { mutableStateOf(false) }
     var lyricsLogsOpen by remember { mutableStateOf(false) }
     val showLyricsLogsEnabled by AppSettings.showLyricsLogs.collectAsStateWithLifecycle()
+    val reduceTranslationMotion by AppSettings.reduceAnimation.collectAsStateWithLifecycle()
+    val configuredLocale = AppCompatDelegate.getApplicationLocales().get(0)?.toLanguageTag()
+        ?.takeIf { it.isNotBlank() }
+        ?: context.resources.configuration.locales.get(0).toLanguageTag()
+    val translationLanguage = remember(configuredLocale) {
+        Locale.forLanguageTag(configuredLocale).language.ifBlank { "en" }
+    }
+    val translationLanguageName = remember(configuredLocale, translationLanguage) {
+        val locale = Locale.forLanguageTag(configuredLocale)
+        Locale.forLanguageTag(translationLanguage).getDisplayLanguage(locale)
+            .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+    }
+    var translationState by remember(song.videoId, translationLanguage, lyrics) {
+        mutableStateOf<LyricsTranslationUiState>(LyricsTranslationUiState.Idle)
+    }
+    var showingTranslation by remember(song.videoId, translationLanguage, lyrics) {
+        mutableStateOf(false)
+    }
+    var translationTransition by remember(song.videoId) { mutableIntStateOf(0) }
+    var translationJob by remember(song.videoId, translationLanguage, lyrics) {
+        mutableStateOf<Job?>(null)
+    }
+    DisposableEffect(song.videoId, translationLanguage, lyrics) {
+        onDispose { translationJob?.cancel() }
+    }
+    val displayedLyrics = if (showingTranslation) {
+        (translationState as? LyricsTranslationUiState.Ready)?.lines ?: lyrics.orEmpty()
+    } else {
+        lyrics.orEmpty()
+    }
+    val translationScope = rememberCoroutineScope()
+    val toggleTranslation: () -> Unit = toggleTranslation@{
+        when (val state = translationState) {
+            is LyricsTranslationUiState.Ready -> {
+                showingTranslation = !showingTranslation
+                translationTransition++
+                haptics.play(Haptic.Select)
+            }
+            LyricsTranslationUiState.Loading -> Unit
+            LyricsTranslationUiState.SameLanguage -> {
+                haptics.play(Haptic.Tap)
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.lyrics_already_in_language, translationLanguageName),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+            LyricsTranslationUiState.Idle -> {
+                val source = lyrics.orEmpty()
+                if (source.isEmpty()) return@toggleTranslation
+                haptics.play(Haptic.Tap)
+                translationState = LyricsTranslationUiState.Loading
+                translationJob?.cancel()
+                translationJob = translationScope.launch {
+                    when (
+                        val result = LyricsTranslation.translate(
+                            context = context.applicationContext,
+                            trackId = song.videoId,
+                            lines = source,
+                            targetLanguageTag = configuredLocale,
+                        )
+                    ) {
+                        is LyricsTranslation.Result.Translated -> {
+                            translationState = LyricsTranslationUiState.Ready(result.lines)
+                            showingTranslation = true
+                            translationTransition++
+                            haptics.play(Haptic.ToggleOn)
+                        }
+                        is LyricsTranslation.Result.SameLanguage -> {
+                            translationState = LyricsTranslationUiState.SameLanguage
+                            Toast.makeText(
+                                context,
+                                context.getString(
+                                    R.string.lyrics_already_in_language,
+                                    translationLanguageName,
+                                ),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
+                        LyricsTranslation.Result.Unavailable -> {
+                            translationState = LyricsTranslationUiState.Idle
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.lyrics_translation_unavailable),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
+                    }
+                }
+            }
+        }
+    }
     LaunchedEffect(song.videoId) {
         lyricsOpen = false
         lyricsLogsOpen = false
@@ -1968,11 +2087,9 @@ fun NowPlayingScreen(
                                 },
                         )
                     } else {
-                        LyricsPanel(
-                            lines = lyrics.orEmpty(),
-                            positionMs = positionMs,
-                            isPlaying = isPlaying,
-                            onSeekToLine = onSeek,
+                        LyricsTranslationMotion(
+                            trigger = translationTransition,
+                            reduceMotion = reduceTranslationMotion,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .padding(top = HEADER_HEIGHT)
@@ -1985,7 +2102,15 @@ fun NowPlayingScreen(
                                     alpha = ((p - 0.45f) / 0.55f).coerceIn(0f, 1f)
                                     translationY = (1f - p) * 26.dp.toPx()
                                 },
-                        )
+                        ) {
+                            LyricsPanel(
+                                lines = displayedLyrics,
+                                positionMs = positionMs,
+                                isPlaying = isPlaying,
+                                onSeekToLine = onSeek,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
                     }
                 }
 
@@ -2212,6 +2337,12 @@ fun NowPlayingScreen(
                     ) {
                         Text(
                             text = when {
+                                translationState is LyricsTranslationUiState.Loading ->
+                                    stringResource(R.string.translating_lyrics_to, translationLanguageName)
+                                showingTranslation ->
+                                    stringResource(R.string.lyrics_translated_to, translationLanguageName)
+                                translationState is LyricsTranslationUiState.SameLanguage ->
+                                    stringResource(R.string.lyrics_already_in_language, translationLanguageName)
                                 lyricsSource != null -> stringResource(R.string.lyrics_by, lyricsSource.label)
                                 lyrics.isNullOrEmpty() -> stringResource(R.string.no_lyrics_found)
                                 else -> stringResource(R.string.lyrics_saved_with_download)
@@ -2222,6 +2353,13 @@ fun NowPlayingScreen(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
+                    Spacer(Modifier.width(8.dp))
+                    TranslationToggleButton(
+                        state = translationState,
+                        showingTranslation = showingTranslation,
+                        enabled = !lyricsLogsOpen && !lyrics.isNullOrEmpty(),
+                        onClick = toggleTranslation,
+                    )
                     Spacer(Modifier.width(8.dp))
                     Box(
                         modifier = Modifier
@@ -2763,6 +2901,137 @@ private fun ContentDrawScope.sweepTo(layout: TextLayoutResult, revealedChars: Fl
     }
 }
 
+
+@Composable
+private fun TranslationToggleButton(
+    state: LyricsTranslationUiState,
+    showingTranslation: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val active = showingTranslation || state is LyricsTranslationUiState.Loading
+    val tint = when {
+        !enabled || state is LyricsTranslationUiState.SameLanguage -> Color.White.copy(alpha = 0.42f)
+        active -> Color.White
+        else -> Color.White.copy(alpha = 0.78f)
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxHeight()
+            .width(54.dp)
+            .clip(RoundedCornerShape(percent = 50))
+            .background(Color.White.copy(alpha = if (active) 0.22f else 0.10f))
+            .clickable(
+                enabled = enabled,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (state is LyricsTranslationUiState.Loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                color = tint,
+                strokeWidth = 1.7.dp,
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Rounded.Translate,
+                contentDescription = stringResource(
+                    if (showingTranslation) R.string.show_original_lyrics
+                    else R.string.translate_lyrics,
+                ),
+                tint = tint,
+                modifier = Modifier.size(19.dp),
+            )
+        }
+    }
+}
+
+/**
+ * A short text-material transition: the list and its playback clock stay in
+ * place while a field of tiny glyph-like particles resolves into the new text.
+ * Only alpha/scale and Canvas drawing move, so changing language never causes a
+ * second scroll, a blank frame, or a new lyrics timeline. The app's Reduce
+ * animation preference collapses the whole response to an immediate swap.
+ */
+@Composable
+private fun LyricsTranslationMotion(
+    trigger: Int,
+    reduceMotion: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val progress = remember { Animatable(1f) }
+    val particles = remember(trigger) {
+        val random = Random(trigger * 7_919 + 41)
+        List(52) {
+            TranslationParticle(
+                x = 0.06f + random.nextFloat() * 0.88f,
+                y = 0.05f + random.nextFloat() * 0.78f,
+                angle = random.nextFloat() * (PI * 2.0).toFloat(),
+                distance = 0.012f + random.nextFloat() * 0.045f,
+                radius = 0.7f + random.nextFloat() * 1.35f,
+                delay = random.nextFloat() * 0.34f,
+                cool = random.nextBoolean(),
+            )
+        }
+    }
+    LaunchedEffect(trigger, reduceMotion) {
+        if (trigger <= 0 || reduceMotion) {
+            progress.snapTo(1f)
+        } else {
+            progress.snapTo(0f)
+            progress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(durationMillis = 620, easing = FastOutSlowInEasing),
+            )
+        }
+    }
+
+    val amount = progress.value
+    val eased = FastOutSlowInEasing.transform(amount)
+    Box(modifier = modifier.clipToBounds()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    if (!reduceMotion && trigger > 0) {
+                        alpha = 0.74f + eased * 0.26f
+                        val scale = 0.992f + eased * 0.008f
+                        scaleX = scale
+                        scaleY = scale
+                        transformOrigin = TransformOrigin(0.5f, 0.42f)
+                    }
+                },
+        ) {
+            content()
+        }
+
+        if (!reduceMotion && trigger > 0 && amount < 0.999f) {
+            Canvas(Modifier.fillMaxSize()) {
+                val travelBase = size.minDimension
+                particles.forEach { particle ->
+                    val local = ((amount - particle.delay) / (1f - particle.delay)).coerceIn(0f, 1f)
+                    if (local > 0f && local < 1f) {
+                        val envelope = sin(PI * local).toFloat()
+                        val travel = travelBase * particle.distance * local
+                        drawCircle(
+                            color = if (particle.cool) Color(0xFFBFE9FF) else Color.White,
+                            radius = particle.radius.dp.toPx() * (0.75f + envelope * 0.55f),
+                            center = Offset(
+                                x = size.width * particle.x + cos(particle.angle) * travel,
+                                y = size.height * particle.y + sin(particle.angle) * travel,
+                            ),
+                            alpha = envelope * 0.72f,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
 /**
  * Apple Music's lyrics view: big tight type, the playing line crisp and

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -2952,7 +2952,7 @@ private fun TranslationToggleButton(
 /**
  * A short text-material transition: the list and its playback clock stay in
  * place while a field of tiny glyph-like particles resolves into the new text.
- * Only alpha/scale and Canvas drawing move, so changing language never causes a
+ * Only the dedicated Canvas drawing moves, so changing language never causes a
  * second scroll, a blank frame, or a new lyrics timeline. The app's Reduce
  * animation preference collapses the whole response to an immediate swap.
  */
@@ -2966,7 +2966,7 @@ private fun LyricsTranslationMotion(
     val progress = remember { Animatable(1f) }
     val particles = remember(trigger) {
         val random = Random(trigger * 7_919 + 41)
-        List(52) {
+        List(30) {
             TranslationParticle(
                 x = 0.06f + random.nextFloat() * 0.88f,
                 y = 0.05f + random.nextFloat() * 0.78f,
@@ -2990,27 +2990,26 @@ private fun LyricsTranslationMotion(
         }
     }
 
-    val amount = progress.value
-    val eased = FastOutSlowInEasing.transform(amount)
-    Box(modifier = modifier.clipToBounds()) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer {
-                    if (!reduceMotion && trigger > 0) {
-                        alpha = 0.74f + eased * 0.26f
-                        val scale = 0.992f + eased * 0.008f
-                        scaleX = scale
-                        scaleY = scale
-                        transformOrigin = TransformOrigin(0.5f, 0.42f)
-                    }
-                },
-        ) {
-            content()
-        }
+    Box(modifier = modifier) {
+        // Keep the lyrics subtree completely outside the animation clock. In
+        // particular, do not read progress in composition or apply a clipping
+        // layer here: the panel's active line deliberately scales beyond its
+        // measured bounds and its glow uses unbounded blur.
+        content()
 
-        if (!reduceMotion && trigger > 0 && amount < 0.999f) {
-            Canvas(Modifier.fillMaxSize()) {
+        if (!reduceMotion && trigger > 0) {
+            Canvas(
+                Modifier
+                    .fillMaxSize()
+                    // Particles stay inside the panel; only this decorative
+                    // layer is clipped, never the text or its bloom.
+                    .clipToBounds(),
+            ) {
+                // Reading Animatable state from DrawScope invalidates only
+                // this Canvas. The LazyColumn and every text layout remain
+                // untouched for all frames of the 620 ms flourish.
+                val amount = progress.value
+                if (amount >= 0.999f) return@Canvas
                 val travelBase = size.minDimension
                 particles.forEach { particle ->
                     val local = ((amount - particle.delay) / (1f - particle.delay)).coerceIn(0f, 1f)

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -103,6 +102,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -130,6 +130,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
@@ -171,6 +172,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
@@ -218,7 +220,6 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 import kotlin.math.PI
-import kotlin.math.cos
 import kotlin.math.roundToInt
 import kotlin.math.sin
 import kotlin.random.Random
@@ -541,14 +542,14 @@ private sealed interface LyricsTranslationUiState {
     data object SameLanguage : LyricsTranslationUiState
 }
 
+private const val TRANSLATION_MOTION_MS = 540
+private const val PARTICLES_PER_VOICE = 18
+
 private data class TranslationParticle(
-    val x: Float,
-    val y: Float,
-    val angle: Float,
-    val distance: Float,
+    val anchor: Offset,
+    val drift: Offset,
     val radius: Float,
     val delay: Float,
-    val cool: Boolean,
 )
 
 /**
@@ -2102,12 +2103,13 @@ fun NowPlayingScreen(
                                     alpha = ((p - 0.45f) / 0.55f).coerceIn(0f, 1f)
                                     translationY = (1f - p) * 26.dp.toPx()
                                 },
-                        ) {
+                        ) { particleProgress ->
                             LyricsPanel(
                                 lines = displayedLyrics,
                                 positionMs = positionMs,
                                 isPlaying = isPlaying,
                                 onSeekToLine = onSeek,
+                                translationProgress = particleProgress,
                                 modifier = Modifier.fillMaxSize(),
                             )
                         }
@@ -2172,9 +2174,9 @@ fun NowPlayingScreen(
                         // the timestamps below are pulled back up into it.
                         .offset(y = 6.dp),
                 ) {
-                    if (!lyrics.isNullOrEmpty()) {
+                    if (displayedLyrics.isNotEmpty()) {
                         CurrentLyricLine(
-                            lines = lyrics,
+                            lines = displayedLyrics,
                             trackKey = song.videoId,
                             positionMs = positionMs,
                             isPlaying = isPlaying,
@@ -2701,6 +2703,7 @@ private fun SweptLyricLine(
     glowAlpha: Float = 0f,
     glowRadius: Dp = GLOW_RADIUS,
     glowRoom: Dp = 0.dp,
+    translationProgress: State<Float>? = null,
 ) {
     var layout by remember(line) { mutableStateOf<TextLayoutResult?>(null) }
 
@@ -2730,7 +2733,7 @@ private fun SweptLyricLine(
         }
     }
 
-    Box(modifier) {
+    Box(modifier.lyricParticles(layout, translationProgress, glowRoom)) {
         Text(
             text = line.text,
             style = style,
@@ -2811,9 +2814,11 @@ private fun ContentDrawScope.glowAt(
     val lineStart = layout.getLineStart(visualLine)
     val lineEnd = layout.getLineEnd(visualLine, visibleEnd = true)
 
-    val right = horizontalAt(layout, edge.coerceIn(lineStart.toFloat(), lineEnd.toFloat()), lineStart, lineEnd)
+    val boundary = horizontalAt(layout, edge.coerceIn(lineStart.toFloat(), lineEnd.toFloat()), lineStart, lineEnd)
+    val rtl = layout.getParagraphDirection(lineStart) == ResolvedTextDirection.Rtl
     val trail = GLOW_TRAIL.toPx() * (GLOW_TRAIL_FLOOR + (1f - GLOW_TRAIL_FLOOR) * intensity)
-    val left = (right - trail).coerceAtLeast(layout.getLineLeft(visualLine))
+    val left = if (rtl) boundary else (boundary - trail).coerceAtLeast(layout.getLineLeft(visualLine))
+    val right = if (rtl) (boundary + trail).coerceAtMost(layout.getLineRight(visualLine)) else boundary
     if (right <= left) return
 
     // The band, cut out of the line. This is only the vertical and trailing
@@ -2841,8 +2846,8 @@ private fun ContentDrawScope.glowAt(
             0f to Color.Transparent,
             0.45f to Color.White.copy(alpha = 0.22f),
             1f to Color.White,
-            startX = left,
-            endX = right,
+            startX = if (rtl) right else left,
+            endX = if (rtl) left else right,
         ),
         blendMode = BlendMode.DstIn,
     )
@@ -2855,13 +2860,17 @@ private fun horizontalAt(
     lineStart: Int,
     lineEnd: Int,
 ): Float {
-    val index = chars.toInt().coerceIn(lineStart, lineEnd)
-    val here = layout.getHorizontalPosition(index, usePrimaryDirection = true)
-    val next = layout.getHorizontalPosition(
-        (index + 1).coerceAtMost(lineEnd),
-        usePrimaryDirection = true,
-    )
-    return here + (next - here) * (chars - index)
+    if (lineEnd <= lineStart) return layout.getLineLeft(layout.getLineForOffset(lineStart))
+    // A caret at lineEnd may belong to the NEXT wrapped row. Interpolating to
+    // that caret made the last glyph's fill travel backwards across the row.
+    val index = chars.toInt().coerceIn(lineStart, lineEnd - 1)
+    val box = layout.getBoundingBox(index)
+    val fraction = (chars - index).coerceIn(0f, 1f)
+    return if (layout.getBidiRunDirection(index) == ResolvedTextDirection.Rtl) {
+        box.right - box.width * fraction
+    } else {
+        box.left + box.width * fraction
+    }
 }
 
 /**
@@ -2885,15 +2894,13 @@ private fun ContentDrawScope.sweepTo(layout: TextLayoutResult, revealedChars: Fl
         // anything after them.
         if (revealedChars <= start) return
         val end = layout.getLineEnd(visualLine, visibleEnd = true)
-        val right = if (revealedChars >= end) {
-            layout.getLineRight(visualLine)
-        } else {
-            horizontalAt(layout, revealedChars, start, end)
-        }
+        val complete = revealedChars >= end
+        val rtl = layout.getParagraphDirection(start) == ResolvedTextDirection.Rtl
+        val edge = if (complete) 0f else horizontalAt(layout, revealedChars, start, end)
         clipRect(
-            left = layout.getLineLeft(visualLine),
+            left = if (!complete && rtl) edge else layout.getLineLeft(visualLine),
             top = layout.getLineTop(visualLine),
-            right = right,
+            right = if (!complete && !rtl) edge else layout.getLineRight(visualLine),
             bottom = layout.getLineBottom(visualLine),
         ) {
             this@sweepTo.drawContent()
@@ -2961,31 +2968,23 @@ private fun LyricsTranslationMotion(
     trigger: Int,
     reduceMotion: Boolean,
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    content: @Composable (State<Float>?) -> Unit,
 ) {
     val progress = remember { Animatable(1f) }
-    val particles = remember(trigger) {
-        val random = Random(trigger * 7_919 + 41)
-        List(30) {
-            TranslationParticle(
-                x = 0.06f + random.nextFloat() * 0.88f,
-                y = 0.05f + random.nextFloat() * 0.78f,
-                angle = random.nextFloat() * (PI * 2.0).toFloat(),
-                distance = 0.012f + random.nextFloat() * 0.045f,
-                radius = 0.7f + random.nextFloat() * 1.35f,
-                delay = random.nextFloat() * 0.34f,
-                cool = random.nextBoolean(),
-            )
-        }
-    }
-    LaunchedEffect(trigger, reduceMotion) {
-        if (trigger <= 0 || reduceMotion) {
+    val foreground = rememberIsForeground()
+    // Reopening the panel or returning from the background must not replay a
+    // previous toggle. A new toggle cancels the previous effect automatically.
+    var consumedTrigger by remember { mutableIntStateOf(trigger) }
+    LaunchedEffect(trigger, reduceMotion, foreground) {
+        val changed = trigger != consumedTrigger
+        consumedTrigger = trigger
+        if (!changed || trigger <= 0 || reduceMotion || !foreground) {
             progress.snapTo(1f)
         } else {
             progress.snapTo(0f)
             progress.animateTo(
                 targetValue = 1f,
-                animationSpec = tween(durationMillis = 620, easing = FastOutSlowInEasing),
+                animationSpec = tween(durationMillis = TRANSLATION_MOTION_MS, easing = LinearEasing),
             )
         }
     }
@@ -2995,37 +2994,48 @@ private fun LyricsTranslationMotion(
         // particular, do not read progress in composition or apply a clipping
         // layer here: the panel's active line deliberately scales beyond its
         // measured bounds and its glow uses unbounded blur.
-        content()
+        content(progress.asState().takeIf { !reduceMotion && foreground && trigger > 0 })
+    }
+}
 
-        if (!reduceMotion && trigger > 0) {
-            Canvas(
-                Modifier
-                    .fillMaxSize()
-                    // Particles stay inside the panel; only this decorative
-                    // layer is clipped, never the text or its bloom.
-                    .clipToBounds(),
-            ) {
-                // Reading Animatable state from DrawScope invalidates only
-                // this Canvas. The LazyColumn and every text layout remain
-                // untouched for all frames of the 620 ms flourish.
-                val amount = progress.value
-                if (amount >= 0.999f) return@Canvas
-                val travelBase = size.minDimension
+/** Glyph positions are cached at layout time; the shared clock is draw-only. */
+private fun Modifier.lyricParticles(
+    layout: TextLayoutResult?,
+    progress: State<Float>?,
+    room: Dp,
+): Modifier {
+    if (layout == null || progress == null) return this
+    return drawWithCache {
+        val text = layout.layoutInput.text.text
+        val candidates = text.indices.filter { text[it].isLetterOrDigit() }
+        val random = Random(text.hashCode())
+        val inset = room.toPx()
+        val particles = candidates.shuffled(random).take(PARTICLES_PER_VOICE).map { index ->
+            val glyph = layout.getBoundingBox(index)
+            TranslationParticle(
+                anchor = glyph.center + Offset(inset, inset),
+                drift = Offset((random.nextFloat() - 0.5f) * 12.dp.toPx(),
+                    -(5f + random.nextFloat() * 11f).dp.toPx()),
+                radius = (0.65f + random.nextFloat() * 0.65f).dp.toPx(),
+                delay = 0.16f * index / text.length.coerceAtLeast(1),
+            )
+        }
+        onDrawWithContent {
+            drawContent()
+            val value = progress.value
+            if (value > 0f && value < 1f) {
                 particles.forEach { particle ->
-                    val local = ((amount - particle.delay) / (1f - particle.delay)).coerceIn(0f, 1f)
-                    if (local > 0f && local < 1f) {
-                        val envelope = sin(PI * local).toFloat()
-                        val travel = travelBase * particle.distance * local
-                        drawCircle(
-                            color = if (particle.cool) Color(0xFFBFE9FF) else Color.White,
-                            radius = particle.radius.dp.toPx() * (0.75f + envelope * 0.55f),
-                            center = Offset(
-                                x = size.width * particle.x + cos(particle.angle) * travel,
-                                y = size.height * particle.y + sin(particle.angle) * travel,
-                            ),
-                            alpha = envelope * 0.72f,
-                        )
-                    }
+                    val t = ((value - particle.delay) / 0.84f).coerceIn(0f, 1f)
+                    val envelope = sin(PI * t).toFloat()
+                    val ease = 1f - (1f - t) * (1f - t)
+                    val center = particle.anchor + Offset(
+                        particle.drift.x * ease,
+                        particle.drift.y * ease + 3.dp.toPx() * t * t,
+                    )
+                    // Two inexpensive circles give a soft halo without another
+                    // blur layer; opacity rises and falls without a flash.
+                    drawCircle(Color.White, particle.radius * 2.7f, center, alpha = envelope * 0.07f)
+                    drawCircle(Color.White, particle.radius, center, alpha = envelope * 0.58f)
                 }
             }
         }
@@ -3046,6 +3056,7 @@ private fun LyricsPanel(
     positionMs: Long,
     isPlaying: Boolean,
     onSeekToLine: (Long) -> Unit,
+    translationProgress: State<Float>? = null,
     modifier: Modifier = Modifier,
 ) {
     val clock = rememberLyricClock(positionMs, isPlaying)
@@ -3102,7 +3113,7 @@ private fun LyricsPanel(
         }
     }
 
-    var placed by remember(lines) { mutableStateOf(false) }
+    var placed by remember { mutableStateOf(false) }
     LaunchedEffect(activeLine, browsing) {
         if (isSynced && !browsing && !listState.isScrollInProgress &&
             activeLine >= 0 && activeLine in lines.indices
@@ -3271,6 +3282,9 @@ private fun LyricsPanel(
                         browsing = browsing,
                         glowAlpha = glow,
                         room = GLOW_ROOM,
+                        translationProgress = translationProgress.takeIf {
+                            if (isSynced) distance <= 1 else index < 4
+                        },
                         modifier = Modifier.fillMaxWidth(),
                     )
                     line.background?.let { backing ->
@@ -3323,6 +3337,7 @@ private fun PanelVoice(
     browsing: Boolean,
     glowAlpha: Float,
     room: Dp,
+    translationProgress: State<Float>? = null,
     modifier: Modifier = Modifier,
 ) {
     if (line.isWordSynced && !browsing) {
@@ -3347,6 +3362,7 @@ private fun PanelVoice(
             modifier = modifier,
             glowAlpha = glowAlpha,
             glowRoom = room,
+            translationProgress = translationProgress,
         )
     } else if (line.isWordSynced) {
         // Browsing: keep the sweep so sung lines stay fully lit and unsung
@@ -3365,17 +3381,20 @@ private fun PanelVoice(
             modifier = modifier,
             glowAlpha = 0f,
             glowRoom = room,
+            translationProgress = translationProgress,
         )
     } else {
         // Non word-synced: during playback the sweep is not available so we
         // rely on graphicsLayer alpha (set by the parent) to dim inactive
         // lines.  During browsing the same rule applies — do not default to
         // full white.
+        var layout by remember(line.text) { mutableStateOf<TextLayoutResult?>(null) }
         Text(
             text = line.text,
             style = style,
             color = Color.White,
-            modifier = modifier.padding(room),
+            onTextLayout = { layout = it },
+            modifier = modifier.lyricParticles(layout, translationProgress, room).padding(room),
         )
     }
 }
@@ -3483,7 +3502,7 @@ private fun CurrentLyricLine(
     val text = when {
         intro -> introLine
         instrumental -> stringResource(R.string.instrumental)
-        else -> current!!.text
+        else -> current.text
     }
 
     Row(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -256,6 +256,12 @@
     <string name="buttons">Schaltflächen</string>
     <string name="clear_name">Namen löschen</string>
     <string name="close_lyrics">Songtexte schließen</string>
+    <string name="translate_lyrics">Songtext übersetzen</string>
+    <string name="show_original_lyrics">Originaltext anzeigen</string>
+    <string name="translating_lyrics_to">Wird ins %1$s übersetzt…</string>
+    <string name="lyrics_translated_to">Ins %1$s übersetzt</string>
+    <string name="lyrics_already_in_language">Dieser Songtext ist bereits auf %1$s</string>
+    <string name="lyrics_translation_unavailable">Die Übersetzung ist derzeit nicht verfügbar</string>
     <string name="connect_account_first">Verbinde zuerst ein Konto</string>
     <string name="connected_presence_off">Verbunden, Presence aus</string>
     <string name="copy_log">Protokoll kopieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -268,6 +268,12 @@
     <string name="buttons">Botones</string>
     <string name="clear_name">Borrar nombre</string>
     <string name="close_lyrics">Cerrar letra</string>
+    <string name="translate_lyrics">Traducir letra</string>
+    <string name="show_original_lyrics">Mostrar letra original</string>
+    <string name="translating_lyrics_to">Traduciendo al %1$s…</string>
+    <string name="lyrics_translated_to">Traducida al %1$s</string>
+    <string name="lyrics_already_in_language">Esta letra ya está en %1$s</string>
+    <string name="lyrics_translation_unavailable">La traducción no está disponible ahora</string>
     <string name="connect_account_first">Primero conecta una cuenta</string>
     <string name="connected_presence_off">Conectado, presencia desactivada</string>
     <string name="copy_log">Copiar registro</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -256,6 +256,12 @@
     <string name="buttons">Boutons</string>
     <string name="clear_name">Effacer le nom</string>
     <string name="close_lyrics">Fermer les paroles</string>
+    <string name="translate_lyrics">Traduire les paroles</string>
+    <string name="show_original_lyrics">Afficher les paroles originales</string>
+    <string name="translating_lyrics_to">Traduction en %1$s…</string>
+    <string name="lyrics_translated_to">Traduit en %1$s</string>
+    <string name="lyrics_already_in_language">Ces paroles sont déjà en %1$s</string>
+    <string name="lyrics_translation_unavailable">La traduction est indisponible pour le moment</string>
     <string name="connect_account_first">Connectez d\'abord un compte</string>
     <string name="connected_presence_off">Connecté, présence désactivée</string>
     <string name="copy_log">Copier le journal</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -256,6 +256,12 @@
     <string name="buttons">כפתורים</string>
     <string name="clear_name">נקה שם</string>
     <string name="close_lyrics">סגור מילים</string>
+    <string name="translate_lyrics">תרגם מילים</string>
+    <string name="show_original_lyrics">הצג מילים מקוריות</string>
+    <string name="translating_lyrics_to">מתרגם ל%1$s…</string>
+    <string name="lyrics_translated_to">תורגם ל%1$s</string>
+    <string name="lyrics_already_in_language">המילים כבר ב%1$s</string>
+    <string name="lyrics_translation_unavailable">התרגום אינו זמין כרגע</string>
     <string name="connect_account_first">חבר חשבון תחילה</string>
     <string name="connected_presence_off">מחובר, נוכחות כבויה</string>
     <string name="copy_log">העתק יומן</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -256,6 +256,12 @@
     <string name="buttons">बटन</string>
     <string name="clear_name">नाम साफ़ करें</string>
     <string name="close_lyrics">लिरिक्स बंद करें</string>
+    <string name="translate_lyrics">लिरिक्स का अनुवाद करें</string>
+    <string name="show_original_lyrics">मूल लिरिक्स दिखाएँ</string>
+    <string name="translating_lyrics_to">%1$s में अनुवाद हो रहा है…</string>
+    <string name="lyrics_translated_to">%1$s में अनुवादित</string>
+    <string name="lyrics_already_in_language">ये लिरिक्स पहले से %1$s में हैं</string>
+    <string name="lyrics_translation_unavailable">अनुवाद अभी उपलब्ध नहीं है</string>
     <string name="connect_account_first">पहले कोई खाता कनेक्ट करें</string>
     <string name="connected_presence_off">कनेक्टेड, प्रेज़ेंस बंद</string>
     <string name="copy_log">लॉग कॉपी करें</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -252,6 +252,12 @@
     <string name="buttons">Tombol</string>
     <string name="clear_name">Hapus nama</string>
     <string name="close_lyrics">Tutup lirik</string>
+    <string name="translate_lyrics">Terjemahkan lirik</string>
+    <string name="show_original_lyrics">Tampilkan lirik asli</string>
+    <string name="translating_lyrics_to">Menerjemahkan ke %1$s…</string>
+    <string name="lyrics_translated_to">Diterjemahkan ke %1$s</string>
+    <string name="lyrics_already_in_language">Lirik ini sudah dalam %1$s</string>
+    <string name="lyrics_translation_unavailable">Terjemahan tidak tersedia saat ini</string>
     <string name="connect_account_first">Hubungkan akun terlebih dahulu</string>
     <string name="connected_presence_off">Terhubung, presence nonaktif</string>
     <string name="copy_log">Salin log</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -280,6 +280,12 @@
     <string name="buttons">Pulsanti</string>
     <string name="clear_name">Cancella nome</string>
     <string name="close_lyrics">Chiudi testi</string>
+    <string name="translate_lyrics">Traduci testo</string>
+    <string name="show_original_lyrics">Mostra testo originale</string>
+    <string name="translating_lyrics_to">Traduzione in %1$s…</string>
+    <string name="lyrics_translated_to">Tradotto in %1$s</string>
+    <string name="lyrics_already_in_language">Questo testo è già in %1$s</string>
+    <string name="lyrics_translation_unavailable">La traduzione non è disponibile al momento</string>
     <string name="connect_account_first">Collega prima un account</string>
     <string name="connected_presence_off">Connesso, presenza disattivata</string>
     <string name="copy_log">Copia log</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -252,6 +252,12 @@
     <string name="buttons">ボタン</string>
     <string name="clear_name">名前を消去</string>
     <string name="close_lyrics">歌詞を閉じる</string>
+    <string name="translate_lyrics">歌詞を翻訳</string>
+    <string name="show_original_lyrics">元の歌詞を表示</string>
+    <string name="translating_lyrics_to">%1$sに翻訳中…</string>
+    <string name="lyrics_translated_to">%1$sに翻訳済み</string>
+    <string name="lyrics_already_in_language">この歌詞はすでに%1$sです</string>
+    <string name="lyrics_translation_unavailable">現在、翻訳を利用できません</string>
     <string name="connect_account_first">先にアカウントを連携してください</string>
     <string name="connected_presence_off">接続済み、プレゼンスはオフ</string>
     <string name="copy_log">ログをコピー</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -252,6 +252,12 @@
     <string name="buttons">Przyciski</string>
     <string name="clear_name">Wyczyść nazwę</string>
     <string name="close_lyrics">Zamknij teksty</string>
+    <string name="translate_lyrics">Przetłumacz tekst</string>
+    <string name="show_original_lyrics">Pokaż oryginalny tekst</string>
+    <string name="translating_lyrics_to">Tłumaczenie na %1$s…</string>
+    <string name="lyrics_translated_to">Przetłumaczono na %1$s</string>
+    <string name="lyrics_already_in_language">Ten tekst jest już w języku %1$s</string>
+    <string name="lyrics_translation_unavailable">Tłumaczenie jest teraz niedostępne</string>
     <string name="connect_account_first">Najpierw połącz konto</string>
     <string name="connected_presence_off">Połączono, obecność wyłączona</string>
     <string name="copy_log">Kopiuj log</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -257,6 +257,12 @@
     <string name="buttons">Botões</string>
     <string name="clear_name">Limpar nome</string>
     <string name="close_lyrics">Fechar letras</string>
+    <string name="translate_lyrics">Traduzir letra</string>
+    <string name="show_original_lyrics">Mostrar letra original</string>
+    <string name="translating_lyrics_to">Traduzindo para %1$s…</string>
+    <string name="lyrics_translated_to">Traduzida para %1$s</string>
+    <string name="lyrics_already_in_language">Esta letra já está em %1$s</string>
+    <string name="lyrics_translation_unavailable">A tradução não está disponível agora</string>
     <string name="connect_account_first">Conecte uma conta primeiro</string>
     <string name="connected_presence_off">Conectado, presença desligada</string>
     <string name="copy_log">Copiar log</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -264,6 +264,12 @@
     <string name="buttons">Кнопки</string>
     <string name="clear_name">Очистить имя</string>
     <string name="close_lyrics">Закрыть текст песни</string>
+    <string name="translate_lyrics">Перевести текст</string>
+    <string name="show_original_lyrics">Показать оригинал</string>
+    <string name="translating_lyrics_to">Перевод на %1$s…</string>
+    <string name="lyrics_translated_to">Переведено на %1$s</string>
+    <string name="lyrics_already_in_language">Текст уже на языке %1$s</string>
+    <string name="lyrics_translation_unavailable">Перевод сейчас недоступен</string>
     <string name="connect_account_first">Сначала подключите аккаунт</string>
     <string name="connected_presence_off">Подключено, Presence отключён</string>
     <string name="copy_log">Скопировать журнал</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -280,6 +280,12 @@
     <string name="buttons">Düğmeler</string>
     <string name="clear_name">Adı temizle</string>
     <string name="close_lyrics">Sözleri kapat</string>
+    <string name="translate_lyrics">Sözleri çevir</string>
+    <string name="show_original_lyrics">Özgün sözleri göster</string>
+    <string name="translating_lyrics_to">%1$s diline çevriliyor…</string>
+    <string name="lyrics_translated_to">%1$s diline çevrildi</string>
+    <string name="lyrics_already_in_language">Bu sözler zaten %1$s dilinde</string>
+    <string name="lyrics_translation_unavailable">Çeviri şu anda kullanılamıyor</string>
     <string name="connect_account_first">Önce bir hesap bağlayın</string>
     <string name="connected_presence_off">Bağlandı, varlık kapalı</string>
     <string name="copy_log">Günlüğü kopyala</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -252,6 +252,12 @@
     <string name="buttons">按钮</string>
     <string name="clear_name">清除名称</string>
     <string name="close_lyrics">关闭歌词</string>
+    <string name="translate_lyrics">翻译歌词</string>
+    <string name="show_original_lyrics">显示原歌词</string>
+    <string name="translating_lyrics_to">正在翻译为%1$s…</string>
+    <string name="lyrics_translated_to">已翻译为%1$s</string>
+    <string name="lyrics_already_in_language">歌词已经是%1$s</string>
+    <string name="lyrics_translation_unavailable">翻译目前不可用</string>
     <string name="connect_account_first">请先连接账号</string>
     <string name="connected_presence_off">已连接，状态显示已关闭</string>
     <string name="copy_log">复制日志</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -293,6 +293,12 @@
     <string name="buttons">Buttons</string>
     <string name="clear_name">Clear name</string>
     <string name="close_lyrics">Close lyrics</string>
+    <string name="translate_lyrics">Translate lyrics</string>
+    <string name="show_original_lyrics">Show original lyrics</string>
+    <string name="translating_lyrics_to">Translating to %1$s…</string>
+    <string name="lyrics_translated_to">Translated to %1$s</string>
+    <string name="lyrics_already_in_language">These lyrics are already in %1$s</string>
+    <string name="lyrics_translation_unavailable">Translation is unavailable right now</string>
     <string name="connect_account_first">Connect an account first</string>
     <string name="connected_presence_off">Connected, presence off</string>
     <string name="copy_log">Copy log</string>

--- a/docs/LYRICS_TRANSLATION.md
+++ b/docs/LYRICS_TRANSLATION.md
@@ -75,11 +75,9 @@ lyrics remain line-synced.
 ## Visual response
 
 Switching versions keeps the existing lyrics list and playback clock mounted.
-For 620 ms, the new text resolves through:
-
-- a subtle alpha recovery;
-- a 0.8% scale settle;
-- 52 small Canvas particles distributed through the lyric field.
+For 620 ms, 30 small Canvas particles resolve through the lyric field. The
+animation clock is read only from the Canvas draw phase, so it does not
+recompose, rescale or clip the lyrics list on every frame.
 
 The effect only animates draw properties, does not intercept touches and is
 clipped to the lyrics panel. Enabling BitChord's **Reduce animations** preference

--- a/docs/LYRICS_TRANSLATION.md
+++ b/docs/LYRICS_TRANSLATION.md
@@ -21,6 +21,9 @@ change Automix, playback transitions, source replacement or audio processing.
 6. Tap the same button again to return immediately to the original lyrics.
 
 The original lyrics are always retained in memory and are never overwritten.
+While the translated version is selected, the compact current-lyric strip above
+the playback scrubber uses that version too. Closing the full lyrics view does
+not switch the strip back to the source language.
 
 ## Destination language
 
@@ -67,21 +70,32 @@ Every translated `LyricLine` retains:
 
 Exact source-language word boundaries cannot describe a translated sentence
 because word order and word count can change. For word-synced lyrics, BitChord
-tokenizes the translated line and redistributes those words proportionally over
-the original line's first-to-last sung interval. This preserves the continuous
-playback sweep without presenting invented phoneme-level precision. Line-synced
-lyrics remain line-synced.
+projects the original character progress onto the translated text. The sweep
+therefore follows the original holds, pauses and pace changes instead of running
+uniformly from start to end. Bloom also uses the source vocal envelope. This is
+an approximate reading guide, not semantic word alignment or phoneme timing in
+the target language. Line-synced lyrics remain line-synced. Cached translations
+are rebuilt with this timing on load; no cache deletion or download is needed.
+
+The renderer interpolates within glyph bounds, avoiding next-row caret positions
+that could send the highlight backwards at a line wrap. Right-to-left paragraphs
+use a reversed reveal and glow direction.
 
 ## Visual response
 
 Switching versions keeps the existing lyrics list and playback clock mounted.
-For 620 ms, 30 small Canvas particles resolve through the lyric field. The
-animation clock is read only from the Canvas draw phase, so it does not
-recompose, rescale or clip the lyrics list on every frame.
+For 540 ms, small particles drift from actual glyph positions in the active lyric
+and its immediate neighbours (up to 18 per voice). Unsynchronized lyrics use the
+first four lines. Positions and drift vectors are cached at text layout time.
+A single animation clock is read only in the draw phase, so it does not
+recompose, rescale or clip the lyrics list on every frame. Soft halos use two
+circles rather than extra blur layers; particles fade in and out continuously.
 
-The effect only animates draw properties, does not intercept touches and is
-clipped to the lyrics panel. Enabling BitChord's **Reduce animations** preference
-turns the effect into an immediate text swap.
+The effect only animates draw properties and does not intercept touches.
+Enabling BitChord's **Reduce animations** preference turns it into an immediate
+text swap. Compose's animator respects the platform duration scale. Going into
+the background cancels decoration, and returning or reopening the panel does
+not replay an old toggle. Rapid toggles replace the previous animation.
 
 ## Storage and performance
 
@@ -122,6 +136,10 @@ settings.
 - Translate English lyrics with BitChord set to Spanish.
 - Translate the same song again and verify the cached response is immediate.
 - Switch back and forth without losing the active line or scroll position.
+- Check held notes, vocal pauses and two-line phrases: the translated sweep
+  should follow the source progress without reversing near a line wrap.
+- Toggle repeatedly, close/reopen the panel, and background/restore the app;
+  particles should settle completely and old transitions should not replay.
 - Use Spanish lyrics while BitChord is set to Spanish and verify no translation
   view is created.
 - Change BitChord to another supported language and verify the new destination.

--- a/docs/LYRICS_TRANSLATION.md
+++ b/docs/LYRICS_TRANSLATION.md
@@ -1,0 +1,132 @@
+# Lyrics translation
+
+## Overview
+
+BitChord can translate the currently displayed lyrics into the language selected
+inside the app. The translation keeps the original lyric timestamps, scroll
+position, line activation and playback-driven highlighting. A compact button in
+the full lyrics view switches between the original and translated versions.
+
+This contribution is intentionally limited to lyrics translation. It does not
+change Automix, playback transitions, source replacement or audio processing.
+
+## User flow
+
+1. Open the full lyrics view.
+2. Tap the translation button beside the source credit.
+3. BitChord resolves the active application locale and requests a translation.
+4. If the detected source language matches the app language, the original lyrics
+   remain visible and BitChord explains that no translation is needed.
+5. Otherwise, the translated text appears with a short particle transition.
+6. Tap the same button again to return immediately to the original lyrics.
+
+The original lyrics are always retained in memory and are never overwritten.
+
+## Destination language
+
+The destination comes from
+`AppCompatDelegate.getApplicationLocales()`, which is the language explicitly
+selected in BitChord's language dialog. When the application locale list is
+empty, BitChord follows Android's effective configuration locale, matching the
+app's normal “follow system” behaviour.
+
+The translation therefore follows the language shown by BitChord, not an
+unrelated device default. Language tags are normalized to their base language,
+including legacy aliases such as `iw` → `he` and `in` → `id`.
+
+## Translation pipeline
+
+`LyricsTranslation` performs translation on demand:
+
+- Blank instrumental lines are preserved and never sent.
+- Section labels and background vocals are translated as independent text slots.
+- Text slots are batched up to 3,500 characters using private-use delimiters,
+  which preserves the exact mapping between the response and lyric lines.
+- At most two short requests run concurrently, avoiding contention with the
+  audio stream while keeping long lyrics responsive.
+- The source language is automatically detected by the translation response.
+- Requests have a 12-second call deadline and are cancelled if the song, lyrics
+  or application language changes.
+- A partial or malformed response is discarded; original lyrics stay on screen.
+
+The current implementation uses Google's lightweight web translation endpoint
+over HTTPS with `sl=auto`. It does not install an on-device translation model or
+require an API key. This endpoint is not a versioned public API, so it may need to
+be replaced by a maintainer-selected provider in the future. The provider is
+isolated inside `LyricsTranslation.kt` to keep that replacement small.
+
+## Timing and lyric animation
+
+Every translated `LyricLine` retains:
+
+- `timeMs`
+- `sungUntilMs`
+- background-vocal placement
+- instrumental gaps
+- the original list position
+
+Exact source-language word boundaries cannot describe a translated sentence
+because word order and word count can change. For word-synced lyrics, BitChord
+tokenizes the translated line and redistributes those words proportionally over
+the original line's first-to-last sung interval. This preserves the continuous
+playback sweep without presenting invented phoneme-level precision. Line-synced
+lyrics remain line-synced.
+
+## Visual response
+
+Switching versions keeps the existing lyrics list and playback clock mounted.
+For 620 ms, the new text resolves through:
+
+- a subtle alpha recovery;
+- a 0.8% scale settle;
+- 52 small Canvas particles distributed through the lyric field.
+
+The effect only animates draw properties, does not intercept touches and is
+clipped to the lyrics panel. Enabling BitChord's **Reduce animations** preference
+turns the effect into an immediate text swap.
+
+## Storage and performance
+
+No language packs or ML translation models are downloaded.
+
+Translated text uses a two-level cache:
+
+- 12 entries in memory for instant toggling and recently played songs;
+- GZIP-compressed JSON files in Android's reclaimable `cacheDir`;
+- a hard 2 MiB disk limit, trimmed least-recently-used first;
+- SHA-256 keys derived from track, destination language and source lyrics;
+- a cache format version so incompatible entries are ignored safely.
+
+A typical cached song occupies only a few kilobytes. Clearing the application's
+cache removes all persisted translations without affecting downloaded music or
+settings.
+
+## Failure behaviour
+
+- Network failure: a localized message is shown and the original stays visible.
+- Same source and destination language: no translated view is created.
+- Song or locale changes: the pending request is cancelled and UI state resets.
+- Invalid line mapping: the whole response is rejected instead of displaying
+  translations against the wrong timestamps.
+- Repeated toggle after success: no network request; it uses the in-memory result.
+
+## Files
+
+- `app/src/main/java/com/music/bitchord/data/lyrics/LyricsTranslation.kt`
+  contains batching, source detection, timing reconstruction and bounded caching.
+- `app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt`
+  contains the toggle, state handling and motion response.
+- `app/src/main/res/values-*/strings.xml` localizes the new UI messages for every
+  language currently offered by BitChord.
+
+## Manual verification checklist
+
+- Translate English lyrics with BitChord set to Spanish.
+- Translate the same song again and verify the cached response is immediate.
+- Switch back and forth without losing the active line or scroll position.
+- Use Spanish lyrics while BitChord is set to Spanish and verify no translation
+  view is created.
+- Change BitChord to another supported language and verify the new destination.
+- Change tracks while a translation is loading and verify no stale text appears.
+- Enable **Reduce animations** and verify the particle transition is skipped.
+- Clear the app cache and verify original lyrics continue to work normally.


### PR DESCRIPTION
I’m very happy to have the opportunity to work on BitChord. Thank you for building and maintaining this project!

## Summary

- Add on-demand lyric translation into the language currently selected inside BitChord.
- Keep the original lyrics available and provide a compact toggle between original and translated text.
- Show the selected translated line in both the full lyrics panel and the compact strip above the scrubber.
- Localize the new controls and status messages for every language currently offered by the app.

## Language behavior

- Resolve the destination from `AppCompatDelegate.getApplicationLocales()`, falling back to the effective Android configuration only when BitChord follows the system language.
- Detect the source language automatically.
- Skip translation when source and destination are the same language.
- Cancel pending work when the track, lyrics, or app locale changes.

## Timing and motion

- Preserve original line timestamps, gaps, section placement, and background vocals.
- Project the original word-synced vocal progress onto translated text, including holds and pauses, without inventing target-language phoneme timestamps.
- Avoid backwards or clipped highlights at wrapped glyph boundaries and support RTL reveal direction.
- Use a short glyph-anchored particle transition driven only from the draw phase, with reduced-motion and lifecycle handling.

## Storage and performance

- Download no on-device language packs or ML models.
- Batch lyric text into short requests with at most two concurrent calls.
- Cache only compressed text: 12 in-memory entries and a reclaimable disk cache capped at 2 MiB.
- Reject partial or malformed line mappings so original lyrics remain safe.

## Scope

This pull request is intentionally limited to lyric translation. It contains no Automix, playback-transition, source-replacement, or audio-processing changes.

## Verification

- [x] `./gradlew :app:assembleDevDebug`
- [x] `git diff --check`
- [x] Signed ARM64 `devDebug` APK verified with Android `apksigner`
- [x] Manual real-device checks of translation, synchronization, compact lyrics, and motion

The implementation, cache policy, failure behavior, and manual verification checklist are documented in `docs/LYRICS_TRANSLATION.md`.