### PR TITLE
feat(player): keep playback in mini-player without expanding full view

### DIFF
--- a/app/src/main/java/com/music/bitchord/MainActivity.kt
+++ b/app/src/main/java/com/music/bitchord/MainActivity.kt
@@ -729,8 +729,7 @@ private fun BitChordApp(
         activeRadioSeed = null
         scope.launch {
             controller?.playSongs(songs, index)
-            // Nothing to raise where the player is already open beside the page.
-            if (!playerDocked) showNowPlaying = true
+            // Start playback in the mini-player; the user opens the full view by tapping it.
         }
     }
     LaunchedEffect(player.song?.videoId) {
@@ -754,7 +753,7 @@ private fun BitChordApp(
         activeRadioSeed = null
         scope.launch {
             controller?.playSongs(listOf(song), 0)
-            if (!playerDocked) showNowPlaying = true
+            // Start radio in the mini-player; the user opens the full view by tapping it.
         }
     }
 
@@ -830,7 +829,6 @@ private fun BitChordApp(
                     context.getString(R.string.radio_started, song.title),
                     Toast.LENGTH_SHORT,
                 ).show()
-                if (!playerDocked) showNowPlaying = true
             }
         }
     }


### PR DESCRIPTION
### Summary of Changes

This PR improves the playback user experience by preventing the player UI from automatically expanding to full screen whenever audio playback or a radio session is initiated.

Currently, selecting a track (e.g., from search suggestions, song lists, or radio starts) automatically sets `showNowPlaying = true`, forcing the app to interrupt the user's navigation context and launch the expanded player view.

### Key Modifications

* **`MainActivity.kt`**: Removed automatic triggers that toggle `showNowPlaying = true` upon invoking playback routines (`playSongs`, radio generation, etc.).
* **Non-Intrusive Playback**: Audio playback starts immediately in the background / bottom mini-player while preserving the user's current view (such as search, library browsing, or song lists).
* **Manual Expansion**: The full-screen player view is now strictly user-driven and can still be opened manually by tapping the mini-player bar.

### User Impact

Users can now start songs or radios directly from live search results or lists without being kicked out of their current screen context.

Testing

* Verified build succeeds and tested locally.
* Selected a song from search results → audio plays in background mini-player, search view remains active.
* Initiated radio from a track → radio starts in mini-player without launching full view.
* Tapped mini-player bar → full-screen player expands normally as expected.

Automated PR generated 100% via Hermes Agent.




