### PR TITLE
fix:  status bar icon contrast on now playing screen based on artwork

### DIFF
--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -177,9 +177,16 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.media3.common.Player
+import coil3.SingletonImageLoader
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
 import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.allowHardware
+import coil3.toBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import com.music.bitchord.ui.theme.SystemBarIcons
 import com.music.bitchord.ui.rememberIsForeground
 import com.music.bitchord.ui.components.thumbnailBorder
 import com.music.bitchord.ui.components.optimizedHazeEffect
@@ -524,6 +531,53 @@ private const val BACKING_ALPHA = 0.72f
 private const val LYRICS_UNAVAILABLE_HOLD_MS = 5_000L
 private const val LYRICS_UNAVAILABLE_FADE_MS = 900
 
+@Composable
+private fun rememberArtworkLuminance(imageUrl: String?): Float? {
+    val context = LocalContext.current
+    var luminance by remember(imageUrl) { mutableStateOf<Float?>(null) }
+
+    LaunchedEffect(imageUrl) {
+        if (imageUrl == null) {
+            luminance = null
+            return@LaunchedEffect
+        }
+        val request = ImageRequest.Builder(context)
+            .data(imageUrl.artworkAt(ART_PX))
+            .size(128)
+            .allowHardware(false)
+            .build()
+        val result = SingletonImageLoader.get(context).execute(request)
+        val bitmap = (result as? SuccessResult)?.image?.toBitmap()
+        if (bitmap != null) {
+            val lum = withContext(Dispatchers.Default) {
+                bitmap.topAreaLuminance()
+            }
+            luminance = lum
+        } else {
+            luminance = 0f
+        }
+    }
+    return luminance
+}
+
+private fun Bitmap.topAreaLuminance(): Float {
+    val sampleHeight = (height * 0.35f).toInt().coerceIn(1, height)
+    val sampleWidth = width.coerceAtLeast(1)
+    val pixels = IntArray(sampleWidth * sampleHeight)
+    getPixels(pixels, 0, sampleWidth, 0, 0, sampleWidth, sampleHeight)
+
+    var totalLuminance = 0.0
+    val count = pixels.size.coerceAtLeast(1)
+    for (pixel in pixels) {
+        val r = ((pixel shr 16) and 0xFF) / 255.0f
+        val g = ((pixel shr 8) and 0xFF) / 255.0f
+        val b = (pixel and 0xFF) / 255.0f
+        val lum = 0.2126f * r + 0.7152f * g + 0.0722f * b
+        totalLuminance += lum
+    }
+    return (totalLuminance / count).toFloat()
+}
+
 /**
  * Apple Music's Now Playing, closely: artwork that shrinks when paused, a
  * hairline scrubber with elapsed / remaining either side, oversized transport
@@ -600,6 +654,11 @@ fun NowPlayingScreen(
     val context = LocalContext.current
     val density = LocalDensity.current
     val haptics = rememberHaptics()
+
+    val artLuminance = rememberArtworkLuminance(song.thumbnailUrl)
+    val isLightArtwork = artLuminance?.let { it > 0.45f } ?: false
+    SystemBarIcons(dark = isLightArtwork)
+
     // Kept local to the player: a modal player is not in the page's Haze
     // source tree, so it needs its own source for the same frosted material as
     // the bottom navigation pill.

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -11,6 +11,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.provider.Settings
+import android.util.LruCache
 import android.view.View
 import android.window.OnBackInvokedCallback
 import android.window.OnBackInvokedDispatcher
@@ -530,6 +531,9 @@ private const val BACKING_ALPHA = 0.72f
 
 private const val LYRICS_UNAVAILABLE_HOLD_MS = 5_000L
 private const val LYRICS_UNAVAILABLE_FADE_MS = 900
+private const val LIGHT_ARTWORK_LUMINANCE_THRESHOLD = 0.45f
+
+private val artworkLuminanceCache = LruCache<String, Float>(20)
 
 @Composable
 private fun rememberArtworkLuminance(imageUrl: String?): Float? {
@@ -537,10 +541,14 @@ private fun rememberArtworkLuminance(imageUrl: String?): Float? {
     var luminance by remember(imageUrl) { mutableStateOf<Float?>(null) }
 
     LaunchedEffect(imageUrl) {
-        if (imageUrl == null) {
-            luminance = null
+        luminance = null
+        if (imageUrl == null) return@LaunchedEffect
+
+        artworkLuminanceCache.get(imageUrl)?.let { cached ->
+            luminance = cached
             return@LaunchedEffect
         }
+
         val request = ImageRequest.Builder(context)
             .data(imageUrl.artworkAt(ART_PX))
             .size(128)
@@ -552,8 +560,10 @@ private fun rememberArtworkLuminance(imageUrl: String?): Float? {
             val lum = withContext(Dispatchers.Default) {
                 bitmap.topAreaLuminance()
             }
+            artworkLuminanceCache.put(imageUrl, lum)
             luminance = lum
         } else {
+            // Default to dark artwork (0f) so status bar icons stay light if image fails to load
             luminance = 0f
         }
     }
@@ -656,7 +666,7 @@ fun NowPlayingScreen(
     val haptics = rememberHaptics()
 
     val artLuminance = rememberArtworkLuminance(song.thumbnailUrl)
-    val isLightArtwork = artLuminance?.let { it > 0.45f } ?: false
+    val isLightArtwork = artLuminance?.let { it > LIGHT_ARTWORK_LUMINANCE_THRESHOLD } ?: false
     SystemBarIcons(dark = isLightArtwork)
 
     // Kept local to the player: a modal player is not in the page's Haze

--- a/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/music/bitchord/ui/player/NowPlayingScreen.kt
@@ -665,9 +665,14 @@ fun NowPlayingScreen(
     val density = LocalDensity.current
     val haptics = rememberHaptics()
 
-    val artLuminance = rememberArtworkLuminance(song.thumbnailUrl)
-    val isLightArtwork = artLuminance?.let { it > LIGHT_ARTWORK_LUMINANCE_THRESHOLD } ?: false
-    SystemBarIcons(dark = isLightArtwork)
+    // A docked pane sits beside the page rather than covering the screen, so
+    // the status bar it's under belongs to the page, not this artwork — only
+    // the full-screen sheet gets to repaint it.
+    if (!docked) {
+        val artLuminance = rememberArtworkLuminance(song.thumbnailUrl)
+        val isLightArtwork = artLuminance?.let { it > LIGHT_ARTWORK_LUMINANCE_THRESHOLD } ?: false
+        SystemBarIcons(dark = isLightArtwork)
+    }
 
     // Kept local to the player: a modal player is not in the page's Haze
     // source tree, so it needs its own source for the same frosted material as

--- a/app/src/main/java/com/music/bitchord/ui/theme/Theme.kt
+++ b/app/src/main/java/com/music/bitchord/ui/theme/Theme.kt
@@ -117,11 +117,29 @@ fun BitChordTheme(
 fun SystemBarIcons(dark: Boolean) {
     val view = LocalView.current
     if (view.isInEditMode) return
-    val window = (view.context as? Activity)?.window ?: return
+    val window = findWindow(view) ?: return
     SideEffect {
         WindowCompat.getInsetsController(window, view).apply {
             isAppearanceLightStatusBars = dark
             isAppearanceLightNavigationBars = dark
         }
     }
+}
+
+private fun findWindow(view: android.view.View): android.view.Window? {
+    var parent = view.parent
+    while (parent != null) {
+        if (parent is androidx.compose.ui.window.DialogWindowProvider) {
+            return parent.window
+        }
+        parent = parent.parent
+    }
+    var context = view.context
+    while (context is android.content.ContextWrapper) {
+        if (context is Activity) {
+            return context.window
+        }
+        context = context.baseContext
+    }
+    return null
 }

--- a/app/src/main/java/com/music/bitchord/ui/theme/Theme.kt
+++ b/app/src/main/java/com/music/bitchord/ui/theme/Theme.kt
@@ -126,6 +126,7 @@ fun SystemBarIcons(dark: Boolean) {
     }
 }
 
+// Walks up the Compose view hierarchy to find a DialogWindowProvider (e.g. modal player) before falling back to Activity context.
 private fun findWindow(view: android.view.View): android.view.Window? {
     var parent = view.parent
     while (parent != null) {


### PR DESCRIPTION
### Summary
Fixed the status bar icons on the Now Playing screen so they automatically switch between light and dark depending on the artwork.
### Changes
* Added artwork luminance detection by checking the top 35% of the album art.
* Used Rec. 709 luminance values to decide whether the artwork is light or dark.
* Added a small cache for recently used artwork so the same image doesn't have to be processed again.
* Reset the luminance whenever the artwork changes to avoid showing the wrong icon color for a moment during track changes.
* Added a fallback for cases where the artwork can't be decoded, keeping the icons light by default.
* Improved `findWindow` in `Theme.kt` so it can correctly find the window when Now Playing is shown inside a dialog or modal sheet.
### Tested
* Tested with both light and dark album artwork on a Pixel 8.
* Tested Now Playing inside the modal/dialog player sheet to make sure the status bar icons still work correctly.