### PR TITLE
fix(playback): prevent mismatched cached rendition playback

### DIFF
--- a/app/src/main/java/com/music/bitchord/data/sources/TrackMatcher.kt
+++ b/app/src/main/java/com/music/bitchord/data/sources/TrackMatcher.kt
@@ -591,7 +591,18 @@ object TrackMatcher {
      * Wide enough for a fade or an intro a service trims differently, narrow
      * enough to rule out an extended cut or a full-album upload.
      */
-    private const val DURATION_LIMIT_SEC = 30
+    const val DURATION_LIMIT_SEC = 30
+
+    /**
+     * Whether two runtimes differ by more than [DURATION_LIMIT_SEC], meaning
+     * they cannot be the same recording. Used to detect when a cached or
+     * live stream is a different edit from the requested catalogue track.
+     */
+    fun isSevereMismatch(expectedSec: Int?, actualSec: Int?): Boolean {
+        if (expectedSec == null || actualSec == null) return false
+        return abs(actualSec - expectedSec) > DURATION_LIMIT_SEC
+    }
+
     /** Visual intros/outros can make the video substantially longer than its audio master. */
     private const val VIDEO_DURATION_LIMIT_SEC = 90
 

--- a/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
+++ b/app/src/main/java/com/music/bitchord/playback/PlaybackService.kt
@@ -2411,10 +2411,20 @@ class PlaybackService : MediaLibraryService() {
         val videoId = uri.getQueryParameter("v") ?: return false
         val downloaded = com.music.bitchord.download.Downloads.savedUri(this, videoId) != null
         if (downloaded) return false
+        val target = SourceResolver.targetIn(uri)
+        val expectedSec = target.durationSec
+        if (TrackMatcher.isSevereMismatch(expectedSec, durationSec)) {
+            TrackLog.w(
+                "BitChord",
+                "cached rendition duration mismatch: playing ${durationSec}s vs catalogue ${expectedSec}s for $videoId; discarding cache rendition",
+                about = mediaId,
+            )
+            withContext(Dispatchers.IO) { AudioCache.discardRendition(uri) }
+        }
         return QualityUpgrade.adoptUnresolved(
             mediaId = mediaId,
             uri = uri,
-            target = SourceResolver.targetIn(uri),
+            target = target,
             playingMime = mime,
             playing = withContext(Dispatchers.IO) { cachedFloor(uri, format, durationSec) },
         )

--- a/app/src/main/java/com/music/bitchord/playback/QualityUpgrade.kt
+++ b/app/src/main/java/com/music/bitchord/playback/QualityUpgrade.kt
@@ -407,6 +407,23 @@ object QualityUpgrade {
      * @return the better stream, or null if there isn't one, in which case
      *   this track is never asked about again.
      */
+    /**
+     * Computes the duration to match against during an upgrade.
+     * When runtime decoder duration differs severely from the known catalogue
+     * duration (e.g. a 3:29 video edit playing for a 5:02 album track), the
+     * authoritative catalogue duration is preserved so the correct recording can
+     * be found.
+     */
+    fun effectiveTargetDuration(expectedSec: Int?, playingSec: Int?): Int? {
+        return if (expectedSec != null && playingSec != null &&
+            TrackMatcher.isSevereMismatch(expectedSec, playingSec)
+        ) {
+            expectedSec
+        } else {
+            playingSec ?: expectedSec
+        }
+    }
+
     suspend fun lookAgain(mediaId: String, playingDurationSec: Int?): SourceStream? {
         val waiting = pending[mediaId] ?: return null
         var found: SourceStream? = null
@@ -416,6 +433,17 @@ object QualityUpgrade {
          * [asked] is allowed to mean.
          */
         var answered = false
+        val expectedSec = waiting.target.durationSec
+        val effectiveDurationSec = effectiveTargetDuration(expectedSec, playingDurationSec)
+        if (expectedSec != null && playingDurationSec != null &&
+            TrackMatcher.isSevereMismatch(expectedSec, playingDurationSec)
+        ) {
+            TrackLog.w(
+                TAG,
+                "playing duration ($playingDurationSec s) drifted severely from catalogue duration ($expectedSec s); preserving catalogue duration for upgrade",
+                about = mediaId,
+            )
+        }
         return try {
             // The lookup that was still running when the fallback won the race
             // gets first refusal: what it returns is the stream that would
@@ -438,11 +466,12 @@ object QualityUpgrade {
                 val late = runCatching { lookup.await() }.getOrNull()
                 if (late != null &&
                     SourceResolver.worthSwapping(late.format, waiting.playing) &&
-                    SourceResolver.sameRecordingAs(late.durationSec, playingDurationSec)
+                    SourceResolver.sameRecordingAs(late.durationSec, effectiveDurationSec)
                 ) {
                     found = late
                     if (needsLosslessFollowUp(late.format)) {
                         followUps[mediaId] = waiting.copy(
+                            target = waiting.target.copy(durationSec = effectiveDurationSec),
                             inFlight = null,
                             playing = late.format,
                             servedBy = late.sourceConfigId,
@@ -457,13 +486,14 @@ object QualityUpgrade {
             // what the live path could not afford to do. The source already
             // serving the track is left out — see [SourceResolver.upgradeFor].
             SourceResolver.upgradeFor(
-                waiting.target.copy(durationSec = playingDurationSec ?: waiting.target.durationSec),
+                waiting.target.copy(durationSec = effectiveDurationSec),
                 playing = waiting.playing,
                 servedBy = waiting.servedBy,
             ).also {
                 found = it
                 if (it != null && needsLosslessFollowUp(it.format)) {
                     followUps[mediaId] = waiting.copy(
+                        target = waiting.target.copy(durationSec = effectiveDurationSec),
                         inFlight = null,
                         playing = it.format,
                         servedBy = it.sourceConfigId,

--- a/app/src/test/java/com/music/bitchord/TrackIdentityMismatchTest.kt
+++ b/app/src/test/java/com/music/bitchord/TrackIdentityMismatchTest.kt
@@ -1,0 +1,208 @@
+package com.music.bitchord
+
+import com.music.bitchord.data.model.Song
+import com.music.bitchord.data.sources.SourceResolver
+import com.music.bitchord.data.sources.TrackMatcher
+import com.music.bitchord.playback.QualityUpgrade
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Validates playback identity preservation and duration mismatch handling.
+ *
+ * Specifically addresses the São Paulo (Hurry Up Tomorrow) regression where a
+ * 3:29 (209s) YouTube music video was cached or substituted for a 5:02 (302s)
+ * album track, and the runtime decoder duration poisoned the upgrade search target.
+ */
+class TrackIdentityMismatchTest {
+
+    private fun song(
+        title: String,
+        artist: String,
+        durationText: String? = null,
+        album: String? = null,
+        videoId: String = "test-id",
+    ) = Song(
+        videoId = videoId,
+        title = title,
+        artist = artist,
+        thumbnailUrl = null,
+        durationText = durationText,
+        albumName = album,
+    )
+
+    @Test
+    fun `Test 1 - catalogue target 302s + runtime 209s preserves catalogue duration`() {
+        val catalogueDuration = 302
+        val runtimeDuration = 209
+
+        val effectiveDuration = QualityUpgrade.effectiveTargetDuration(
+            expectedSec = catalogueDuration,
+            playingSec = runtimeDuration,
+        )
+
+        assertEquals(
+            "Authoritative catalogue duration must be preserved when runtime drifts severely",
+            302,
+            effectiveDuration,
+        )
+    }
+
+    @Test
+    fun `Test 2 - catalogue target 302s + candidate 302s accepted`() {
+        val catalogueDuration = 302
+        val candidateDuration = 302
+
+        assertTrue(
+            "Candidate duration matching catalogue duration must be accepted as same recording",
+            SourceResolver.sameRecordingAs(candidateDuration, catalogueDuration),
+        )
+
+        val target = TrackMatcher.Target(
+            title = "São Paulo",
+            artist = "The Weeknd",
+            durationSec = catalogueDuration,
+            album = "Hurry Up Tomorrow",
+        )
+        val jioSaavnTrack = song("São Paulo", "The Weeknd", "5:02", album = "Hurry Up Tomorrow")
+
+        assertTrue(
+            "TrackMatcher must accept 302s candidate against 302s catalogue target",
+            TrackMatcher.withinSeconds(jioSaavnTrack, target, 2),
+        )
+    }
+
+    @Test
+    fun `Test 3 - catalogue target 302s + cached rendition 209s detects severe mismatch`() {
+        val catalogueDuration = 302
+        val cachedRenditionDuration = 209
+
+        assertTrue(
+            "Cached rendition drifting 93s (> 30s limit) must be flagged as severe mismatch",
+            TrackMatcher.isSevereMismatch(catalogueDuration, cachedRenditionDuration),
+        )
+    }
+
+    @Test
+    fun `Test 4 - small legitimate duration difference retains existing runtime behavior`() {
+        val catalogueDuration = 302
+        val runtimeDuration = 300 // 2s drift, common between audio masters
+
+        assertFalse(
+            "2s drift between masters is within tolerance and not a severe mismatch",
+            TrackMatcher.isSevereMismatch(catalogueDuration, runtimeDuration),
+        )
+
+        val effectiveDuration = QualityUpgrade.effectiveTargetDuration(
+            expectedSec = catalogueDuration,
+            playingSec = runtimeDuration,
+        )
+
+        assertEquals(
+            "Small legitimate differences retain runtime decoder duration for upgrade matching",
+            300,
+            effectiveDuration,
+        )
+
+        // Test with 14s difference (typical intro/outro pad)
+        val runtime14sDrift = 288
+        assertFalse(
+            "14s drift is within 30s canonical duration limit",
+            TrackMatcher.isSevereMismatch(catalogueDuration, runtime14sDrift),
+        )
+        assertEquals(
+            288,
+            QualityUpgrade.effectiveTargetDuration(catalogueDuration, runtime14sDrift),
+        )
+    }
+
+    @Test
+    fun `Test 5 - catalogue duration null retains existing runtime behavior`() {
+        val runtimeDuration = 209
+
+        assertFalse(
+            "Null catalogue duration cannot be flagged as a severe mismatch",
+            TrackMatcher.isSevereMismatch(null, runtimeDuration),
+        )
+
+        val effectiveDurationWithNullCatalogue = QualityUpgrade.effectiveTargetDuration(
+            expectedSec = null,
+            playingSec = runtimeDuration,
+        )
+        assertEquals(
+            "When catalogue duration is null, runtime decoder duration is used",
+            209,
+            effectiveDurationWithNullCatalogue,
+        )
+
+        val effectiveDurationWithNullRuntime = QualityUpgrade.effectiveTargetDuration(
+            expectedSec = 302,
+            playingSec = null,
+        )
+        assertEquals(
+            "When playing runtime is null, catalogue duration is used",
+            302,
+            effectiveDurationWithNullRuntime,
+        )
+    }
+
+    @Test
+    fun `Test 6 - full Sao Paulo regression scenario`() {
+        val catalogueTarget = TrackMatcher.Target(
+            title = "São Paulo",
+            artist = "The Weeknd, Anitta",
+            durationSec = 302,
+            album = "Hurry Up Tomorrow",
+        )
+
+        val youtubeVideoRuntime = 209 // 3:29 music video (2kjolTLZ_Mg)
+        val jioSaavnCandidateDuration = 302 // 5:02 album stream (-rq378sI)
+
+        // 1. Check cached rendition mismatch detection
+        assertTrue(
+            "Cached 209s video rendition must be identified as mismatched against 302s catalogue entry",
+            TrackMatcher.isSevereMismatch(catalogueTarget.durationSec, youtubeVideoRuntime),
+        )
+
+        // 2. Target duration calculation in QualityUpgrade.lookAgain
+        val effectiveDuration = QualityUpgrade.effectiveTargetDuration(
+            expectedSec = catalogueTarget.durationSec,
+            playingSec = youtubeVideoRuntime,
+        )
+        assertEquals(
+            "Effective target duration must preserve 302s instead of being poisoned by 209s",
+            302,
+            effectiveDuration,
+        )
+
+        // 3. Confirm regression behavior without fix:
+        // Raw runtime comparison would fail and reject the genuine JioSaavn album stream
+        assertFalse(
+            "Flawed check against raw 209s runtime would reject genuine 302s album stream",
+            SourceResolver.sameRecordingAs(jioSaavnCandidateDuration, youtubeVideoRuntime),
+        )
+
+        // 4. Confirm fixed behavior:
+        // Comparison against effective catalogue duration accepts the genuine JioSaavn stream
+        assertTrue(
+            "Check against effective duration accepts genuine 302s JioSaavn album stream",
+            SourceResolver.sameRecordingAs(jioSaavnCandidateDuration, effectiveDuration),
+        )
+
+        val jioSaavnSong = song(
+            title = "São Paulo",
+            artist = "The Weeknd, Anitta",
+            durationText = "5:02",
+            album = "Hurry Up Tomorrow",
+            videoId = "-rq378sI",
+        )
+        val effectiveTarget = catalogueTarget.copy(durationSec = effectiveDuration)
+
+        assertTrue(
+            "TrackMatcher matches genuine JioSaavn song against effective target",
+            TrackMatcher.withinSeconds(jioSaavnSong, effectiveTarget, 2),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a wrong-recording playback case where a YouTube music-video
rendition can be treated as the requested album recording.

The primary regression case is:

- Album: Hurry Up Tomorrow
- Track: São Paulo
- Catalogue duration: 302s
- Incorrect YouTube video duration: 209s

## Root cause

The album metadata can contain the correct 302s catalogue duration while
pointing to a YouTube video ID whose actual media is a 209s music-video edit.

A cached rendition can then be served before source resolution.

During the upgrade path, the runtime 209s duration was previously allowed to
replace the authoritative 302s catalogue target. This caused the legitimate
302s source to fail strict duration matching.

## Fix

- Preserve the catalogue duration when runtime duration is severely
  mismatched.
- Detect severely mismatched cached renditions.
- Evict the invalid cached rendition.
- Continue through BitChord's existing resolution/upgrade path.
- Keep the existing TrackMatcher thresholds and source-substitution behavior.

## Verification

- `compileDevDebugKotlin` passed.
- `TrackIdentityMismatchTest`: 6/6 passed.
- Audio Pipeline/Source regression tests remained passing.

## Scope

This PR does not modify the Audio Pipeline UI or source-reporting feature.
That work is submitted separately in PR #267.